### PR TITLE
Remove incorrect description of the GPL

### DIFF
--- a/lisp/ess-bugs-d.el
+++ b/lisp/ess-bugs-d.el
@@ -21,10 +21,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
 ;; the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
-;;
-;; In short: you may use this code any way you like, as long as you
-;; don't charge money for it, remove this notice, or hold anyone liable
-;; for its results.
 
 ;; Code:
 

--- a/lisp/ess-bugs-l.el
+++ b/lisp/ess-bugs-l.el
@@ -21,10 +21,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
 ;; the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
-;;
-;; In short: you may use this code any way you like, as long as you
-;; don't charge money for it, remove this notice, or hold anyone liable
-;; for its results.
 
 ;; Code:
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -26,11 +26,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
 ;; the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
-;;
-;; In short: you may use this code any way you like, as long as you
-;; don't charge more than a distribution fee for it, do distribute the
-;; source with any binaries, remove this notice, or hold anyone liable
-;; for its results.
 
 ;;; Code:
 

--- a/lisp/ess-font-lock.el
+++ b/lisp/ess-font-lock.el
@@ -23,10 +23,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.	If not, write to
 ;; the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
-;;
-;; In short: you may use this code any way you like, as long as you
-;; don't charge money for it, remove this notice, or hold anyone liable
-;; for its results.
 
 ;;; Commentary:
 

--- a/lisp/ess-install.el
+++ b/lisp/ess-install.el
@@ -21,12 +21,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
 ;; the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
-;;
-;; In short: you may use this code any way you like, as long as you
-;; don't charge more than a distribution fee for it, do distribute the
-;; source with any binaries, remove this notice, or hold anyone liable
-;; for its results.
-
 
 ;;; Commentary:
 

--- a/lisp/ess-jags-d.el
+++ b/lisp/ess-jags-d.el
@@ -21,10 +21,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
 ;; the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
-;;
-;; In short: you may use this code any way you like, as long as you
-;; don't charge money for it, remove this notice, or hold anyone liable
-;; for its results.
 
 ;; Code:
 

--- a/lisp/ess-r-a.el
+++ b/lisp/ess-r-a.el
@@ -24,10 +24,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
 ;; the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
-;;
-;; In short: you may use this code any way you like, as long as you
-;; don't charge money for it, remove this notice, or hold anyone liable
-;; for its results.
 
 ;;; Code:
 

--- a/lisp/ess-sas-a.el
+++ b/lisp/ess-sas-a.el
@@ -23,10 +23,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.  If not, write to
 ;; the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
-;;
-;; In short: you may use this code any way you like, as long as you
-;; don't charge money for it, remove this notice, or hold anyone liable
-;; for its results.
 
 ;; Code:
 

--- a/lisp/ess.el
+++ b/lisp/ess.el
@@ -28,10 +28,6 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with GNU Emacs; see the file COPYING.	If not, write to
 ;; the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
-;;
-;; In short: you may use this code any way you like, as long as you
-;; don't charge money for it, remove this notice, or hold anyone liable
-;; for its results.
 
 ;;; Commentary:
 


### PR DESCRIPTION
A couple files had the following in their header:

```
In short: you may use this code any way you like, as long as you
don't charge money for it, remove this notice, or hold anyone liable
for its results.
```

This is not an accurate description of the GPL, and should therefore not appear
in the headers.

Fixes issue #4
