### PR TITLE
avoid assoc - it sucks on so many levels, it's scary

### DIFF
--- a/lisp/ChangeLog
+++ b/lisp/ChangeLog
@@ -1,33 +1,39 @@
+2012-05-02  Sam Steingold  <sds@gnu.org>
+
+	* ess-r-args.el (tooltip-show-at-point): Do not use the assoc
+	package (which is obsoleted by Emacs 24.2 anyway), use let
+	instead, it is cleaner and more reliable.
+
 2012-04-23  Vitalie Spinu  <spinuvit@gmail.com>
 
 	* merged Daniel Hackney's changes
 	Squashed commit of the following:
-	
+
 	commit 708101bef3e5c1f20f53736a9e93799eddaf4f0c
 	Author: Daniel Hackney <dan@haxney.org>
 	Date:   Mon Apr 23 00:28:53 2012 -0400
-	
+
         Remove incorrect description of the GPL
-	
+
         A couple files had the following in their header:
-	
+
         In short: you may use this code any way you like, as long as you
         don't charge money for it, remove this notice, or hold anyone liable
         for its results.
-	
+
         This is not an accurate description of the GPL, and should therefore not appear
         in the headers.
-	
+
 	commit c93848d930783f0c38fec1ff07af40fb623799d1
 	Author: Daniel Hackney <dan@haxney.org>
 	Date:   Sun Apr 22 23:03:42 2012 -0400
-	
+
         Clean up all whitespace according to settings from ".dir-locals.el"
-	
+
         Uses `whitespace-cleanup' to set a consistent style for whitespace throughout
         the project. This can be applied with:
 
-	
+
         (defun recursive-files (dir func)
           (loop with before-save-hook
                 for (file is-dir)
@@ -39,34 +45,34 @@
         	     (apply func)
         	     (basic-save-buffer)
         	     (kill-buffer))))
-        	
+
         (recursive-files 'whitespace-cleanup)
-	
+
         Again, this can be run from "emacs -Q" after "(require 'cl)"
-	
+
 	commit 3c9c0857d67bda1e9161e37ed426e97a8c61223c
 	Author: Daniel Hackney <dan@haxney.org>
 	Date:   Sun Apr 22 22:51:54 2012 -0400
-	
+
         Directory-local variables for whitespace cleanup.
-	
+
         Use the `whitespace' library for the cleaning.
-	
+
 	commit 8dc3d6db1d40956ab96c33b18a80a95a047b46b3
 	Author: Daniel Hackney <dan@haxney.org>
 	Date:   Sun Apr 22 22:40:28 2012 -0400
-	
+
         Convert files to `utf-8-unix' coding system.
-	
+
         The default coding system to use going forward, `utf-8-unix', is set as a
         directory-local variable in ".dir-locals.el".
-	
+
         To force all elisp files to use the `utf-8-unix' coding system, the following
         code will recursively walk through all elisp files in the specified directory
         set the encoding system, and save the file.
-	
+
         (require 'cl)
-	
+
         (defun recursive-files (dir func)
         (loop with before-save-hook
         for (file is-dir)
@@ -78,44 +84,44 @@
         (apply func)
         (basic-save-buffer)
         (kill-buffer))))
-	
+
         This can be invoked as follows:
-	
+
         (recursive-files "/path/to/ess" '(lambda () (set-buffer-file-coding-system 'utf-8-unix)))
-	
+
         To ensure no other variables from the user environment impact the process, this
         code can be run in "emacs -Q", which doesn't load any startup files (outside of
         the emacs core).
-	
+
         This function could perhaps be split out, named better, and put in its own file.
-	
+
 	commit 6352290fe13ce9048abaa0e401679a67bbcafe43
 	Author: Daniel Hackney <dan@haxney.org>
 	Date:   Tue Apr 17 21:01:36 2012 -0400
-	
+
         Reformat all headers to be consistent.
-	
+
         Summary of changes made:
-	
+
         * Correct first- and last-line format. Preferred is three semicolons, file name,
         either three dashes and the description (first line) or the string "ends
         here" (last line).
-	
+
         * Changed header comment lines to match conventions. "Author" and "Maintainer"
         headers are singular, even when there are multiple authors or maintainers.
-	
+
         * Use the correct number of semicolons for each header section. Regular comments
         should have two semicolons; section headers, such as "Commentary" or "Code"
         should have three.
-	
+
         * Fixed "Keywords" header comments. There is a standard-ish set of keywords used
         in Emacs, available through `finder-by-keyword'; this commit uses those
         conventions. Also, keywords are now separated by comma then space and do not
         have a trailing period.
-	
+
         * Trailing newline at end of file. A few files lacked this, which makes
         subsequent diffs which modify the last line unnecessarily noisy.
-	
+
         * Moved "Code" section marker before any and all code in a file.
 
 

--- a/lisp/ess-r-args.el
+++ b/lisp/ess-r-args.el
@@ -303,7 +303,6 @@ ess-r-args-current-function if no argument given."
 
 ;; SJE: 2009-01-30 -- this contribution from
 ;; Erik Iverson <iverson@biostat.wisc.edu>
-(require 'assoc)                        ;needed for aput, below.
 (defun tooltip-show-at-point (text xo yo)
   "Show a tooltip displaying 'text' at (around) point, xo and yo are x-
 and y-offsets for the toolbar from point."
@@ -348,21 +347,11 @@ and y-offsets for the toolbar from point."
                          (cdr(posn-x-y (posn-at-point)))
                          frame-top yo))
 
-    ;; this clobbers current tooltip-frame-parameters 'top' and 'left',
-    ;; which are not set by default.  use push/pop instead of aput/adelete?
-    ;; the problem with using aput again is that if top/left were nil, aput'ing
-    ;; nil will have no effect.
-
-    (aput 'tooltip-frame-parameters 'top my-y-offset)
-    (aput 'tooltip-frame-parameters 'left my-x-offset)
-
-    (tooltip-show text)
-
-    ;; remove parameters so that further tooltip-show calls aren't shown in
-    ;; odd place (i.e., wherever point happened to be the last time this was
-    ;; called
-    (adelete 'tooltip-frame-parameters 'top)
-    (adelete 'tooltip-frame-parameters 'left)
+    (let ((tooltip-frame-parameters
+           (cons (cons 'top my-y-offset)
+                 (cons (cons 'left my-x-offset)
+                       tooltip-frame-parameters))))
+      (tooltip-show text))
     ))
 
 (provide 'ess-r-args)


### PR DESCRIPTION
```
* ess-r-args.el (tooltip-show-at-point): Do not use the assoc
package (which is obsoleted by Emacs 24.2 anyway), use let
instead, it is cleaner and more reliable.
```
