### PR TITLE
make tracebugs tempfiles multiuser safe

### DIFF
--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -196,7 +196,8 @@ Return new command, a string."
       (setq orig-beg (+ beg (marker-position orig-marker))))
 
      (let ((tmpfile
-            (expand-file-name (concat (file-name-nondirectory (or filename "unknown")) "@"
+            (expand-file-name (concat (file-name-nondirectory 
+                                       (or filename (make-temp-file "unknown"))) "@"
                                       (number-to-string ess--tracebug-eval-index))
                               (if remote
                                   (tramp-get-remote-tmpdir remote)


### PR DESCRIPTION
i found that my colleague and me both generate files named like /tmp/unknown@1 which our emacsen then cannot delete as needed when permissions don't match. This change appears to fix that issue but unsure if it breaks something else... can you please have a look
