### PR TITLE
Allow Cards to be indented consistently.

### DIFF
--- a/lisp/ess-sas-l.el
+++ b/lisp/ess-sas-l.el
@@ -936,7 +936,7 @@ This will (hopefully) be fixed in later versions."
           (beginning-of-sas-statement 1 t))
         (if (or
              (looking-at
-              "data[ \n\t;]\\|cards[ \n\t];\\|proc[ \n\t]\\|%?do[ \n\t;]\\|%macro[ \n\t]\\|/\\*")
+              "data[ \n\t;]\\|cards[ \n\t]*;\\|proc[ \n\t]\\|%?do[ \n\t;]\\|%macro[ \n\t]\\|/\\*")
              (save-excursion
                (re-search-forward
                 "\\b%?then\\>[ \n\t]*\\b%?do\\>\\|\\b%?else\\>[ \n\t]*\\b%?do\\>"


### PR DESCRIPTION
Typically ESS indents SAS  cards statments as:

```
data c12053_red_0;
    input dose time n1 n2 dv;
    time = time/60;    
    cards;
    1 2 3 4 5
        1 2 3 4 5
run;
```

But I think it should be

```
data c12053_red_0;
    input dose time n1 n2 dv;
    time = time/60;    
    cards;
        1 2 3 4 5
        1 2 3 4 5
run;
```
