### PR TITLE
Indent comments appropriately.

### DIFF
--- a/lisp/ess-sas-l.el
+++ b/lisp/ess-sas-l.el
@@ -840,7 +840,7 @@ number."
                 ((save-excursion;; added 4/28/94 to properly check
                    (if (bobp) () (backward-char 1));; for end of comment
                    (setq prev-end (point))
-                   (looking-at "*/"));;  improved 1/31/95
+                   (looking-at "\\*/"));;  improved 1/31/95
                  (save-excursion
                    (search-backward "*/"
                                     (point-min) 1 1); comment start is first /*
@@ -852,7 +852,8 @@ number."
                          (if (bobp) 0
                            (if (looking-at ";")
                                (sas-next-statement-indentation)
-                             (+ (current-indentation) sas-indent-width))))))
+                             ;;(+ (current-indentation) sas-indent-width)
+                             (current-indentation))))))
 
                 ;; added 6/27/94 to leave "* ;" comments alone
                 ((save-excursion


### PR DESCRIPTION
Comments in SAS are indented as follows:

```
proc nlmixed data=one; 
   ...
  ktol=exp(lk); /* comment */
     ec50=exp(lec50);
```

I think it should be:

```
proc nlmixed data=one; 
   ...
  ktol=exp(lk); /* comment */
  ec50=exp(lec50);
```
