### PR TITLE
R-mode: Support prettify-symbols-mode.

### DIFF
--- a/lisp/ess-r-d.el
+++ b/lisp/ess-r-d.el
@@ -229,7 +229,11 @@
      (ess-describe-object-at-point-commands . 'ess-R-describe-object-at-point-commands)
      (ess-STERM		. "iESS")
      (ess-editor	. R-editor)
-     (ess-pager		. R-pager))
+     (ess-pager		. R-pager)
+     (prettify-symbols-alist            . '(("<-" . ?←)
+                                            ("<<-" . ?↞)
+                                            ("->" . ?→)
+                                            ("->>" . ?↠))))
    S-common-cust-alist)
   "Variables to customize for R -- set up later than emacs initialization.")
 


### PR DESCRIPTION
Prettify-symbols-mode is new in the upcoming Emacs release.  It can
convert symbols into unicode representation, e.g., <- to ←.  This patch
sets the `prettify-symbols-alist`.  The user can then activate the
prettify mode by calling `prettify-symbols-mode`.
- lisp/ess-r-d.el (R-mode--prettify-symbols-alist): New constant.
  (R-mode): Set `prettify-symbols-alist`.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
