### PR TITLE
Add autoload to ess-help.el

### DIFF
--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -52,6 +52,7 @@
 (autoload 'ess-eval-line                "ess-inf" "[autoload]" t)
 (autoload 'ess-eval-line-and-go         "ess-inf" "[autoload]" t)
 (autoload 'ess-eval-line-and-step       "ess-inf" "[autoload]" t)
+(autoload 'ess-with-current-buffer      "ess-inf" "[autoload]" t)
 
 (autoload 'ess-goto-beginning-of-function-or-para    "ess-mode" "[autoload]" t)
 (autoload 'ess-goto-end-of-function-or-para          "ess-mode" "[autoload]" t)


### PR DESCRIPTION
Since the last update (20131027.2006), calling help on an object in the iESS buffer opened the help text in the same buffer, changing its status to 'read-only'. Adding this line to ess-help.el fixes this.
