### PR TITLE
Fix bad indentation in Julia.

### DIFF
--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -121,7 +121,7 @@
 ))
 
 (defconst julia-block-start-keywords
-  (list "if" "while" "for" "begin" "try" "function" "type" "let" "macro"
+  (list "if" "while" "^\s*for" "begin" "try" "function" "type" "let" "macro"
 	"quote" "do" "immutable"))
 
 (defconst julia-block-other-keywords


### PR DESCRIPTION
Stop the `for` in Julia's comprehension syntax from causing the next
line to be indented.

Previously:

```
X = [x for x in xs]
>>>>|
```

Now:

```
X = [x for x in xs]
|
```

|
|
