### PR TITLE
Extend list of two-parameter roxygen commands

### DIFF
--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -90,7 +90,8 @@
               "\\)\\>")
      (1 'font-lock-keyword-face prepend))
     (,(concat ess-roxy-re " *\\([@\\]"
-              (regexp-opt '("param" "importFrom") t)
+              (regexp-opt '("param" "importFrom" "importClassesFrom"
+                            "importMethodsFrom") t)
               "\\)\\>\\(?:[ \t]+\\(\\sw+\\)\\)?")
      (1 'font-lock-keyword-face prepend)
      (3 'font-lock-variable-name-face prepend))


### PR DESCRIPTION
Treat font lock for the roxygen statements `@importMethodsFrom` and `@importClassesFrom` the same
as that of `@importFrom`: namespace name (first parameter) in `font-lock-variable-name-face`, objects to import (second parameter) in `font-lock-comment-face`.
