### PR TITLE
make ess-inside-brackets-p work with nested brackets

### DIFF
--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -73,7 +73,7 @@ POS defaults to point if no value is given."
         (goto-char (nth 1 ppss))
         (when (char-equal ?\[ (char-after))
           (setq r t))
-        (setq ppss (syntax-ppss))
+        (setq ppss (syntax-ppss)))
       r)))
 
 (defun ess--extract-default-fl-keywords (keywords)


### PR DESCRIPTION
Given an expression `[1,[2],3]`, `ess-inside-brackets-p` returns `t`, `t`, `nil` when evaluated at `1`, `2`, and `3`, respectively.  As it stands, this function returns `nil` at any position following innermost pair of brackets.

This behavior can cause bad indentation in Julia.  For example, lines after statement `[[] for i=1:2]` get one additional level of indentation, as `for` is interpreted as opening of a new block (rather than a part of comprehension).
