### PR TITLE
Add autoload dependency to ess-noweb-mode for ess-write-to-dribble-buffer.

### DIFF
--- a/lisp/ess-noweb-mode.el
+++ b/lisp/ess-noweb-mode.el
@@ -89,8 +89,8 @@
 
 ;; Want to use these now in order to cater for all obscure kinds of emacsen
 (eval-and-compile
-  (require 'ess-compat))
-
+  (require 'ess-compat)
+  (autoload 'ess-write-to-dribble-buffer "ess"))
 
 
 ;;; Variables


### PR DESCRIPTION
Addresses issue #85. When running **ess-noweb-mode** on its own, autoload the dependency for the function **ess-write-to-dribble-buffer** in _ess.el_. This at least keeps it from choking on the error.
