### PR TITLE
Modified auto-fill in noweb-code chunks to respect chunk headers.

### DIFF
--- a/lisp/ess-noweb-mode.el
+++ b/lisp/ess-noweb-mode.el
@@ -947,10 +947,17 @@ indent according to mode."
   (if auto-fill-function
       (setq auto-fill-function 'ess-noweb-auto-fill-doc-chunk)))
 
+(defun ess-noweb-auto-fill-code-chunk ()
+  "Replacement for do-auto-fill. Cancel filling in chunk headers"
+  (unless (save-excursion
+            (beginning-of-line)
+            (looking-at "<<"))
+    (do-auto-fill)))
+
 (defun ess-noweb-auto-fill-code-mode ()
   "Install the default auto fill function, iff necessary."
   (if auto-fill-function
-      (setq auto-fill-function 'do-auto-fill)))
+      (setq auto-fill-function 'ess-noweb-auto-fill-code-chunk)))
 
 ;;; Marking
 


### PR DESCRIPTION
The current verstion of ess-noweb-auto-fill-code-mode is hard-coded to set the auto-fill-function to the default do-auto-fill. This causes problems with the chunk headers. Headers cannot have line breaks, so we need to modify the fill function to respect this.

My proposed change mirrors the behaviour of ess-noweb-auto-fill-doc-chunk, which provides equivalent wrapping to do-auto-fill for that context.
