### PR TITLE
Better newline-and-indent for ess-roxy

### DIFF
--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -734,11 +734,23 @@ list of strings."
 
 (defadvice newline-and-indent (around ess-roxy-newline)
   "Insert a newline in a roxygen field."
-  (if (ess-roxy-entry-p)
-      (progn
-        ad-do-it
-        (insert (concat (ess-roxy-guess-str t) " ")))
-    ad-do-it))
+  (cond
+   ;; Not in roxy entry; do nothing
+   ((not (ess-roxy-entry-p))
+    ad-do-it)
+   ;; Point at beginning of first line of entry; do nothing
+   ((= (point) (ess-roxy-beg-of-entry))
+    ad-do-it)
+   ;; Otherwise: skip over roxy comment string if necessary and then
+   ;; newline and then inset new roxy comment string
+   (t
+    (let ((point-after-roxy-string
+           (save-excursion (forward-line 0)
+                           (move-beginning-of-line nil)
+                           (point))))
+      (goto-char (max (point) point-after-roxy-string)))
+    ad-do-it
+    (insert (concat (ess-roxy-guess-str t) " ")))))
 
 (provide 'ess-roxy)
 


### PR DESCRIPTION
This implements more intelligent behavior for the ess-roxy advice to "newline-and-indent". The two changes in behavior are:
1. If point is at the very beginning of the first line of an roxy entry, the advice doesn't activate, which means that pressing enter will simply insert a blank line before the roxy entry instead of inserting a new line with a roxy comment at the beginning of the entry.
2. If point is inside the roxy comment (e.g. between the "#" and the "'"), then pressing enter no longer breaks the existing roxy comment on the current line by inserting the newline and new roxy comment inside of it. Instead, it moves point to the end of the roxy comment on the current line and then inserts the newline.
