### PR TITLE
Fix ess-build-tags-for-directory if no TAGS filename provided

### DIFF
--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -1007,9 +1007,10 @@ If prefix is given, force tag generation based on imenu. Might be
 useful when different language files are also present in the
 directory (.cpp, .c etc)."
   (interactive "DDirectory to tag:
-FTags file (default TAGS): ")
-  (when (eq (length (file-name-nondirectory tagfile)) 0)
-    (setq tagfile (concat tagfile "TAGS")))
+GTags file (default TAGS): ")
+  (when (or (eq (length (file-name-nondirectory tagfile)) 0)
+            (file-directory-p tagfile))
+    (setq tagfile (concat (file-name-as-directory tagfile) "TAGS")))
   ;; emacs find-tags doesn't play well with remote TAG files :(
   (when (file-remote-p tagfile)
     (require 'tramp)


### PR DESCRIPTION
Running ess-build-tags-for-directory appears to default to the current directory (e.g. mypackage/R) when asking for the name of the TAGS file. This should default to TAGS within that directory. However if I simply accept the default emacs (version 24.3.1) provides the full file path with the R file being edited currently, causing that file to be overwritten on disk.
