### PR TITLE
ess-kill-buffer-and-go modfied to not restart R if it is not already run...

### DIFF
--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -789,7 +789,7 @@ to see which keystrokes find which sections."
   "Kill the current buffer and switch back to the ESS process."
   (interactive)
   (kill-buffer (current-buffer))
-  (if (and ess-current-process-name (get-process ess-current-process-name))
+  (when (and ess-current-process-name (get-process ess-current-process-name))
       (ess-switch-to-ESS nil)))
 
 (defun ess-describe-sec-map nil


### PR DESCRIPTION
The behaviour of ess-kill-buffer-and-go is unexpected when you're trying to close a help file after R has already been closed. As is, this will call ess-switch-to-ESS, which will in turn call ess-force-buffer-current. This will restart the R process, just as you're trying to kill an errant help window.

This pull request modifes the behaviour of ess-kill-buffer-and-go to skip the call to ess-swtich-to-ESS if R is not running. There may be other, cleaner fixes, but this seems to work.
