### PR TITLE
ess-inf.el(ess-quit-r): call base::q() even if it is masked

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -2753,7 +2753,7 @@ regarding whether the workspace image should be saved."
     ;;Q (unless (string-equal response "cancel")
     (ess-cleanup)
     ;;Q   (setq cmd (format "q(\"%s\")\n" response))
-    (setq cmd "q()\n")
+    (setq cmd "base::q()\n")
     (goto-char (marker-position (process-mark sprocess)))
     (process-send-string sprocess cmd)
     ;;(rename-buffer (concat (buffer-name) "-exited") t)


### PR DESCRIPTION
In a interactive session I tend to define functions with simple names like `f()`, `g()`, ... , and by accident `q()`, and when I press `C-c C-q`, I saw strange error messages. I guess this case is not uncommon, and it is better to make the namespace explicit.
