### PR TITLE
Fix bug in fill paragraph with roxy

### DIFF
--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -258,7 +258,7 @@
               (beg-par (point-min))
               (end-par (point-max)))
           (save-excursion
-            (if (re-search-backward (concat ess-roxy-re " *$") beg t)
+            (if (re-search-backward (concat ess-roxy-re " *$") (min beg (point)) t)
                 (setq beg-par (match-end 0))))
           (save-excursion
             (if (re-search-forward (concat ess-roxy-re " *$") end t)


### PR DESCRIPTION
Currently if you attempt to call fill-paragraph with point in position `X` below

    #'X

an error

    Invalid search bound (wrong side of point)

occurs. This is problematic when using [aggressive-fill-paragraph](https://github.com/davidshepherd7/aggressive-fill-paragraph-mode) which continuously attempts to fill comment paragraphs.

This patch fixes the issue.