### PR TITLE
Add r-completion.elc to Makefile

### DIFF
--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -48,7 +48,7 @@ ELC = $(CORE) ess-comp.elc ess-custom.elc \
 	ess-omg-l.elc ess-omg-d.elc \
 	ess-bugs-l.elc ess-bugs-d.elc ess-jags-d.elc \
 	ess-noweb.elc ess-noweb-mode.elc ess-noweb-font-lock-mode.elc \
-	ess-eldoc.elc ess-roxy.elc ess-rutils.elc \
+	ess-eldoc.elc ess-roxy.elc ess-rutils.elc ess-r-completion.elc \
 	ess-s-l.elc ess-s3-d.elc ess-s4-d.elc \
 	ess-sp3-d.elc ess-sp4-d.elc ess-sp5-d.elc ess-sp6-d.elc \
 	ess-rdired.elc ess-r-args.elc ess-r-d.elc ess-rd.elc \


### PR DESCRIPTION
ess-r-completion is not byte-compiled therefore not sent to /usr/share/emacs/site-lisp for people using make install it creates some problem