### PR TITLE
Fixed install failure and missing file

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -102,7 +102,7 @@ install-info : info/ess.info
 
 install-other-docs: pdf html
 	-$(INSTALLDIR) $(DOCDIR)
-	$(INSTALL) ess.dvi ess.pdf readme.dvi readme.pdf ../README ../ANNOUNCE $(DOCDIR)
+	$(INSTALL) ess.pdf readme.pdf $(DOCDIR)
 	$(INSTALL) html/ess.html html/readme.html html/news.html $(DOCDIR)
 	$(INSTALL) refcard/refcard.pdf $(DOCDIR)
 

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -9,7 +9,7 @@ include ../Makeconf
 
 #ETCFILES = $(wildcard BACKBUG[S5].BAT backbug[s5] *.S sas-keys.*)
 #ETCFILES = ESSR.R ess-developer.R SVN-REVISION *.S sas-keys.* ess-sas-sh-command
-ETCFILES = SVN-REVISION *.S sas-keys.* ess-sas-sh-command
+ETCFILES = SVN-REVISION *.S sas-keys.* ess-sas-sh-command *.jl
 
 #ICONS = $(wildcard icons/*.xpm)
 ICONS = icons/*.xpm


### PR DESCRIPTION
Not sure if this is specific to Mac, but doc was missing the .dvi files after make and also there was no README or ANNOUNCE, so make install was failing.  I just removed them.
Also, there's a julia.jl file in etc, that wasn't installed, but needed when calling `julia`.
