### PR TITLE
make-variable-buffer-local should not be called at other than top-level

### DIFF
--- a/lisp/msdos.el
+++ b/lisp/msdos.el
@@ -147,8 +147,7 @@ d. strips ctrl-m from output.
 "
   (interactive)
   (setq msdos-minor-mode t)
-  (make-variable-buffer-local 'comint-completion-addsuffix)
-  (setq comint-completion-addsuffix '("\\" . " "))
+  (set (make-local-variable 'comint-completion-addsuffix) '("\\" . " "))
   (setq comint-process-echoes t)
   (add-hook 'comint-output-filter-functions 'shell-strip-ctrl-m nil t)
   (set-buffer-process-coding-system 'raw-text-dos 'raw-text-dos)


### PR DESCRIPTION
I got following warning with original code.
```
In msdos-minor-mode:
msdos.el:149:9:Warning: `make-variable-buffer-local' not called at toplevel
```