### PR TITLE
make-local-variable is better than make-variable-buffer-local

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -256,7 +256,7 @@ Alternatively, it can appear in its own frame if
             ;; Set up history file
             (if ess-history-file
                 (if (eq t ess-history-file)
-                    (set (make-variable-buffer-local 'ess-history-file)
+                    (set (make-local-variable 'ess-history-file)
                          (concat "." ess-dialect "history"))
                   ;; otherwise must be a string "..."
                   (unless (stringp ess-history-file)


### PR DESCRIPTION
This is similar to #155.

This patch resolves following byte-compile warning.
```
ess-inf.el:328:41:Warning: `make-variable-buffer-local' not called at toplevel
```