### PR TITLE
Implement ess-arg-function-offset-continued

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -671,12 +671,12 @@ This is in addition to ess-continued-statement-offset.")
 (defvar ess-arg-function-offset 2
   "Extra indent for internal substatements of function `foo' that called
 in `arg=foo(...)' form.
-If not number, the statements are indented at open-parenthesis following foo.")
+If not number, the statements are indented at open-parenthesis following `foo'.")
 
 (defvar ess-arg-function-offset-new-line '(2)
   "Extra indent for function arguments when ( is folowed by new line.
 
-If nil, the statements are indented at open-parenthesis following foo:
+If nil, the statements are indented at open-parenthesis following `foo':
 
   a <- some.function(other.function(
                                     arg1,
@@ -686,16 +686,16 @@ If a list of the form '(N) where N is a number, the statements
 are indented at the previous line indentation + N characters:
 
   a <- some.function(other.function(
-     arg1,
-     arg2)
+      arg1,
+      arg2)
 
 
 If a number N, the statement are alligned at the beginning of
 function call + N characters:
 
   a <- some.function(other.function(
-                       arg1,
-                       arg2)
+                         arg1,
+                         arg2)
 
 
 For inner function arguments the behavior is unchanged:
@@ -717,6 +717,39 @@ some.function(arg1,
                      a,
                      b,
 
+")
+
+(defvar ess-arg-function-offset-continued nil
+  "Extra indent for function arguments when ( is folowed by arguments and
+a new line. This setting is mainly intended for compatibility with Rstudio
+indentation rules. The default (nil) is recommended.
+
+If nil, the statements are indented at open-parenthesis following `foo':
+
+  a <- some.function(other.function(arg1,
+                                    arg2)
+
+If a list of the form '(N) where N is a number, the statements are indented
+at the previous line indentation + N characters, as in Rstudio:
+
+  a <- some.function(other.function(arg1,
+      arg2)
+
+
+If a number N, the statement are alligned at the beginning of
+function call + N characters:
+
+  a <- some.function(other.function(arg1,
+                         arg2)
+
+Note that this setting only applies to function calls, not functions
+declarations. For declarations, arguments are always aligned with
+the opening parenthese:
+
+  a <- function(arg1,
+                arg2) {
+      body
+  }
 ")
 
 ;;added rmh 2Nov97 at request of Terry Therneau


### PR DESCRIPTION
Hello,

This implements `ess-arg-function-offset-continued`, a companion to `ess-arg-function-offset-new-line`. While the latter acts when no function arguments have been entered, the new setting allows to control the indentation for continuations of an argument list.

The behaviour is similar to existing parameters:
```r
# nil (the default, same indentation as before the patch)
fun(arg1,
    fun2(arg2,
         arg3
    ))

# 2
fun(arg1,
      fun2(arg2,
             arg3
      ))

# '(2)
fun(arg1,
  fun2(arg2,
    arg3
  ))
```

This feature was [requested] (https://stat.ethz.ch/pipermail/ess-help/2011-December/007344.html) a while ago on the mailing list. Also, setting this parameter to `'(2)` produces code in line with Hadley Wickham's coding style.