### PR TITLE
ERT testing framework and indentation test cases

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -835,6 +835,10 @@ If not number, the statements are indented at open-parenthesis following
                (ess-expression-offset . 4)
                (ess-else-offset . 0)
                (ess-close-brace-offset . 0)
+               (ess-brace-imaginary-offset . 0)
+               (ess-continued-brace-offset . 0)
+               (ess-close-paren-offset . 0)
+               (ess-fancy-comments . t)
                )
           ;; CLB added rmh 2Nov97 at request of Terry Therneau
           (CLB (ess-indent-level . 2)

--- a/test/ess-tests.el
+++ b/test/ess-tests.el
@@ -1,0 +1,81 @@
+;; ess-tests.el --- Tests for ESS
+;;
+;;
+;; Filename: ess-tests.el
+;; Created: 07-05-2015 (ESS 15.09)
+;; Keywords: tests, indentation
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; This file is *NOT* part of GNU Emacs.
+;; This file is part of ESS
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 3, or
+;; (at your option) any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; A copy of the GNU General Public License is available at
+;; http://www.r-project.org/Licenses/
+;;
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Commentary:
+;;
+;; To run these tests:
+;;   All tests: M-x ert t
+;;
+;; To apply styles for manual testing:
+;;   M-: (let ((ess-style-alist ess-test-style-alist))
+;;         (ess-set-style 'test-misc1))
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;; Code:
+
+(require 'ert)
+
+
+;;; Indentation tests
+
+(defvar ess-test-style-alist
+  ;; New test-RRR style containing additional settings.
+  ;; Compared to RRR, it makes sure personal configuration does not
+  ;; interfere with tests
+  `(,(assq 'RRR ess-style-alist)
+    (misc1
+     (ess-indent-level . 6)
+     (ess-first-continued-statement-offset . 3)
+     (ess-continued-statement-offset . 0)
+     (ess-brace-offset . -6)
+     (ess-arg-function-offset . 0)
+     (ess-arg-function-offset-new-line . 6)
+     (ess-expression-offset . 0)
+     (ess-else-offset . 6)
+     (ess-close-brace-offset . 6)
+     (ess-brace-imaginary-offset . 3)
+     (ess-continued-brace-offset . 3)
+     (ess-close-paren-offset . '(3)))))
+
+(defun ess-test-R-indentation (file style)
+  (let ((ess-style-alist (append ess-test-style-alist ess-style-alist)))
+    (with-temp-buffer
+      (insert-file-contents-literally file t)
+      (let ((expected (buffer-string)))
+        (R-mode)
+        (setq ess-fancy-comments t)
+        (ess-set-style style)
+        (indent-region (point-min) (point-max))
+        (should (equal (buffer-string) expected))))))
+
+(ert-deftest test-ess-R-indentation-RRR ()
+  (ess-test-R-indentation "styles/RRR.R" 'RRR))
+
+(ert-deftest test-ess-R-indentation-misc1 ()
+  (ess-test-R-indentation "styles/misc1.R" 'misc1))

--- a/test/generate-indent-cases
+++ b/test/generate-indent-cases
@@ -1,0 +1,41 @@
+#!/usr/bin/env emacs --script
+
+;; (Re)generate files with test cases for indentation
+
+(let ((current-directory (file-name-directory load-file-name)))
+  (setq ess-test-path (expand-file-name "." current-directory))
+  (setq ess-styles-path (expand-file-name "./styles/" current-directory))
+  (setq ess-root-path (expand-file-name "../lisp/" current-directory)))
+
+(add-to-list 'load-path ess-root-path)
+(add-to-list 'load-path ess-test-path)
+
+(require 'ess-site)
+(load (expand-file-name "ess-tests.el" ess-test-path) nil t)
+
+;; The RRR file is taken as a model, so modify this file to add or
+;; adjust test cases.
+(let ((ess-style-alist ess-test-style-alist)
+      (RRR-file (expand-file-name "RRR.R" ess-styles-path)))
+
+  ;; Regenerate indentation in RRR file
+  (set-buffer (find-file-noselect RRR-file))
+  (setq ess-fancy-comments t)
+  (ess-set-style 'RRR)
+  (indent-region (point-min) (point-max))
+  (save-buffer)
+
+  (mapc
+   (lambda (test-conf)
+     (let* ((test-name (car test-conf))
+            (test-file (expand-file-name
+                        (concat (symbol-name test-name) ".R")
+                        ess-styles-path)))
+       (set-buffer (find-file-noselect test-file))
+       (setq ess-fancy-comments t)
+       (ess-set-style test-name)
+       (delete-region (point-min) (point-max))
+       (insert-file-contents-literally RRR-file t)
+       (indent-region (point-min) (point-max))
+       (save-buffer)))
+   (assq-delete-all 'RRR ess-test-style-alist)))

--- a/test/run-tests
+++ b/test/run-tests
@@ -1,0 +1,16 @@
+#!/usr/bin/env emacs --script
+
+;; This script must be run from the test directory
+
+(let ((current-directory (file-name-directory load-file-name)))
+  (setq ess-test-path (expand-file-name "." current-directory))
+  (setq ess-root-path (expand-file-name "../lisp/" current-directory)))
+
+(add-to-list 'load-path ess-root-path)
+(add-to-list 'load-path ess-test-path)
+
+(require 'ess-site)
+(load (expand-file-name "ess-tests.el" ess-test-path) nil t)
+
+;; run tests
+(ert-run-tests-batch-and-exit t)

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -1,0 +1,375 @@
+
+
+### Function declarations
+
+## 1
+fun <- function(argument1,
+                argument2) {
+    body
+}
+
+## 2
+function(
+    argument1,
+    argument2
+    )
+    {
+        body
+    }
+
+## 3
+function(argument_fun(sub_argument1,
+                      sub_argument2),
+         argument) {}
+
+## 4
+function(argument1, parameter = fun_call(
+                        sub_argument),
+         argument2) {}
+
+
+
+### Function calls
+
+## 1
+fun_call(argument1,
+         argument2)
+
+## 2
+fun_call(
+    argument1,
+    argument2
+    )
+
+## 3
+fun_call(parameter = (
+    stuff
+    ),
+         argument)
+
+## 4
+fun_call(parameter = fun_argument(
+             stuff
+    ),
+         argument)
+
+
+
+### Blocks
+
+## 1
+function()
+    {
+        body
+    }
+
+## 2
+fun_call({
+    stuff1
+},
+         {
+             stuff2
+         }
+         )
+
+## 3
+fun_call({
+    stuff1
+}, {
+    stuff2
+})
+
+## 4
+fun_call(
+    parameter1 = {
+        stuff1
+    },
+    parameter2 = {
+        stuff2
+    }
+    )
+
+## 5
+fun_call(parameter1 = {
+             stuff1
+         },
+         {
+             stuff2
+         }, parameter2 = {
+             stuff3
+         }, {
+             stuff4
+         },
+         parameter3 =
+             stuff5 ~
+                 stuff6 +
+                     stuff7)
+
+## 6
+fun <- fun_call({
+    stuff1
+}, {
+    stuff2
+},
+                {
+                    stuff3
+                }
+                )
+
+## 7
+fun_call(function(x) {
+             body1
+         },
+         function(x) {
+             body2
+         })
+
+## 8
+object <-
+    fun_call({
+        body
+    })
+
+## 9
+object <-
+    fun_call(     {
+                 body
+             }
+             )
+
+## 10
+{
+    {
+        stuff
+    }
+}
+
+## 11
+{{
+     stuff
+ }
+}
+
+## 12
+({
+    stuff
+})
+
+## 13
+( {
+     stuff
+ }
+ )
+
+## 14
+object[
+       argument1,
+       argument2
+       ]
+
+## 15
+{
+    object[
+           fun_call(
+               body
+               ),
+           argument[
+                    (
+                        sub_argument
+                        )
+                    ]
+           ]
+}
+
+
+
+### Control flow
+
+## 1
+if (condition) {
+    stuff1
+} else {
+    stuff2
+}
+
+## 2
+if (condition) {
+    stuff1
+}
+else {
+    stuff2
+}
+
+## 3
+if (condition)
+    {
+        stuff1
+    } else
+        {
+            stuff2
+        }
+
+## 4
+if (condition)
+    {
+        stuff1
+    }
+else
+    {
+        stuff2
+    }
+
+## 5
+for (sequence)
+    {
+        stuff
+    }
+
+## 6
+for (sequence) {
+    stuff
+}
+
+## 7
+if (condition)
+    stuff
+
+## 8
+for (sequence)
+    stuff
+
+
+
+### Continuation lines
+
+## 1
+stuff1 %>%
+    stuff2 %>%
+        stuff3
+
+## 2
+{
+    stuff1 %>%
+        stuff2 %>%
+            stuff3
+} %>%
+    stuff4 %>%
+        stuff5
+
+## 3
+(
+    stuff1 %>%
+        stuff2 %>%
+            stuff3
+    ) %>%
+    stuff4 %>%
+        stuff5
+
+## 4
+[
+ stuff1 %>%
+     stuff2 %>%
+         stuff3
+ ] %>%
+     stuff4 %>%
+         stuff5
+
+## 5
+stuff1 %>%
+    stuff2 %>%
+        if (condition) {
+            stuff3 %>%
+                stuff4 %>%
+                    stuff5
+        } else {
+            stuff6 %>%
+                stuff7 %>%
+                    for (sequence) {
+                        stuff8
+                    } %>%
+                        stuff9 %>%
+                            stuff10
+        } %>%
+            stuff11 %>%
+                stuff12
+
+## 6
+stuff[stuff1 %>%
+          stuff2 %>%
+              stuff3] %>%
+                  stuff4 %>%
+                      stuff5
+
+## 7
+ggplot() +
+    geom(lhs -
+             rhs
+         ) +
+        geom()
+
+## 8
+{
+    ggplot() +
+        geom1(argument1,
+              argument2 = (
+                  stuff
+                  )) +
+            geom2()
+}
+
+## 9
+stuff +
+    fun_call(parameter = argument1,
+             fun_call((lhs - rhs
+                       argument2
+                       ) /
+                          argument3)
+             )
+
+
+
+### Comments
+
+## 1
+                                        # Side comment
+
+## 2
+{
+    ## Hanging comment 1
+    fun_call(
+        {
+            ## Hanging comment 2
+        }
+        )
+}
+
+## 3
+{
+### Section comment
+}
+
+
+### Logical operators
+
+## 1
+stuff1 &&
+    stuff2 ||
+        stuff3
+
+## 2
+(stuff1 &&
+     stuff2 ||
+         stuff3)
+
+## 3
+if (condition1 &&
+    condition2 ||
+    (condition3 && condition4) ||
+    (condition5 &&
+         condition6 &&
+             condition7) ||
+    condition8) {
+    stuff
+} && condition8 ||
+    condition9 ||
+        condition10

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -1,0 +1,349 @@
+
+
+### Function declarations
+
+## 1
+fun <- function(argument1,
+                argument2) {
+         body
+         }
+
+## 2
+function(
+      argument2,
+      argument2
+   )
+{
+      body
+      }
+
+## 3
+function(argument_fun(sub_argument1,
+                      sub_argument2),
+         argument) {}
+
+## 4
+function(argument1, parameter = fun_call(
+                    sub_argument),
+         argument2) {}
+
+
+
+### Function calls
+
+## 5
+fun_call(argument1,
+         argument2)
+
+## 6
+fun_call(
+      argument1,
+      argument2
+   )
+
+## 7
+fun_call(parameter = (
+               stuff
+   ),
+         argument)
+
+## 8
+fun_call(parameter = fun_argument(
+         stuff
+   ),
+         argument)
+
+
+
+### Blocks
+
+## 9
+function()
+{
+      body
+      }
+
+## 10
+fun_call(parameter1 = {
+                  stuff
+                  },
+   {
+         stuff
+         }, parameter2 = {
+                  stuff
+                  }, {
+                           stuff
+                           },
+         parameter3 =
+            stuff1 ~
+            stuff2 +
+            stuff4)
+
+## 11
+fun <- fun_call({
+                         stuff1
+                         }, {
+                                  stuff2
+                                  },
+          {
+                stuff2
+                }
+   )
+
+## 12
+fun_call(function(x) {
+                  body
+                  },
+         function(x) {
+                  body
+                  })
+
+## 13
+object <-
+      fun_call({
+                        body
+                        })
+
+## 14
+object <-
+      fun_call( {
+                        body
+                        }
+         )
+
+## 15
+{
+{
+      stuff
+      }
+}
+
+## 16
+{{
+          stuff
+          }
+ }
+
+## 17
+({
+          stuff
+          })
+
+## 18
+( {
+          stuff
+          }
+   )
+
+## 19
+object[
+       argument1,
+       argument2
+       ]
+
+## 20
+{
+      object[
+             fun_call(
+                   body
+                ),
+             argument[
+                      (
+                        sub_argument
+                        )
+                    ]
+           ]
+}
+
+
+
+### Control flow
+
+## 21
+if (condition) {
+         stuff
+         } else {
+                  stuff
+                  }
+
+## 22
+if (condition) {
+         stuff
+         }
+      else {
+               stuff
+               }
+
+## 23
+if (condition)
+{
+      stuff
+      } else
+      {
+            stuff
+            }
+
+## 24
+if (condition)
+{
+      stuff
+      }
+      else
+      {
+            stuff
+            }
+
+## 25
+for (sequence)
+{
+      stuff
+      }
+
+## 26
+for (sequence) {
+         stuff
+         }
+
+## 27
+if (condition)
+      stuff
+
+## 28
+for (sequence)
+      stuff
+
+
+
+### Continuation lines
+
+## 29
+stuff1 %>%
+   stuff2 %>%
+   stuff3
+
+## 30
+{
+      stuff1 %>%
+         stuff2 %>%
+         stuff3
+      } %>%
+         stuff4 %>%
+         stuff5
+
+## 31
+(
+               stuff1 %>%
+                  stuff2 %>%
+                  stuff3
+   ) %>%
+   stuff4 %>%
+   stuff5
+
+## 32
+[
+ stuff1 %>%
+    stuff2 %>%
+    stuff3
+ ] %>%
+    stuff4 %>%
+    stuff5
+
+## 33
+stuff1 %>%
+   stuff2 %>%
+   if (condition) {
+            stuff3 %>%
+               stuff4 %>%
+               stuff5
+            } else {
+                     stuff6 %>%
+                        stuff7 %>%
+                        for (sequence) {
+                                 stuff8
+                                 } %>%
+                                    stuff9 %>%
+                                    stuff10
+                     } %>%
+                        stuff11 %>%
+                        stuff12
+
+## 34
+stuff[stuff1 %>%
+         stuff2 %>%
+         stuff3] %>%
+         stuff4 %>%
+         stuff5
+
+## 35
+ggplot() +
+   geom(lhs -
+           rhs
+      ) +
+   geom()
+
+## 36
+{
+      ggplot() +
+         geom1(argument1,
+               argument2 = (
+                     stuff
+                  )) +
+         geom2()
+      }
+
+## 37
+stuff +
+   fun_call(parameter = argument1,
+            fun_call((lhs - rhs
+                      argument2
+               ) /
+                        argument3)
+      )
+
+
+
+### Comments
+
+## 38
+# Side comment
+
+## 39
+{
+      ## Hanging comment 1
+      fun_call(
+      {
+            ## Hanging comment 2
+            }
+         )
+      }
+
+## 40
+{
+      ### Section comment
+      }
+
+
+### Logical operators
+
+## 41
+stuff1 &&
+   stuff2 ||
+   stuff3
+
+## 42
+(stuff1 &&
+    stuff2 ||
+    stuff3)
+
+## 43
+if (condition1 &&
+    condition2 ||
+    (condition3 && condition4) ||
+    (condition5 &&
+        condition6 &&
+        condition7) ||
+    condition8) {
+         stuff
+         } && condition8 ||
+            condition9 ||
+            condition10


### PR DESCRIPTION
Here is the testing framework discussed in #174.

The tests can be run with `./run-tests` (needs to be launched from the test directory) and the indentation test files can be regenerated with `./run-tests --generate-indent-cases`.

The latter will:
* (re)generate test files based on all configurations contained in the variable `ess-test-style-alist`.
* take the `indentation-test-RRR.R` file as a model so any addition or modification of the test cases should be done in this file.

Currently the tests are broken because I have added this `test-misc1` configuration that makes ESS indentation fail with an error :-). It fails on the test cases 11, 13, 17 and 20.

So this PR can be merged and we can correct this bug later. We'll have `./run-tests` to check everything is fixed.