### PR TITLE
roxygen editing enhancements

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -35,6 +35,10 @@ or @code{'(t)} to refer to the base indentation level
 as possible R files indented via RStudio. To reproduce the setup of some
 RStudio users, you will also need to set @code{ess-offset-arguments} to
 @code{'(t)}.
+@item @ESS{[R]}: Roxygen fields will now be indented on paragraph
+refilling in order to make the documentation more readable. You can also
+refill commented lines in the @code{@examples} field without squashing
+the surrounding code in the comments.
 @end itemize
 
 Changes and New Features in 15.03-1:

--- a/etc/ess-roxy-tests.R
+++ b/etc/ess-roxy-tests.R
@@ -1,10 +1,10 @@
 ##' \code{loadings(object)} and then design your own plotting method.
 ##' @title Side by side scores and loadings plot
 ##' @usage slplot(object, pcs=c(1,2), scoresLoadings=c(TRUE, TRUE),
-##' sl="def", ll="def", hotelling=0.95, rug=TRUE, sub=NULL,...)
-##' @param object 
-##' @param pcs 
-##' @param tjo 
+##'   sl="def", ll="def", hotelling=0.95, rug=TRUE, sub=NULL,...)
+##' @param object
+##' @param pcs
+##' @param tjo
 ##' @return None, used for side effect.
 ##' @export
 ##' @author Henning Redestig
@@ -18,12 +18,12 @@ setMethod("slplot", "pcaRes",
 ##' .. content for \description{} (no empty lines) ..
 ##'
 ##' .. content for \details{} ..
-##' @title 
-##' @param a 
-##' @param b 
-##' @param d 
-##' @param asd 
-##' @return 
+##' @title
+##' @param a
+##' @param b
+##' @param d
+##' @param asd
+##' @return
 ##' @author Henning Redestig
 trickyInArgsComments <- function(a,#comment
                                  b,#hejhopp trams
@@ -34,11 +34,11 @@ trickyInArgsComments <- function(a,#comment
 ##' .. content for \description{} (no empty lines) ..
 ##'
 ##' .. content for \details{} ..
-##' @title 
-##' @param a 
-##' @param b 
-##' @param cc 
-##' @return 
+##' @title
+##' @param a
+##' @param b
+##' @param cc
+##' @return
 ##' @author Henning Redestig
 withdef <- function(a, b=c("asd","ffd", "asd", "ffd",
                          "asd",
@@ -54,18 +54,18 @@ setClass(Class="inference", representation=representation(model="character"
                                    , two.sided="logical"
                                    , ci.level="numeric"), contains=c("matrix"))
 
-##' .. content for \description{} (no empty lines) 
-##' 
+##' .. content for \description{} (no empty lines)
+##'
 ##' .. content for \details{} ..
 ##' @title asd
-##' @param a 
-##' @param asdsd 
-##' @param sd 
-##' @param ... 
+##' @param a
+##' @param asdsd
+##' @param sd
+##' @param ...
 ##' @return s
 ##' @author Henning Redestig
 tempFixNasFunction <- function(a,asdsd, sd, ...) {
-  asds 
+  asds
 }
 
 setGeneric("updateMu", function(respM, gamma, ...)
@@ -83,16 +83,16 @@ setGeneric("updateMu", function(respM, gamma, ...)
 ## (auto-fill-mode)
 asd
 
-##'   aqdasd lksa odnsl dlsakdn lsakdn sladn  asijdi j 1. asdsd alksnd
+##'   aqdasd lksa odnsl dlsakdn lsakdn sladn asijdi j 1. asdsd alksnd
 ##'   lasdn ldnad
-##' 
+##'
 ##'
 ##' alkdnal dl lakd lasdnladna ld aldan lda dlakd nladn a amd lakdn
 ##' ajdn asjdns
 ##'
 ##'    lajnsd jasdn aksjdnaksjnd asjdnaksdnajsdnajsd aksdn askdjn
 ##'    akjdn aksdnkasjdnka
-##' 
+##'
 ##'       1. aldn adlnsald ladn saldnlaksd naskl
 ##'       2. ad asdjnksadn adjn skajan kda dksadkas dkjan dkasndkadn
 ##'       ajsd nkj dakjd sd
@@ -100,10 +100,9 @@ asd
 ##' @param fitta asdadsd
 ##' 1.
 ##' 	2. asd
-##' @param diagonals pung asa as a  sad s dsa da das d asd asd
-##' add
+##' @param diagonals pung asa as a sad s dsa da das d asd asd add
 ##' @param tjo asd
-##' @param asdasd 
+##' @param asdasd
 ##' @return me
 ##' @author Henning Redestig
 tempFixNas <- function(fitta, diagonals, tjo, asdasd) {
@@ -116,22 +115,22 @@ tempFixNas <- function(fitta, diagonals, tjo, asdasd) {
 
 
 ##' Simply replace completely ajksbdkjsa djskbdkajbd
-##' 
+##'
 ##' ksdb skdb skasdaj ahd (ess-roxy-beg-of-field) (newline-and-indent)
-##' aksndlsakndlksdn jkahd ksn dkjands 
+##' aksndlsakndlksdn jkahd ksn dkjands
 ##' @title Temporary fix for missing values
 ##' @param diagonals The diagonal to be replaced, i.e. the first,
-##' second and so on when looking at the fat version of the matrix
+##'   second and so on when looking at the fat version of the matrix
 ##' @param tjo asdsdsdw
 ##' @return The original matrix with completely missing rows/cols
-##' filled with zeroes. oasndsnd aksdnkasdnskans dkas ndkjasndksdn
-##' skandkand ksjandknsd
+##'   filled with zeroes. oasndsnd aksdnkasdnskans dkas ndkjasndksdn
+##'   skandkand ksjandknsd
 ##' @export
-##' @examples  
+##' @examples
 ##' tempFixNas(iris)
 ##' pi <- 1
 ##' plot(x)
-##' @author Henning Redestig 
+##' @author Henning Redestig
 tempFixNas <- function(diagonals, tjo) {
   (ess-roxy-delete-args)
 wilcox.test
@@ -140,54 +139,54 @@ wilcox.test
   badCols <- apply(mat, 2, function(x) all(is.na(x)))
   mat[ badRows,] <- 0 (ess-roxy-get-args-list-from-def)
   mat[,badCols ] <- 0 (ess-roxy-get-args-list-from-entry)
-  mat 
+  mat
 }
 
 ##' <description>
 ##'
-##' <details> 
+##' <details>
 ##' @title asdsd
 ##' @param asd asd
 ##' @param test1 asd
-##' @param asdsd 
+##' @param asdsd
 ##' @param tjo asdasd
 ##' @return aa
 ##' @author Henning Redestig
 tempFixNas <- function(asd,test1,asdsd,tjo=c("asd", "asdasd")) {
-## (ess-roxy-goto-end-of-entry)  
+## (ess-roxy-goto-end-of-entry)
 ##   (setq fun (ess-roxy-get-args-list-from-def))
 ##   (setq ent (ess-roxy-get-args-list-from-entry))
-##   (ess-roxy-merge-args fun ent) 
-##   (ess-roxy-mrg-args fun ent) 
+##   (ess-roxy-merge-args fun ent)
+##   (ess-roxy-mrg-args fun ent)
 ##   (ess-roxy-get-args-list-from-entry)
 ## (ess-roxy-get-function-args)
 ## (ess-roxy-goto-end-of-entry)
 
-##   (setq here (ess-roxy-delete-args)) 
+##   (setq here (ess-roxy-delete-args))
 ##   (ess-roxy-insert-args (ess-roxy-get-args-list-from-def) here)
   badRows <- apply(mat, 1, function(x) all(is.na(x)))
   badCols <- apply(mat, 2, function(x) all(is.na(x)))
   mat[ badRows,] <- 0
-  mat[,badCols ] <- 0 
-  mat 
+  mat[,badCols ] <- 0
+  mat
 }
 
 ##' <description>
 ##'
 ##' <details>
 ##' @title my title
-##' @param test1 
-##' @param tjo 
-##' @param pung 
-##' @param str 
+##' @param test1
+##' @param tjo
+##' @param pung
+##' @param str
 ##' @return value
 ##' @author Henning Redestig
 tempFixNasBad <- function(test1,tjo=c("asd", "asdasd"), pung, str) {
-asdsd# (car (cdr (ess-end-of-function nil t))) 
+asdsd# (car (cdr (ess-end-of-function nil t)))
 }
 
 ##' Provides Bayesian PCA, Probabilistic PCA, Nipals PCA, Inverse
-##' Non-Linear PCA and the conventional SVD PCA. A cluster  based
+##' Non-Linear PCA and the conventional SVD PCA. A cluster based
 ##' method for missing value estimation is included for comparison.
 ##' BPCA, PPCA and NipalsPCA may be used to perform PCA on incomplete
 ##' data as well as for accurate missing value estimation.  A set of
@@ -208,4 +207,15 @@ asdsd# (car (cdr (ess-end-of-function nil t)))
 NULL
 
 
-asdsd
+#' Title
+#'
+#' @param par Lorem ipsum dolor sit amet, consectetur adipiscing
+#'   elit. Vivamus ligula purus, ultricies quis odio non, vulputate
+#'   finibus risus. Donec eleifend quis dolor ut rhoncus.
+#' @param par2 Lorem ipsum dolor sit amet, consectetur adipiscing
+#'   elit. Vivamus ligula purus, ultricies quis odio non.
+#' @examples
+#' # This long comment line can be paragraph-filled without squashing
+#' # the following lines of code into the comment
+#' fun(arg)
+#' print(object)

--- a/lisp/ess-r-d.el
+++ b/lisp/ess-r-d.el
@@ -473,6 +473,7 @@ Executed in process buffer."
   (ad-activate 'mark-paragraph)
   (ad-activate 'fill-paragraph)
   (ad-activate 'move-beginning-of-line)
+  (ad-activate 'back-to-indentation)
   (ad-activate 'newline-and-indent)
   (ad-activate 'ess-eval-line-and-step)
   (if ess-roxy-hide-show-p

--- a/lisp/ess-r-d.el
+++ b/lisp/ess-r-d.el
@@ -470,7 +470,6 @@ Executed in process buffer."
        'ess-end-of-function)
 
   (ess-roxy-mode t)
-  (ad-activate 'mark-paragraph)
   (ad-activate 'fill-paragraph)
   (ad-activate 'move-beginning-of-line)
   (ad-activate 'back-to-indentation)

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -694,6 +694,15 @@ list of strings."
     string))
 (add-hook 'ess-presend-filter-functions 'ess-roxy-remove-roxy-re nil)
 
+(defun ess-roxy-first-non-blank ()
+  (interactive)
+  (if (ess-roxy-entry-p)
+      (progn
+        (end-of-line)
+        (re-search-backward (concat ess-roxy-re " *") (point-at-bol))
+        (goto-char (match-end 0)))
+    (back-to-indentation)))
+
 (defadvice ess-eval-line-and-step (around ess-eval-line-and-step-roxy)
   "evaluate line but do not skip over comment (roxy) lines"
   (if (ess-roxy-entry-p)
@@ -724,11 +733,10 @@ list of strings."
 
 (defadvice move-beginning-of-line (around ess-roxy-beginning-of-line)
   "move to start"
-  (if (and (ess-roxy-entry-p)
-           (not (looking-back (concat ess-roxy-re " *\\="))))
+  (if (ess-roxy-entry-p)
       (progn
         (end-of-line)
-        (re-search-backward (concat ess-roxy-re " *") (point-at-bol))
+        (re-search-backward (concat ess-roxy-re " ?") (point-at-bol))
         (goto-char (match-end 0)))
     ad-do-it))
 

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -63,6 +63,8 @@
 
 (require 'ess-custom)
 (require 'hideshow)
+(eval-when-compile
+  (require 'cl))
 (autoload 'Rd-preview-help "ess-rd" "[autoload]" t)
 
 ;; ------------------
@@ -132,11 +134,12 @@
   (when font-lock-mode
     (font-lock-fontify-buffer))
   ;; for auto fill functionality
-  (make-local-variable 'adaptive-fill-regexp)
-  (setq adaptive-fill-regexp (concat ess-roxy-re adaptive-fill-regexp))
-  (make-local-variable 'adaptive-fill-first-line-regexp)
-  (setq adaptive-fill-first-line-regexp (concat ess-roxy-re
-                                                adaptive-fill-first-line-regexp))
+  (make-local-variable 'paragraph-start)
+  (setq paragraph-start (concat "\\(" ess-roxy-re "\\)*" paragraph-start))
+  (make-local-variable 'paragraph-separate)
+  (setq paragraph-separate (concat "\\(" ess-roxy-re "\\)*" paragraph-separate))
+  (make-local-variable 'adaptive-fill-function)
+  (setq adaptive-fill-function 'ess-roxy-adaptive-fill-function)
   (add-hook 'ess-presend-filter-functions 'ess-roxy-remove-roxy-re nil 'local)
   )
 
@@ -243,23 +246,36 @@
         (end (ess-roxy-end-of-field)))
     (narrow-to-region beg end)))
 
-(defun ess-roxy-fill-field ()
-  "Fill the current paragraph in the current roxygen field."
-  (interactive)
-  (if (ess-roxy-entry-p)
-      (save-excursion
-        (let ((beg (ess-roxy-beg-of-field))
-              (end (ess-roxy-end-of-field))
-              (fill-prefix (concat (ess-roxy-guess-str) " "))
-              (beg-par (point-min))
-              (end-par (point-max)))
+(defun ess-roxy-adaptive-fill-function ()
+  "Return prefix for filling paragraph or nil if not determined."
+  (when (ess-roxy-entry-p)
+    (let ((roxy-str (car (split-string (ess-roxy-guess-str) "'"))))
+      (if (ess-roxy-in-header-p)
           (save-excursion
-            (if (re-search-backward (concat ess-roxy-re " *$") (min beg (point)) t)
-                (setq beg-par (match-end 0))))
-          (save-excursion
-            (if (re-search-forward (concat ess-roxy-re " *$") end t)
-                (setq end-par (- (match-beginning 0) 1))))
-          (fill-region (max beg beg-par) (min end end-par))))))
+            (move-beginning-of-line 1)
+            (re-search-forward "\\([ \t]*\\)" (line-end-position) t)
+            (concat roxy-str "' " (match-string 1)))
+        (concat roxy-str "' " (make-string ess-indent-level ? ))))))
+
+(defun ess-roxy-current-field ()
+  "Return the name of the field at point."
+  (and (not (ess-roxy-in-header-p))
+       (save-excursion
+         (goto-char (ess-roxy-beg-of-field))
+         (if (re-search-forward (concat ess-roxy-re
+                                        "[ \t]+@\\([[:alpha:]]+\\)")
+                                (line-end-position) t)
+             (match-string-no-properties 1)))))
+
+(defun ess-roxy-should-indent-line-p ()
+  "Return true when point is in a field, but not in its first line."
+  (and (not (ess-roxy-in-header-p))
+       (not (equal (ess-roxy-current-field) "examples"))
+       (save-excursion
+         (beginning-of-line)
+         (let ((line-n (count-lines 1 (point))))
+           (goto-char (ess-roxy-beg-of-field))
+           (not (equal line-n (count-lines 1 (point))))))))
 
 (defun ess-roxy-goto-func-def ()
   "put point at start of function either that the point is in or
@@ -302,7 +318,7 @@ function at point. if here is supplied start inputting
            (ess-replace-in-string (concat (car (cdr arg-des))) "\n"
                                   (concat "\n" roxy-str)))
           (if ess-roxy-fill-param-p
-              (ess-roxy-fill-field))
+              (fill-paragraph))
           )))))
 
 (defun ess-roxy-merge-args (fun ent)
@@ -704,9 +720,61 @@ list of strings."
     ad-do-it))
 
 (defadvice fill-paragraph (around ess-roxy-fill-advise)
-  "Fill the current roxygen field."
+  "Fill roxygen paragraphs."
   (if (ess-roxy-entry-p)
-      (ess-roxy-fill-field)
+      (let ((saved-pos (point))
+            (comment-start "#+'[ \t]+#")
+            (comment-start-skip "#+'[ \t]+# *")
+            (comment-use-syntax nil)
+            (adaptive-fill-first-line-regexp
+             (concat ess-roxy-re "[ \t]*"))
+            (temp-table (make-syntax-table S-syntax-table)))
+        ;; Prevent the roxy prefix to be interpreted as comment or
+        ;; string starter
+        (modify-syntax-entry ?# "w" temp-table)
+        (modify-syntax-entry ?' "w" temp-table)
+        ;; (comment-normalize-vars) modifies the comment-start regexp
+        ;; in such a way that paragraph filling of comments in
+        ;; @examples fields does not work
+        (cl-letf (((symbol-function 'comment-normalize-vars) #'ignore))
+          (with-syntax-table temp-table
+            (if (save-excursion
+                  (back-to-indentation)
+                  (looking-at "#"))
+                ;; Indentation of comments proceeds simply
+                ad-do-it
+              ;; We refill the whole structural paragraph
+              ;; sequentially, field by field, stopping at @examples
+              (let* ((par-end (save-excursion
+                                (forward-paragraph)
+                                (point)))
+                     (par-start (save-excursion
+                                  (backward-paragraph)
+                                  (point)))
+                     (stop-line (progn
+                                  (goto-char (or (re-search-forward
+                                                  "[ \t]*@examples"
+                                                  par-end t)
+                                                 par-end))
+                                  (line-number-at-pos)))
+                     (paragraph-start
+                      (concat "\\(" ess-roxy-re "\\(" paragraph-start
+                              "\\|[ \t]*@" "\\)" "\\)\\|\\(" paragraph-start "\\)")))
+                (if (re-search-backward
+                     (concat ess-roxy-re "[[:blank:]]+#")
+                     par-start t)
+                    (next-line)
+                  (goto-char par-start))
+                (while (< (line-number-at-pos) stop-line)
+                  (when (ess-roxy-should-indent-line-p)
+                    (move-beginning-of-line 1)
+                    (delete-region (point) (progn (skip-chars-forward " \t") (point)))
+                    (insert (make-string ess-indent-level ? )))
+                  ad-do-it
+                  (forward-paragraph))))))
+        ;; (save-excursion) does not work well here because we may
+        ;; delete the region at point
+        (goto-char saved-pos))
     ad-do-it))
 
 (defadvice move-beginning-of-line (around ess-roxy-beginning-of-line)

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -36,7 +36,7 @@
 ;;   - C-c C-o C-o :: update template
 ;; - navigating and filling roxygen fields
 ;;   - C-c TAB, M-q, C-a, ENTER, M-h :: advised tag completion, fill-paragraph,
-;;        move-beginning-of-line, newline-and-indent, mark-paragraph
+;;        move-beginning-of-line, newline-and-indent
 ;;   - C-c C-o n,p :: next, previous roxygen entry
 ;;   - C-c C-o C-c :: Unroxygen region. Convenient for editing examples.
 ;; - folding visibility using hs-minor-mode
@@ -137,10 +137,6 @@
   (make-local-variable 'adaptive-fill-first-line-regexp)
   (setq adaptive-fill-first-line-regexp (concat ess-roxy-re
                                                 adaptive-fill-first-line-regexp))
-  (make-local-variable 'paragraph-start)
-  (setq paragraph-start (concat "\\(" ess-roxy-re "\\)*" paragraph-start))
-  (make-local-variable 'paragraph-separate)
-  (setq paragraph-separate (concat "\\(" ess-roxy-re "\\)*" paragraph-separate))
   (add-hook 'ess-presend-filter-functions 'ess-roxy-remove-roxy-re nil 'local)
   )
 
@@ -699,15 +695,6 @@ list of strings."
   (if (ess-roxy-entry-p)
       (let ((simple-next t))
         ad-do-it)
-    ad-do-it))
-
-(defadvice mark-paragraph (around ess-roxy-mark-field)
-  "mark this field"
-  (if (and (ess-roxy-entry-p) (not mark-active))
-      (progn
-        (push-mark (point))
-        (push-mark (1+ (ess-roxy-end-of-field)) nil t)
-        (goto-char (ess-roxy-beg-of-field)))
     ad-do-it))
 
 (defadvice ess-indent-command (around ess-roxy-toggle-hiding)

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -694,15 +694,6 @@ list of strings."
     string))
 (add-hook 'ess-presend-filter-functions 'ess-roxy-remove-roxy-re nil)
 
-(defun ess-roxy-first-non-blank ()
-  (interactive)
-  (if (ess-roxy-entry-p)
-      (progn
-        (end-of-line)
-        (re-search-backward (concat ess-roxy-re " *") (point-at-bol))
-        (goto-char (match-end 0)))
-    (back-to-indentation)))
-
 (defadvice ess-eval-line-and-step (around ess-eval-line-and-step-roxy)
   "evaluate line but do not skip over comment (roxy) lines"
   (if (ess-roxy-entry-p)
@@ -737,6 +728,15 @@ list of strings."
       (progn
         (end-of-line)
         (re-search-backward (concat ess-roxy-re " ?") (point-at-bol))
+        (goto-char (match-end 0)))
+    ad-do-it))
+
+(defadvice back-to-indentation (around ess-roxy-back-to-indentation)
+  "Handle back-to-indentation in roxygen doc"
+  (if (ess-roxy-entry-p)
+      (progn
+        (end-of-line)
+        (re-search-backward (concat ess-roxy-re " *") (point-at-bol))
         (goto-char (match-end 0)))
     ad-do-it))
 


### PR DESCRIPTION
This introduces several changes and features to the auto-filling code for roxygen doc blocks.

The most useful feature in that PR is that paragraph filling of fields now produces an indent. This produces more readable code. I use `ess-indent-level` to set the indent size but maybe this needs to be a new setting?

Secondly I modified the `(move-beginning-of-line)` advice to make its behaviour more consistent with the rest of Emacs.

* It now goes to the beginning of line and not to the first non-blank character. I added a `(ess-roxy-first-non-blank)` function to make up for this. Those of you using Evil can bind it to `(evil-first-non-blank)`.

* Calling this command repeatedly would make the cursor switch from the roxy prefix to the zeroth column. I removed this behaviour because I used this function in the code and needed it to be consistent. Also as a user this behaviour felt odd because Ctrl-A did not feel like going against a 'hard wall'. However I can revert this change and find another strategy for the code that relies on this.

I also added the ROxygen fields as paragraph delimiters. This way we can use `(forward-paragraph)` to move from field to field. This also allows to remove the advice around `(mark-paragraph)`.

Finally I modified the `(newline-and-indent)` advice to make it produce an extra indent when the point is in a field. This makes it easier to write long parameter descriptions. On the other hand this also produces an unwanted indentation when we want to write a new field, so I'm not sure if this change is good. Now that field filling will create this indentation, it's also easy to write the field and fill it afterwards.
