### PR TITLE
Fix various indentation bugs introduced in code refactor

### DIFF
--- a/test/ess-tests.el
+++ b/test/ess-tests.el
@@ -65,7 +65,11 @@
      (ess-indent-from-outer-parameter . nil)
      (ess-offset-continued . 0)
      (ess-offset-continued-first . 3)
-     )))
+     )
+    (misc2
+     ,@(cdr (assq 'RStudio ess-style-alist))
+     (ess-offset-block . t)
+     (ess-offset-arguments . '(t)))))
 
 (defun ess-test-R-indentation (file style)
   (let ((ess-style-alist (append ess-test-style-alist ess-style-alist)))

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -36,6 +36,33 @@ function()
 
     function() body
 
+## 6
+object <- function()
+{
+    body
+}
+
+## 7
+{
+    object <- function()
+    {
+        body
+    }
+}
+
+## 8
+fun_call(parameter = function()
+         {
+             body
+         })
+
+## 9
+{
+    fun_call(parameter = function()
+             {
+                 body
+             })
+}
 
 
 ### Function calls
@@ -52,9 +79,9 @@ fun_call(
 
 ## 3
 fun_call(parameter = (
-             stuff
-         ),
-         argument)
+    stuff
+),
+argument)
 
 ## 4
 fun_call(parameter = fun_argument(
@@ -130,6 +157,12 @@ fun_call(parameter = fun_argument(
     )
 }
 
+## 12  # fixme: should be indented relative to <- ?
+
+a <- fun_call(
+         arg1,
+         arg2
+     )
 
 
 ### Blocks
@@ -214,6 +247,15 @@ fun_call(function(x) {
          })
 
 ## 9
+fun_call(
+    {
+        stuff
+    }, {
+        stuff
+    }
+)
+
+## 10
 object <-
     fun_call({
                  stuff
@@ -221,68 +263,81 @@ object <-
                  stuff
              })
 
-## 10
+## 11
 object <-
     fun_call(     {
                  body
              }
              )
 
-## 11
+## 12
+fun_call1(
+    fun_call2({
+                  stuff
+              }
+              )
+)
+
+## 13
 {
-{
-    stuff
-}
+    stuff1
+
+    {
+        stuff2
+    }
 }
 
-## 12
+## 14
 {{
     stuff
 }
 }
 
-## 13
+## 15
 ({
     stuff
 })
 
-## 14
+## 16
 ( {
     stuff
 }
 )
 
-## 15
+
+### Bracket indexing
+
+## 1
 object[
     argument1,
     argument2
 ]
 
-## 16
+## 2
 object[argument1,
        argument2
        ]
 
-## 17
+## 3
 object[(
-           argument1
-       )]
+    argument1
+)]
 
-## 18
+## 4
 {
     object[
         fun_call(
             body
         ),
         argument[
-            (
-                sub_argument
-            )
+        (
+            sub_argument
+        )
         ]
     ]
 }
 
-## 19
+## 5
 {
     object[
         argument1,
@@ -306,48 +361,60 @@ object[(
 ### Control flow
 
 ## 1
-if (condition) {
-    stuff1
-} else {
-    stuff2
+{
+    if (condition) {
+        stuff1
+    } else {
+        stuff2
+    }
 }
 
 ## 2
-if (condition) {
-    stuff1
-}
-else {
-    stuff2
+{
+    if (condition) {
+        stuff1
+    }
+    else {
+        stuff2
+    }
 }
 
 ## 3
-if (condition)
 {
-    stuff1
-} else
-{
-    stuff2
+    if (condition)
+    {
+        stuff1
+    } else
+    {
+        stuff2
+    }
 }
 
 ## 4
-if (condition)
 {
-    stuff1
-}
-else
-{
-    stuff2
+    if (condition)
+    {
+        stuff1
+    }
+    else
+    {
+        stuff2
+    }
 }
 
 ## 5
-for (sequence)
 {
-    stuff
+    for (sequence)
+    {
+        stuff
+    }
 }
 
 ## 6
-for (sequence) {
-    stuff
+{
+    for (sequence) {
+        stuff
+    }
 }
 
 ## 7
@@ -358,6 +425,40 @@ if (condition)
 for (sequence)
     stuff
 
+## 9
+object <-
+    if (condition) {
+        stuff
+    } else {
+        stuff
+    }
+
+## 10
+{
+    object <-
+        if (condition) stuff
+        else stuff
+}
+
+## 10
+{
+    object <-
+        if (condition) fun_call(
+                           argument1,
+                           argument2
+                       )
+        else stuff
+}
+
+## 11
+{
+    fun_call(parameter =
+                 if (condition)
+                     stuff
+                 else
+                     stuff
+             )
+}
 
 
 ### Continuation lines
@@ -444,8 +545,8 @@ stuff +
     fun_call(parameter = argument1,
              fun_call((stuff1 - stuff2 +
                            stuff3
-                      ) /
-                          stuff4)
+             ) /
+                 stuff4)
              )
 
 ## 10

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -36,6 +36,33 @@ function()
 
     function() body
 
+## 6
+object <- function()
+{
+    body
+}
+
+## 7
+{
+    object <- function()
+    {
+        body
+    }
+}
+
+## 8
+fun_call(parameter = function()
+{
+    body
+})
+
+## 9
+{
+    fun_call(parameter = function()
+    {
+        body
+    })
+}
 
 
 ### Function calls
@@ -84,14 +111,14 @@ fun_call(argument1
        , argument2
        , argument3,
          argument4, (
-    stuff1
-),
-argument5, (
-    stuff2
-)
-,
-argument6
-)
+             stuff1
+         ),
+         argument5, (
+             stuff2
+         )
+        ,
+         argument6
+         )
 
 ## 9
 fun_call(parameter =
@@ -130,6 +157,12 @@ fun_call(parameter = fun_argument(
     )
 }
 
+## 12  # fixme: should be indented relative to <- ?
+
+a <- fun_call(
+         arg1,
+         arg2
+     )
 
 
 ### Blocks
@@ -214,6 +247,15 @@ function(x) {
 })
 
 ## 9
+fun_call(
+{
+    stuff
+}, {
+    stuff
+}
+)
+
+## 10
 object <-
     fun_call({
         stuff
@@ -221,68 +263,81 @@ object <-
         stuff
     })
 
-## 10
+## 11
 object <-
     fun_call(     {
         body
     }
     )
 
-## 11
+## 12
+fun_call1(
+    fun_call2({
+        stuff
+    }
+    )
+)
+
+## 13
 {
-{
-    stuff
-}
+    stuff1
+
+    {
+        stuff2
+    }
 }
 
-## 12
+## 14
 {{
     stuff
 }
 }
 
-## 13
+## 15
 ({
     stuff
 })
 
-## 14
+## 16
 ( {
     stuff
 }
 )
 
-## 15
+
+### Bracket indexing
+
+## 1
 object[
     argument1,
     argument2
 ]
 
-## 16
+## 2
 object[argument1,
        argument2
        ]
 
-## 17
+## 3
 object[(
     argument1
 )]
 
-## 18
+## 4
 {
     object[
         fun_call(
             body
         ),
         argument[
-            (
+        (
             sub_argument
         )
         ]
     ]
 }
 
-## 19
+## 5
 {
     object[
         argument1,
@@ -306,48 +361,60 @@ object[(
 ### Control flow
 
 ## 1
-if (condition) {
-    stuff1
-} else {
-    stuff2
+{
+    if (condition) {
+        stuff1
+    } else {
+        stuff2
+    }
 }
 
 ## 2
-if (condition) {
-    stuff1
-}
-else {
-    stuff2
+{
+    if (condition) {
+        stuff1
+    }
+    else {
+        stuff2
+    }
 }
 
 ## 3
-if (condition)
 {
-    stuff1
-} else
-{
-    stuff2
+    if (condition)
+    {
+        stuff1
+    } else
+    {
+        stuff2
+    }
 }
 
 ## 4
-if (condition)
 {
-    stuff1
-}
-else
-{
-    stuff2
+    if (condition)
+    {
+        stuff1
+    }
+    else
+    {
+        stuff2
+    }
 }
 
 ## 5
-for (sequence)
 {
-    stuff
+    for (sequence)
+    {
+        stuff
+    }
 }
 
 ## 6
-for (sequence) {
-    stuff
+{
+    for (sequence) {
+        stuff
+    }
 }
 
 ## 7
@@ -358,6 +425,40 @@ if (condition)
 for (sequence)
     stuff
 
+## 9
+object <-
+    if (condition) {
+        stuff
+    } else {
+        stuff
+    }
+
+## 10
+{
+    object <-
+        if (condition) stuff
+        else stuff
+}
+
+## 10
+{
+    object <-
+        if (condition) fun_call(
+                           argument1,
+                           argument2
+                       )
+        else stuff
+}
+
+## 11
+{
+    fun_call(parameter =
+                 if (condition)
+                     stuff
+                 else
+                     stuff
+             )
+}
 
 
 ### Continuation lines
@@ -432,9 +533,9 @@ ggplot() +
     ggplot() +
         geom1(argument1,
               argument2 = (
-            stuff1
-        ) -
-            stuff2) +
+                  stuff1
+              ) -
+                  stuff2) +
             geom2() +
                 geom3()
 }
@@ -481,7 +582,7 @@ object1 <-
 {
     ## Hanging comment 1
     fun_call(
-        {
+    {
         ## Hanging comment 2
     }
     )
@@ -508,11 +609,11 @@ stuff1 &&
 ## 3
 if (condition1 &&
     condition2 ||
-    (condition3 && condition4) ||
-    (condition5 &&
-         condition6 &&
-             condition7) ||
-    condition8) {
+(condition3 && condition4) ||
+(condition5 &&
+     condition6 &&
+         condition7) ||
+condition8) {
     stuff
 } && condition8 ||
     condition9 ||

--- a/test/styles/RStudio.R
+++ b/test/styles/RStudio.R
@@ -36,6 +36,33 @@ function()
 
   function() body
 
+## 6
+object <- function()
+{
+  body
+}
+
+## 7
+{
+  object <- function()
+  {
+    body
+  }
+}
+
+## 8
+fun_call(parameter = function()
+{
+  body
+})
+
+## 9
+{
+  fun_call(parameter = function()
+  {
+    body
+  })
+}
 
 
 ### Function calls
@@ -84,14 +111,14 @@ fun_call(argument1
        , argument2
        , argument3,
          argument4, (
-  stuff1
-),
-argument5, (
-  stuff2
-)
-,
-argument6
-)
+           stuff1
+         ),
+         argument5, (
+           stuff2
+         )
+        ,
+         argument6
+         )
 
 ## 9
 fun_call(parameter =
@@ -130,6 +157,12 @@ argument
   )
 }
 
+## 12  # fixme: should be indented relative to <- ?
+
+a <- fun_call(
+  arg1,
+  arg2
+)
 
 
 ### Blocks
@@ -214,6 +247,15 @@ function(x) {
 })
 
 ## 9
+fun_call(
+{
+  stuff
+}, {
+  stuff
+}
+)
+
+## 10
 object <-
   fun_call({
     stuff
@@ -221,68 +263,81 @@ object <-
     stuff
   })
 
-## 10
+## 11
 object <-
   fun_call(     {
     body
   }
   )
 
-## 11
+## 12
+fun_call1(
+  fun_call2({
+    stuff
+  }
+  )
+)
+
+## 13
 {
-{
-  stuff
-}
+  stuff1
+
+  {
+    stuff2
+  }
 }
 
-## 12
+## 14
 {{
   stuff
 }
 }
 
-## 13
+## 15
 ({
   stuff
 })
 
-## 14
+## 16
 ( {
   stuff
 }
 )
 
-## 15
+
+### Bracket indexing
+
+## 1
 object[
   argument1,
   argument2
 ]
 
-## 16
+## 2
 object[argument1,
        argument2
        ]
 
-## 17
+## 3
 object[(
   argument1
 )]
 
-## 18
+## 4
 {
   object[
     fun_call(
       body
     ),
     argument[
-      (
+    (
       sub_argument
     )
     ]
   ]
 }
 
-## 19
+## 5
 {
   object[
     argument1,
@@ -306,48 +361,60 @@ object[(
 ### Control flow
 
 ## 1
-if (condition) {
-  stuff1
-} else {
-  stuff2
+{
+  if (condition) {
+    stuff1
+  } else {
+    stuff2
+  }
 }
 
 ## 2
-if (condition) {
-  stuff1
-}
-else {
-  stuff2
+{
+  if (condition) {
+    stuff1
+  }
+  else {
+    stuff2
+  }
 }
 
 ## 3
-if (condition)
 {
-  stuff1
-} else
-{
-  stuff2
+  if (condition)
+  {
+    stuff1
+  } else
+  {
+    stuff2
+  }
 }
 
 ## 4
-if (condition)
 {
-  stuff1
-}
-else
-{
-  stuff2
+  if (condition)
+  {
+    stuff1
+  }
+  else
+  {
+    stuff2
+  }
 }
 
 ## 5
-for (sequence)
 {
-  stuff
+  for (sequence)
+  {
+    stuff
+  }
 }
 
 ## 6
-for (sequence) {
-  stuff
+{
+  for (sequence) {
+    stuff
+  }
 }
 
 ## 7
@@ -358,6 +425,40 @@ if (condition)
 for (sequence)
   stuff
 
+## 9
+object <-
+  if (condition) {
+    stuff
+  } else {
+    stuff
+  }
+
+## 10
+{
+  object <-
+    if (condition) stuff
+    else stuff
+}
+
+## 10
+{
+  object <-
+    if (condition) fun_call(
+      argument1,
+      argument2
+    )
+    else stuff
+}
+
+## 11
+{
+  fun_call(parameter =
+             if (condition)
+               stuff
+             else
+               stuff
+           )
+}
 
 
 ### Continuation lines
@@ -432,9 +533,9 @@ ggplot() +
   ggplot() +
     geom1(argument1,
           argument2 = (
-      stuff1
-    ) -
-      stuff2) +
+            stuff1
+          ) -
+            stuff2) +
     geom2() +
     geom3()
 }
@@ -481,7 +582,7 @@ object1 <-
 {
   ## Hanging comment 1
   fun_call(
-    {
+  {
     ## Hanging comment 2
   }
   )
@@ -508,11 +609,11 @@ stuff1 &&
 ## 3
 if (condition1 &&
     condition2 ||
-    (condition3 && condition4) ||
-    (condition5 &&
-       condition6 &&
-       condition7) ||
-    condition8) {
+(condition3 && condition4) ||
+(condition5 &&
+   condition6 &&
+   condition7) ||
+condition8) {
   stuff
 } && condition8 ||
   condition9 ||

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -16,7 +16,7 @@
                argument1,
                argument2
                )
-      {
+{
             body
       }
 }
@@ -36,6 +36,33 @@ function()
 
       function() body
 
+## 6
+object <- function()
+{
+      body
+}
+
+## 7
+{
+      object <- function()
+{
+            body
+      }
+}
+
+## 8
+fun_call(parameter = function()
+        {
+              body
+        })
+
+## 9
+{
+      fun_call(parameter = function()
+              {
+                    body
+              })
+}
 
 
 ### Function calls
@@ -52,9 +79,9 @@ fun_call(
 
 ## 3
 fun_call(parameter = (
-                           stuff
-                     ),
-      argument)
+      stuff
+),
+argument)
 
 ## 4
 fun_call(parameter = fun_argument(
@@ -84,11 +111,11 @@ fun_call(argument1
     , argument2
     , argument3,
       argument4, (
-                       stuff1
-                 ),
+            stuff1
+      ),
       argument5, (
-                       stuff2
-                 )
+            stuff2
+      )
      ,
       argument6
 )
@@ -130,6 +157,12 @@ fun_call(parameter = fun_argument(
                 )
 }
 
+## 12  # fixme: should be indented relative to <- ?
+
+a <- fun_call(
+              arg1,
+              arg2
+              )
 
 
 ### Blocks
@@ -137,7 +170,7 @@ fun_call(parameter = fun_argument(
 ## 1
 {
       function()
-      {
+{
             body
       }
 }
@@ -147,9 +180,9 @@ fun_call(parameter = fun_argument(
       fun_call({
                      stuff1
                },
-            {
-                  stuff2
-            }
+              {
+                    stuff2
+              }
       )
 }
 
@@ -174,13 +207,13 @@ fun_call(
 fun_call(parameter1 = {
                             stuff1
                       },
-      {
-            stuff2
-      }, parameter2 = {
-                            stuff3
-                      }, {
-                               stuff4
-                         },
+        {
+              stuff2
+        }, parameter2 = {
+                              stuff3
+                        }, {
+                                 stuff4
+                           },
       parameter3 =
          stuff5 ~
          stuff6 +
@@ -193,9 +226,9 @@ fun <- fun_call({
                 }, {
                          stuff2
                    },
-             {
-                   stuff3
-             }
+               {
+                     stuff3
+               }
        )
 
 ## 7
@@ -214,6 +247,15 @@ fun_call(function(x) {
                   })
 
 ## 9
+fun_call(
+        {
+              stuff
+        }, {
+                 stuff
+           }
+        )
+
+## 10
 object <-
       fun_call({
                      stuff
@@ -221,68 +263,81 @@ object <-
                         stuff
                   })
 
-## 10
+## 11
 object <-
       fun_call(     {
                           body
                     }
       )
 
-## 11
-{
-                    {
+## 12
+fun_call1(
+          fun_call2({
                           stuff
                     }
+          )
+          )
+
+## 13
+{
+      stuff1
+
+{
+      stuff2
+}
 }
 
-## 12
+## 14
 {{
       stuff
 }
 }
 
-## 13
+## 15
 ({
       stuff
 })
 
-## 14
+## 16
 ( {
       stuff
 }
 )
 
-## 15
+
+### Bracket indexing
+
+## 1
 object[
        argument1,
        argument2
        ]
 
-## 16
+## 2
 object[argument1,
       argument2
 ]
 
-## 17
+## 3
 object[(
-             argument1
-       )]
+      argument1
+)]
 
-## 18
+## 4
 {
       object[
              fun_call(
                       body
                       ),
              argument[
-                      (
-                            sub_argument
-                      )
-                      ]
+                     (
+                           sub_argument
+                     )
+                     ]
              ]
 }
 
-## 19
+## 5
 {
       object[
              argument1,
@@ -306,48 +361,60 @@ object[(
 ### Control flow
 
 ## 1
-if (condition) {
-      stuff1
-} else {
-      stuff2
+{
+      if (condition) {
+            stuff1
+      } else {
+            stuff2
+      }
 }
 
 ## 2
-if (condition) {
-      stuff1
-}
-else {
-      stuff2
+{
+      if (condition) {
+            stuff1
+      }
+      else {
+            stuff2
+      }
 }
 
 ## 3
-if (condition)
 {
-      stuff1
-} else
+      if (condition)
 {
-      stuff2
+            stuff1
+      } else
+{
+            stuff2
+      }
 }
 
 ## 4
-if (condition)
 {
-      stuff1
-}
+      if (condition)
+{
+            stuff1
+      }
 else
 {
       stuff2
 }
+}
 
 ## 5
-for (sequence)
 {
-      stuff
+      for (sequence)
+{
+            stuff
+      }
 }
 
 ## 6
-for (sequence) {
-      stuff
+{
+      for (sequence) {
+            stuff
+      }
 }
 
 ## 7
@@ -358,6 +425,40 @@ if (condition)
 for (sequence)
       stuff
 
+## 9
+object <-
+      if (condition) {
+            stuff
+      } else {
+            stuff
+      }
+
+## 10
+{
+      object <-
+            if (condition) stuff
+            else stuff
+}
+
+## 10
+{
+      object <-
+            if (condition) fun_call(
+                                    argument1,
+                                    argument2
+                                    )
+            else stuff
+}
+
+## 11
+{
+      fun_call(parameter =
+                  if (condition)
+                        stuff
+                  else
+                        stuff
+      )
+}
 
 
 ### Continuation lines
@@ -432,9 +533,9 @@ ggplot() +
       ggplot() +
          geom1(argument1,
                argument2 = (
-                                 stuff1
-                           ) -
-                              stuff2) +
+                     stuff1
+               ) -
+                  stuff2) +
          geom2() +
          geom3()
 }
@@ -444,8 +545,8 @@ stuff +
    fun_call(parameter = argument1,
          fun_call((stuff1 - stuff2 +
                       stuff3
-                  ) /
-                     stuff4)
+         ) /
+            stuff4)
    )
 
 ## 10
@@ -481,10 +582,10 @@ object1 <-
 {
       ## Hanging comment 1
       fun_call(
-               {
-                     ## Hanging comment 2
-               }
-               )
+              {
+                    ## Hanging comment 2
+              }
+              )
 }
 
 ## 3
@@ -508,11 +609,11 @@ stuff1 &&
 ## 3
 if (condition1 &&
       condition2 ||
-      (condition3 && condition4) ||
-      (condition5 &&
-          condition6 &&
-          condition7) ||
-      condition8) {
+   (condition3 && condition4) ||
+   (condition5 &&
+       condition6 &&
+       condition7) ||
+   condition8) {
       stuff
 } && condition8 ||
    condition9 ||

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -23,13 +23,13 @@
 
 ## 3
 function(argument_fun(sub_argument1,
-                      sub_argument2),
-         argument) {}
+  sub_argument2),
+  argument) {}
 
 ## 4
 function(argument1, parameter = fun_call(
-                        sub_argument),
-         argument2) {}
+  sub_argument),
+  argument2) {}
 
 ## 5
 function()
@@ -52,16 +52,16 @@ object <- function()
 
 ## 8
 fun_call(parameter = function()
-{
-  body
-})
+  {
+    body
+  })
 
 ## 9
 {
   fun_call(parameter = function()
-  {
-    body
-  })
+    {
+      body
+    })
 }
 
 
@@ -69,12 +69,12 @@ fun_call(parameter = function()
 
 ## 1
 fun_call(argument1,
-         argument2)
+  argument2)
 
 ## 2
 fun_call(
-    argument1,
-    argument2
+  argument1,
+  argument2
 )
 
 ## 3
@@ -85,16 +85,16 @@ argument)
 
 ## 4
 fun_call(parameter = fun_argument(
-             argument1
-         ),
-         argument2)
+  argument1
+),
+argument2)
 
 ## 5
 fun_call(parameter = fun_argument(argument1,
-                                  argument2
-                                  )
-        ,
-         argument3)
+  argument2
+)
+,
+argument3)
 
 ## 6
 `fun_call`(argument1,
@@ -108,61 +108,61 @@ fun_call(parameter = fun_argument(argument1,
 
 ## 8
 fun_call(argument1
-       , argument2
-       , argument3,
-         argument4, (
-           stuff1
-         ),
-         argument5, (
-           stuff2
-         )
-        ,
-         argument6
-         )
+, argument2
+, argument3,
+  argument4, (
+    stuff1
+  ),
+  argument5, (
+    stuff2
+  )
+ ,
+  argument6
+)
 
 ## 9
 fun_call(parameter =
            fun_argument(
-               sub_argument
+             sub_argument
            ),
-         argument
-         )
+  argument
+)
 
 ## 10
 fun_call(parameter = fun_argument(
-             sub_argument
-         ),
-         argument
-         )
+  sub_argument
+),
+argument
+)
 
 ## 11
 {
   fun_call1(
-      fun_call2 (argument1, argument2,
-                 parameter = fun_call3(
-                     argument3,
-                     argument4
-                 ), function(x) {
+    fun_call2 (argument1, argument2,
+      parameter = fun_call3(
+        argument3,
+        argument4
+      ), function(x) {
         body
       },
       argument5,
       fun_call3(
-          argument6
+        argument6
       ),
       argument7
-      ), {
-    stuff
-  },
-  argument8
+    ), {
+      stuff
+    },
+    argument8
   )
 }
 
 ## 12  # fixme: should be indented relative to <- ?
 
 a <- fun_call(
-         arg1,
-         arg2
-     )
+  arg1,
+  arg2
+)
 
 
 ### Blocks
@@ -178,104 +178,104 @@ a <- fun_call(
 ## 2
 {
   fun_call({
-    stuff1
-  },
-  {
-    stuff2
-  }
+      stuff1
+    },
+    {
+      stuff2
+    }
   )
 }
 
 ## 3
 fun_call({
-  stuff1
-}, {
-  stuff2
-})
+    stuff1
+  }, {
+    stuff2
+  })
 
 ## 4
 fun_call(
-    parameter1 = {
-  stuff1
-},
-parameter2 = {
-  stuff2
-}
+  parameter1 = {
+    stuff1
+  },
+  parameter2 = {
+    stuff2
+  }
 )
 
 ## 5
 fun_call(parameter1 = {
-  stuff1
-},
-{
-  stuff2
-}, parameter2 = {
-  stuff3
-}, {
-  stuff4
-},
-parameter3 =
-  stuff5 ~
+    stuff1
+  },
+  {
+    stuff2
+  }, parameter2 = {
+    stuff3
+  }, {
+    stuff4
+  },
+  parameter3 =
+    stuff5 ~
     stuff6 +
-      stuff7,
-argument)
+    stuff7,
+  argument)
 
 ## 6
 fun <- fun_call({
-  stuff1
-}, {
-  stuff2
-},
-{
-  stuff3
-}
+    stuff1
+  }, {
+    stuff2
+  },
+  {
+    stuff3
+  }
 )
 
 ## 7
 fun <- fun_call({
-  stuff
-},
-argument
+    stuff
+  },
+  argument
 )
 
 ## 8
 fun_call(function(x) {
-  body1
-},
-function(x) {
-  body2
-})
+    body1
+  },
+  function(x) {
+    body2
+  })
 
 ## 9
 fun_call(
-{
-  stuff
-}, {
-  stuff
-}
+  {
+    stuff
+  }, {
+    stuff
+  }
 )
 
 ## 10
 object <-
   fun_call({
-    stuff
-  }, {
-    stuff
-  })
+      stuff
+    }, {
+      stuff
+    })
 
 ## 11
 object <-
   fun_call(     {
-    body
-  }
+      body
+    }
   )
 
 ## 12
 fun_call1(
-    fun_call2({
+  fun_call2({
       stuff
     }
-    )
+  )
 )
 
 ## 13
@@ -309,14 +309,14 @@ fun_call1(
 
 ## 1
 object[
-    argument1,
-    argument2
+  argument1,
+  argument2
 ]
 
 ## 2
 object[argument1,
-       argument2
-       ]
+  argument2
+]
 
 ## 3
 object[(
@@ -326,34 +326,34 @@ object[(
 ## 4
 {
   object[
-      fun_call(
-          body
-      ),
-      argument[
-      (
-        sub_argument
-      )
-      ]
+    fun_call(
+      body
+    ),
+    argument[
+    (
+      sub_argument
+    )
+    ]
   ]
 }
 
 ## 5
 {
   object[
+    argument1,
+    argument2,
+    by = argument3
+  ][
+    argument4,
+    fun_call1(argument1,
+      argument2)
+    argument5
+  ][
+    argument6,
+    fun_call2(
       argument1,
-      argument2,
-      by = argument3
-  ][
-      argument4,
-      fun_call1(argument1,
-                argument2)
-      argument5
-  ][
-      argument6,
-      fun_call2(
-          argument1,
-          argument2
-      )
+      argument2
+    )
   ]
 }
 
@@ -444,9 +444,9 @@ object <-
 {
   object <-
     if (condition) fun_call(
-                       argument1,
-                       argument2
-                   )
+      argument1,
+      argument2
+    )
     else stuff
 }
 
@@ -457,7 +457,7 @@ object <-
                stuff
              else
                stuff
-           )
+  )
 }
 
 
@@ -466,131 +466,131 @@ object <-
 ## 1
 stuff1 %>%
   stuff2 %>%
-    stuff3
+  stuff3
 
 ## 2
 {
   stuff1 %>%
     stuff2 %>%
-      stuff3
+    stuff3
 } %>%
   stuff4 %>%
-    stuff5
+  stuff5
 
 ## 3
 (
   stuff1 %>%
     stuff2 %>%
-      stuff3
+    stuff3
 ) %>%
   stuff4 %>%
-    stuff5
+  stuff5
 
 ## 4
 object[
-    stuff1 %>%
-      stuff2 %>%
-        stuff3
+  stuff1 %>%
+    stuff2 %>%
+    stuff3
 ] %>%
   stuff4 %>%
-    stuff5
+  stuff5
 
 ## 5
 stuff1 %>%
   stuff2 %>%
-    if (condition) {
-      stuff3 %>%
-        stuff4 %>%
-          stuff5
-    } else {
-      stuff6 %>%
-        stuff7 %>%
-          for (sequence) {
-            stuff8
-          } %>%
-            stuff9 %>%
-              stuff10
-    } %>%
-      stuff11 %>%
-        stuff12
+  if (condition) {
+    stuff3 %>%
+      stuff4 %>%
+      stuff5
+  } else {
+    stuff6 %>%
+      stuff7 %>%
+      for (sequence) {
+        stuff8
+      } %>%
+      stuff9 %>%
+      stuff10
+  } %>%
+    stuff11 %>%
+    stuff12
 
 ## 6
 stuff[stuff1 %>%
         stuff2 %>%
-          stuff3] %>%
+        stuff3] %>%
   stuff4 %>%
-    stuff5
+  stuff5
 
 ## 7
 ggplot() +
   geom(lhs -
          rhs
-       ) +
-    geom()
+  ) +
+  geom()
 
 ## 8
 {
   ggplot() +
     geom1(argument1,
-          argument2 = (
-            stuff1
-          ) -
-            stuff2) +
-      geom2() +
-        geom3()
+      argument2 = (
+        stuff1
+      ) -
+        stuff2) +
+    geom2() +
+    geom3()
 }
 
 ## 9
 stuff +
   fun_call(parameter = argument1,
-           fun_call((stuff1 - stuff2 +
-                       stuff3
-           ) /
-             stuff4)
-           )
+    fun_call((stuff1 - stuff2 +
+                stuff3
+    ) /
+      stuff4)
+  )
 
 ## 10
 fun_call(argument1 %>%
            stuff1, argument2 %>%
-                     stuff2, {
-  stuff3 %>%
-    stuff4
-} %>%
-   stuff5,
-argument3
+                   stuff2, {
+    stuff3 %>%
+      stuff4
+  } %>%
+     stuff5,
+  argument3
 )
 
 ## 11
 object1 <- object2 %>%
   fun_call1() %>%
-    fun_call2()
+  fun_call2()
 
 ## 12
 object1 <-
   object2%>%fun_call1() %>%
-    fun_call2() %>%
-      fun_call3()
+  fun_call2() %>%
+  fun_call3()
 
 
 
 ### Comments
 
 ## 1
-                                        # Side comment
+# Side comment
 
 ## 2
 {
   ## Hanging comment 1
   fun_call(
-  {
-    ## Hanging comment 2
-  }
+    {
+      ## Hanging comment 2
+    }
   )
 }
 
 ## 3
 {
-### Section comment
+  ### Section comment
 }
 
 
@@ -599,22 +599,22 @@ object1 <-
 ## 1
 stuff1 &&
   stuff2 ||
-    stuff3
+  stuff3
 
 ## 2
 (stuff1 &&
    stuff2 ||
-     stuff3)
+   stuff3)
 
 ## 3
 if (condition1 &&
-    condition2 ||
-(condition3 && condition4) ||
-(condition5 &&
-   condition6 &&
+  condition2 ||
+  (condition3 && condition4) ||
+  (condition5 &&
+     condition6 &&
      condition7) ||
-condition8) {
+  condition8) {
   stuff
 } && condition8 ||
   condition9 ||
-    condition10
+  condition10


### PR DESCRIPTION
I think all examples in `R-ESS-bugs.R` work fine now and I spotted a few more bugs related to block indentation. But we still have the issue mentioned in the other PR. I copy it here to pursue the discussion:


I think we have a dilemma here. Before we had
```r
    my.long.Expression <- expression(
        x[a[j]] == exp(theta[1] + theta[2]^2),
        x[b[i]] == sin(theta[3] ~~ theta[4])
        )
```
but now with `ess-offset-arguments-newline` set to `t` we have:
```r
    my.long.Expression <- expression(
                              x[a[j]] == exp(theta[1] + theta[2]^2),
                              x[b[i]] == sin(theta[3] ~~ theta[4])
                          )
```

One way out would be to implement an idea that I had for the future, which is to allow different styles depending on the depth of embeddedness of expressions. For example we could decide to have `'(t)` at level 0 and `t` beyond. This way we'd have:
```r
object <- fun_call(
  arg1,
  arg2
)
```
and
```r
object <- fun_call(
  arg1, other_call(
          arg2,
          arg3
        ),
  arg4)
```
Under this scheme we'd solve the problem above. What do you think?