### PR TITLE
Handle trailing operators in evaluated inputs

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -45,6 +45,10 @@ of the RStudio users, you will also need to set
 refilling in order to make the documentation more readable. You can also
 refill commented lines in the @code{examples} field without squashing
 the surrounding code in the comments.
+@item @ESS{[R]}: A new setting, @code{ess-eval-without-trailing-operator},
+will cause trailing operators to be stripped from any evaluated R
+code. This makes it easy to evaluate partially a magrittr pipeline or a
+ggplot specification.
 @end itemize
 
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1983,6 +1983,12 @@ of Emacs until the code has been successfully evaluated."
   :group 'ess-proc
   :type  'number)
 
+(defvar ess-eval-without-trailing-operator nil
+  "If non-nil, trailing operators will be trimmed from evaled input.
+This is useful to evaluate partially a magrittr pipeline or a
+ggplot specification.")
+
+
  ; System variables
 
 ;;*;; Variables relating to multiple processes

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1312,6 +1312,15 @@ STRING). In all other cases the behavior is as described in
       string
     (concat string "\n")))
 
+(defun ess--delete-trailing-operator-maybe (input)
+  (if ess-eval-without-trailing-operator
+      (replace-regexp-in-string (concat "\\(%[^ \t]%"
+                                        "\\|[-:+*/><=&|~]\\)"
+                                        "[ \t\n]*\\'")
+                                "" input)
+    input))
+(add-hook 'ess-presend-filter-functions 'ess--delete-trailing-operator-maybe)
+
 
 (defvar ess--dbg-del-empty-p t
   "Internal variable to control removal of empty lines during the


### PR DESCRIPTION
Hello,

This creates a setting to trim trailing operators from evaluated inputs. This is particularly useful for working with magrittr pipes or ggplot. For example, with this setting enabled you can select and eval the first two lines of the following snippet without having to think about the trailing `+`:
```r
ggplot(...) +
  geom1(...) +
  geom2(...)
```

I personally find this very useful (maybe because I use vim bindings with which it is natural to select whole lines, I know nothing about regular Emacs workflow). I set it to `nil` by default nonetheless because in case this breaks someone's workflow.