### PR TITLE
Fix indentation at prev-call

### DIFF
--- a/etc/R-ESS-bugs.R
+++ b/etc/R-ESS-bugs.R
@@ -1,5 +1,4 @@
-#### File showing off  things that go wrong or *went* wrong in the past
-#### -- with R-mode (mostly coded in ../lisp/ess-mode.el )
+#### File showing off  things that go wrong or *went* wrong in the past #### -- with R-mode (mostly coded in ../lisp/ess-mode.el )
 
 ### NOTE: this file is indented with RRR style !!!!!
 ### but do not change indentations anymore of anything in here:
@@ -789,6 +788,13 @@ read.csv('file.csv') %>%
                dim = d[1:2])
 }
 
+
+### MM: not ok yet
+## {from real code in R sources}
+{
+    obj <- obj && (condition1 || class2 %in% .BasicClasses ||
+                                             condition3)
+}## not ok yet
 
 
 

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -1399,13 +1399,26 @@ Returns nil if line starts inside a string, t if in a comment."
                                     (looking-at "function\\b")))))
                     'decl
                   t)))
-    (if (not (eq block-type 'own))
-        (ess-calculate-indent--args offset (ess-offset-type 'block)
-                                    containing-sexp indent-point block)
-      ;; Block is not part of an arguments list
-      (ess-climb-block)
-      (+ (current-indentation)
-         offset))))
+    (cond
+     ;; Alignment at 'prev-call
+     ((and (eq (ess-offset-type 'block) 'prev-call)
+           (memq block-type '(opening body))
+           (or (eq block 'decl)
+               (looking-at "{")))
+      ;; In case of opening delimiter on its own line, jump to
+      ;; function decl
+      (when (and (eq block-type 'opening)
+                 (eq block 'decl))
+        (goto-char indent-point)
+        (ess-backward-sexp 2))
+      (+ (current-column) offset))
+     ;; Generic case
+     ((memq block-type '(opening body))
+      (ess-calculate-indent--args offset (ess-offset-type 'block)
+                                  containing-sexp indent-point block))
+     ;; Block is not part of an arguments list
+     ((eq block-type 'own)(ess-climb-block)
+      (+ (current-indentation) offset)))))
 
 (defun ess-calculate-indent--comma ()
   (let ((indent (save-excursion

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -1137,6 +1137,10 @@ be advised"
                   (/= (point) (point-max)))
         (forward-line)
         (ess-back-to-indentation))
+      ;; Handle %op% operators
+      (when (and (eq (char-before) ?%)
+                 (looking-at (concat ess-R-symbol-pattern "+%")))
+        (ess-backward-sexp))
       (when (and (< (point) orig-pos)
                  (ess-forward-sexp))
         (prog1 t

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -53,16 +53,16 @@ object <- function()
 ## 8
 {
     fun_call(parameter = function()
-    {
-        body
-    })
+                         {
+                             body
+                         })
 }
 
 ## 9
 {
     fun_call(parameter = function() {
-        body
-    })
+                             body
+                         })
 }
 
 ## 10
@@ -75,16 +75,16 @@ fun_call(
 ## 11
 {
     fun_call1(fun_call2(argument, function() {
-        stuff
-    })
-    )
+                                      stuff
+                                  })
+              )
 }
 
 ## 12
 {
     fun_call1(argument, fun_call2(function() {
-                            stuff
-                        })
+                                      stuff
+                                  })
               )
 }
 
@@ -177,17 +177,17 @@ fun_call(parameter = fun_argument(
                        argument3,
                        argument4
                    ), function(x) {
-            body
-        },
-        argument5,
-        fun_call4(
-            argument6
-        ),
-        argument7
-        ), {
-        stuff
-    },
-    argument8
+                          body
+                      },
+                   argument5,
+                   fun_call4(
+                       argument6
+                   ),
+                   argument7
+                   ), {
+                          stuff
+                      },
+        argument8
     )
 }
 
@@ -220,11 +220,11 @@ fun_call1(argument1, fun_call2(fun_call3(
 
 ## 17
 fun_call({
-    stuff1
-    stuff2
+             stuff1
+             stuff2
 
-    stuff3
-})
+             stuff3
+         })
 
 
 
@@ -241,8 +241,8 @@ fun_call({
 ## 2
 {
     fun_call({
-        stuff1
-    },
+                 stuff1
+             },
     {
         stuff2
     }
@@ -251,32 +251,32 @@ fun_call({
 
 ## 3
 fun_call({
-    stuff1
-}, {
-    stuff2
-})
+             stuff1
+         }, {
+                stuff2
+            })
 
 ## 4
 fun_call(
     parameter1 = {
-    stuff1
-},
-parameter2 = {
-    stuff2
-}
+                     stuff1
+                 },
+    parameter2 = {
+                     stuff2
+                 }
 )
 
 ## 5
 fun_call(parameter1 = {
-    stuff1
-},
+                          stuff1
+                      },
 {
     stuff2
 }, parameter2 = {
-    stuff3
-}, {
-    stuff4
-},
+                    stuff3
+                }, {
+                       stuff4
+                   },
 parameter3 =
     stuff5 ~
         stuff6 +
@@ -285,10 +285,10 @@ argument)
 
 ## 6
 fun <- fun_call({
-    stuff1
-}, {
-    stuff2
-},
+                    stuff1
+                }, {
+                       stuff2
+                   },
 {
     stuff3
 }
@@ -296,49 +296,49 @@ fun <- fun_call({
 
 ## 7
 fun <- fun_call({
-    stuff
-},
-argument
-)
+                    stuff
+                },
+                argument
+                )
 
 ## 8
 fun_call(function(x) {
-    body1
-},
-function(x) {
-    body2
-})
+             body1
+         },
+         function(x) {
+             body2
+         })
 
 ## 9
 fun_call(
 {
     stuff
 }, {
-    stuff
-}
+       stuff
+   }
 )
 
 ## 10
 object <-
     fun_call({
-        stuff
-    }, {
-        stuff
-    })
+                 stuff
+             }, {
+                    stuff
+                })
 
 ## 11
 object <-
     fun_call(     {
-        body
-    }
-    )
+                      body
+                  }
+             )
 
 ## 12
 fun_call1(
     fun_call2({
-        stuff
-    }
-    )
+                  stuff
+              }
+              )
 )
 
 ## 13
@@ -686,12 +686,12 @@ fun_call(arg1 +
 fun_call(argument1 %>%
              stuff1, argument2 %>%
                          stuff2, {
-    stuff3 %>%
-        stuff4
-} %>%
-    stuff5,
-argument3
-)
+                                     stuff3 %>%
+                                         stuff4
+                                 } %>%
+                                     stuff5,
+         argument3
+         )
 
 ## 11
 object1 <- object2 %>%
@@ -790,8 +790,8 @@ fun_call(stuff1 + stuff2 +
 
 ## 21
 object %>% fun_call({
-               stuff1
-           }) %>%
+                        stuff1
+                    }) %>%
     stuff2
 
 ## 22

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -880,6 +880,12 @@ object <-
     condition1 | condition2 |
     condition3 | condition4
 
+## 8
+if (condition1 || object1 %op% object2 ||
+    condition3) {
+    stuff
+}
+
 
 ### Specific situations and overrides
 

--- a/test/styles/GNU.R
+++ b/test/styles/GNU.R
@@ -880,6 +880,12 @@ object <-
   condition1 | condition2 |
   condition3 | condition4
 
+## 8
+if (condition1 || object1 %op% object2 ||
+    condition3) {
+  stuff
+}
+
 
 ### Specific situations and overrides
 

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -881,7 +881,6 @@ object <-
     condition3 | condition4
 
 
-
 ### Specific situations and overrides
 
 ## 1
@@ -890,10 +889,3 @@ fun_call(
     ifelse(condition2, argument2,
            ifelse))
 )
-## MM: not ok yet
-
-## 2 {from real code in R sources}
-{
-    obj <- obj && (condition1 || class2 %in% .BasicClasses ||
-                                             condition3)
-}## not ok yet

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -880,6 +880,12 @@ object <-
     condition1 | condition2 |
     condition3 | condition4
 
+## 8
+if (condition1 || object1 %op% object2 ||
+    condition3) {
+    stuff
+}
+
 
 ### Specific situations and overrides
 

--- a/test/styles/RStudio.R
+++ b/test/styles/RStudio.R
@@ -880,6 +880,12 @@ object <-
   condition1 | condition2 |
   condition3 | condition4
 
+## 8
+if (condition1 || object1 %op% object2 ||
+      condition3) {
+  stuff
+}
+
 
 ### Specific situations and overrides
 

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -880,6 +880,12 @@ object <-
    condition1 | condition2 |
       condition3 | condition4
 
+## 8
+if (condition1 || object1 %op% object2 ||
+       condition3) {
+   stuff
+}
+
 
 ### Specific situations and overrides
 

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -880,6 +880,12 @@ object <-
   condition1 | condition2 |
   condition3 | condition4
 
+## 8
+if (condition1 || object1 %op% object2 ||
+      condition3) {
+  stuff
+}
+
 
 ### Specific situations and overrides
 

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -53,16 +53,16 @@ object <- function()
 ## 8
 {
   fun_call(parameter = function()
-    {
-      body
-    })
+                       {
+                         body
+                       })
 }
 
 ## 9
 {
   fun_call(parameter = function() {
-      body
-    })
+                         body
+                       })
 }
 
 ## 10
@@ -75,16 +75,16 @@ fun_call(
 ## 11
 {
   fun_call1(fun_call2(argument, function() {
-      stuff
-    })
+                                  stuff
+                                })
   )
 }
 
 ## 12
 {
   fun_call1(argument, fun_call2(function() {
-                          stuff
-                        })
+                                  stuff
+                                })
   )
 }
 
@@ -177,17 +177,17 @@ argument
         argument3,
         argument4
       ), function(x) {
-        body
-      },
+           body
+         },
       argument5,
       fun_call4(
         argument6
       ),
       argument7
     ), {
-    stuff
-  },
-  argument8
+         stuff
+       },
+    argument8
   )
 }
 
@@ -220,11 +220,11 @@ fun_call1(argument1, fun_call2(fun_call3(
 
 ## 17
 fun_call({
-  stuff1
-  stuff2
+           stuff1
+           stuff2
 
-  stuff3
-})
+           stuff3
+         })
 
 
 
@@ -241,8 +241,8 @@ fun_call({
 ## 2
 {
   fun_call({
-    stuff1
-  },
+             stuff1
+           },
   {
     stuff2
   }
@@ -251,32 +251,32 @@ fun_call({
 
 ## 3
 fun_call({
-  stuff1
-}, {
-  stuff2
-})
+           stuff1
+         }, {
+              stuff2
+            })
 
 ## 4
 fun_call(
   parameter1 = {
-  stuff1
-},
-parameter2 = {
-  stuff2
-}
+                 stuff1
+               },
+  parameter2 = {
+                 stuff2
+               }
 )
 
 ## 5
 fun_call(parameter1 = {
-  stuff1
-},
+                        stuff1
+                      },
 {
   stuff2
 }, parameter2 = {
-  stuff3
-}, {
-  stuff4
-},
+                  stuff3
+                }, {
+                     stuff4
+                   },
 parameter3 =
   stuff5 ~
     stuff6 +
@@ -285,10 +285,10 @@ argument)
 
 ## 6
 fun <- fun_call({
-  stuff1
-}, {
-  stuff2
-},
+                  stuff1
+                }, {
+                     stuff2
+                   },
 {
   stuff3
 }
@@ -296,48 +296,48 @@ fun <- fun_call({
 
 ## 7
 fun <- fun_call({
-  stuff
-},
-argument
+                  stuff
+                },
+                argument
 )
 
 ## 8
 fun_call(function(x) {
-    body1
-  },
-  function(x) {
-    body2
-  })
+           body1
+         },
+         function(x) {
+           body2
+         })
 
 ## 9
 fun_call(
 {
   stuff
 }, {
-  stuff
-}
+     stuff
+   }
 )
 
 ## 10
 object <-
   fun_call({
-    stuff
-  }, {
-    stuff
-  })
+             stuff
+           }, {
+                stuff
+              })
 
 ## 11
 object <-
   fun_call(     {
-    body
-  }
+                  body
+                }
   )
 
 ## 12
 fun_call1(
   fun_call2({
-    stuff
-  }
+              stuff
+            }
   )
 )
 
@@ -542,12 +542,12 @@ object <-
 fun_call(
   argument,
   parameter = if (condition1) {
-  stuff1
-} else if (condition2) {
-  stuff3
-} else {
-  stuff2
-}
+                                stuff1
+                              } else if (condition2) {
+                                                       stuff3
+                                                     } else {
+                                                              stuff2
+                                                            }
 )
 
 ## 14
@@ -565,12 +565,12 @@ fun_call(
 ## 15
 object <- fun_call(argument,
   parameter = if (condition1) {
-  stuff1
-} else if (condition2) {
-  stuff3
-} else {
-  stuff2
-}
+                                stuff1
+                              } else if (condition2) {
+                                                       stuff3
+                                                     } else {
+                                                              stuff2
+                                                            }
 )
 
 ## 16
@@ -686,11 +686,11 @@ fun_call(arg1 +
 fun_call(argument1 %>%
            stuff1, argument2 %>%
                      stuff2, {
-  stuff3 %>%
-    stuff4
-} %>%
-  stuff5,
-argument3
+                               stuff3 %>%
+                                 stuff4
+                             } %>%
+                               stuff5,
+           argument3
 )
 
 ## 11
@@ -790,8 +790,8 @@ fun_call(stuff1 + stuff2 +
 
 ## 21
 object %>% fun_call({
-             stuff1
-           }) %>%
+                      stuff1
+                    }) %>%
   stuff2
 
 ## 22


### PR DESCRIPTION
Here is a fix for @mmaechler's recent issue as well as some fixes for indentation at `prev-call`.

Regarding the latter, we now have 
```r
object <- lapply(object, function(x)
                         {
                             body
                         },
                 argument)

test_that("it works", {
                          test()
                      })
```

Altough in the second case I'm not sure whether we should consider that the previous-call is `test_that()` instead of the opening naked `{`.  cc @vspinu