### PR TITLE
Filling call arguments

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -44,6 +44,13 @@ of the RStudio users, you will also need to set
 refilling in order to make the documentation more readable. You can also
 refill commented lines in the @code{examples} field without squashing
 the surrounding code in the comments.
+
+@item @ESS{[R]}: A new setting @code{ess-fill-calls} allows function
+calls to be formatted with @code{(fill-paragraph)}. The function's
+arguments will be arranged so as to not exceed @code{fill-column}.
+When @code{(fill-paragraph)} is called with a prefix, the call is
+formatted with one argument per line.
+
 @end itemize
 
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -576,7 +576,6 @@ during the load. "
                  (const :tag "Always delete"   :value nil)
                  ))
 
-
 (defcustom ess-delete-dump-files nil
   "Non-nil means delete dump files after they are created.
 This applies to dump files created with
@@ -601,6 +600,26 @@ This is useful to prevent sources file being created for objects
 you don't actually modify.  Once the buffer is modified and saved
 however, the file is not subsequently unless `ess-keep-dump-files' is
 nil, and the file is successfully loaded back into S."
+  :group 'ess-edit
+  :type 'boolean)
+
+(defcustom ess-fill-calls t
+  "If non-nil, refilling a paragraph inside a function or
+indexing call will arrange the arguments according to
+`fill-column' as in:
+
+  fun_call(argument1, argument2,
+           argument3, argument4)
+
+When called with a prefix, refilling will format according to one
+argument per line:
+
+  fun_call(
+      argument1,
+      argument2,
+      argument3,
+      argument4
+  )"
   :group 'ess-edit
   :type 'boolean)
 


### PR DESCRIPTION
The first commit fixes some bugs where refilling would overlap over the code following a roxygen block.

The second implements a new setting `ess-fill-calls` to allow refilling of call arguments. When it is non-nil, calling `(fill-paragraph)` when point is inside a call will indent and format all arguments according to `fill-column`. When called with a prefix, it formats them according to one argument per line.