### PR TITLE
Indentation updates

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1110,7 +1110,7 @@ Overrides (implies vertical alignment):
    `ess-offset-continued' should be ignored.
 
  - `ess-align-blocks': whether to ignore `ess-offset-blocks' for
-   function declarations or control flow statements .
+   function declarations or control flow statements.
 
 Control variables:
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -672,134 +672,122 @@ See `ess-style-alist' for all available offsets.")
 (define-obsolete-variable-alias 'ess-indent-level 'ess-indent-offset "15.09")
 
 (defvar ess-offset-arguments 'open-delim
-  "Indent for function arguments or bracket indexing.
+  "Indent for arguments of function calls or indexing brackets.
 This variables has an effect only when the ( or [ are not
 directly followed by a new line. See
 `ess-offset-arguments-newline' for indentation after closing
 newline.
 
-If 'open-delim, the arguments are indented at the opening
-delimiter following foo:
+When set to `open-delim', arguments are indented relative to the
+opening parenthesis of the closest function call:
 
-  object <- some_function(other_function(arg1,
-                                         arg2,
-                                         arg3)
-
-
-If 'prev-call, the arguments are aligned at the beginning of the
-closest function call + N characters:
-
-  object <- some_function(other_function(arg1,
-                              arg2,
-                              arg3)
+  object <- call(argument, other_call(argument,
+                                      other_argument))
 
 
-If 'prev-line, the arguments are indented at the previous line
-indentation + N characters:
+When set to `prev-call', arguments are indented relative to the
+closest function call:
 
-  object <- some_function(other_function(arg1,
-      arg2,
-      arg3)
+  object <- call(argument, other_call(argument,
+                               other_argument))
 
 
-The 'prev-call and 'prev-line settings are actually equivalent to
-'(prev-call . t) and '(prev-line . t), where `t' represents the
-base indent size. More generally, you can supply '(prev-call . N)
-to control the size of indentation.
+When set to `prev-line', arguments are indented relative to the
+preceding line:
 
-See `ess-style-alist' for other offsets.")
+  object <- call(argument, other_call(argument,
+      other_argument))
+
+See `ess-style-alist' for other offsets controlling
+indentation.")
 
 (defvar ess-offset-arguments-newline 'prev-call
   "Indent of arguments when ( or [ is followed by a new line.
 
-If 'open-delim, the arguments are indented at the opening
-delimiter following foo:
+If `prev-call', arguments on a new line are indented relative to
+the closest function call:
 
-  object <- some_function(other_function(
-                                         arg1,
-                                         arg2)
+  object <- call(argument, other_call(
+                               argument,
+                               other_argument
+                           ))
 
-
-If 'prev-call, the arguments are aligned at the beginning of the
-closest function call + N characters:
-
-  object <- some_function(other_function(
-                              arg1,
-                              arg2)
+You can control the details of indentation at `prev-call' with
+`ess-indent-prev-call-lhs' and `ess-indent-prev-call-chains'.
 
 
-If prev-line, the arguments are indented at the previous line
-indentation + N characters:
+When set to `open-delim', arguments on a new line are indented
+relative to the opening parenthesis of the closest function call:
 
-  object <- some_function(other_function(
-      arg1,
-      arg2)
+  object <- call(argument, other_call(
+                                      argument,
+                                      other_argument
+                                      ))
 
 
-The 'prev-call and 'prev-line settings are actually equivalent to
-'(prev-call . t) and '(prev-line . t), where `t' represents the
-base indent size. More generally, you can supply '(prev-call . N)
-to control the size of indentation.")
+When set to `prev-line', arguments on a new line are indented
+relative to the preceding line:
+
+  object <- call(argument, other_call(
+      argument,
+      other_argument
+  ))
+
+See `ess-style-alist' for other offsets controlling
+indentation.")
 
 (defvar ess-offset-block 'prev-line
-  "Indentation for blocks.
-A block is usually declared with braces but a statement wrapped
-in anonymous parentheses is also considered a block.
+  "Indentation for blocks. A block is usually declared with
+braces but a statement wrapped in anonymous parentheses is also
+considered a block. This offset can be either `prev-call',
+`prev-line' or `open-delim'.
 
-If nil, blocks are indented from the opening delimiter:
+When set to `prev-call', blocks are indented relative to the
+closest function call:
 
-  {
-      fun_call(parameter = {
-                               stuff
-                           }, {
-                                  stuff
-                              })
+  call(argument, other_call(parameter = {
+                     stuff
+                 }, {
+                     stuff
+                 }))
 
-      lapply(data, function(x) {
-                                   body
-                               })
-  }
+  call(argument, lapply(data, function(x) {
+                     body
+                 }))
 
-
-If a number N, blocks are indented relative to the opening
-parenthesis of the closest function call:
-
-  {
-      fun_call(parameter = {
-                   stuff
-               }, {
-                   stuff
-               })
-
-      lapply(data, function(x) {
-                 body
-             })
-  }
-
-In this case, the value types of `ess-offset-arguments' and
-`ess-offset-arguments-newline' are taken into account for
-consistency.
+You can control the details of indentation at `prev-call' with
+`ess-indent-prev-call-lhs' and `ess-indent-prev-call-chains'.
 
 
-If a list of the form '(N) where N is a number, blocks are
-indented at the previous line indentation + N characters:
+When set to `open-delim', blocks are indented relative to the
+opening parenthesis of the closest function call:
 
-  {
-      fun_call(parameter = {
-          stuff
-      }, {
-          stuff
-      })
+  call(argument, other_call(parameter = {
+                                stuff
+                            }, {
+                                stuff
+                            }))
 
-      lapply(data, function(x) {
-          body
-      })
-  }
+  call(argument, lapply(data, function(x) {
+                            body
+                        }))
 
-You can refer to `ess-indent-offset' by setting this parameter to t
-or '(t) instead of N or '(N).
 
-See `ess-style-alist' for other offsets.")
+When set to `prev-line', blocks are indented relative to the
+preceding line:
+
+  call(argument, other_call(parameter = {
+      stuff
+  }, {
+      stuff
+  }))
+
+  call(argument, lapply(data, function(x) {
+      body
+  }))
+
+See `ess-style-alist' for other offsets controlling
+indentation.")
 
 (defvar ess-offset-continued 'straight
   "This setting controls indentation of continued statements, that is,
@@ -885,16 +873,16 @@ instead of
 Definition operators (`<-', `=', `:=' and `~') still trigger an
 indentation in all cases.")
 
-(defvar ess-align-blocks '(if-else)
+(defvar ess-align-blocks '(control-flow)
   "List of block types for which `ess-offset-blocks' should be
 ignored. The overridden blocks are vertically aligned. The list
-can contain either or both of the symbols `if-else' and
+can contain either or both of the symbols `control-flow' and
 `fun-decl'.
 
-With `if-else', the if and else calls as well as corresponding
-blocks will always be aligned vertically. With `fun-decl', the
-body of a function declaration will always be aligned with the
-call to `function'.")
+With `control-flow', if, else for and while blocks will always be
+aligned vertically. With `fun-decl', the body of a function
+declaration will always be aligned with the call to
+`function'.")
 
 (defvar ess-indent-prev-call-lhs nil
   "When non-nil, indent arguments from the left-hand side of an assignment.
@@ -976,7 +964,7 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-nested-calls . ("ifelse"))
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
-     (ess-align-blocks . (if-else))
+     (ess-align-blocks . (control-flow))
      (ess-indent-prev-call-lhs . t)
      (ess-indent-prev-call-chains . t)
      (ess-indent-with-fancy-comments . t))
@@ -990,7 +978,7 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-nested-calls . ("ifelse"))
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
-     (ess-align-blocks . (if-else))
+     (ess-align-blocks . (control-flow))
      (ess-indent-prev-call-lhs . t)
      (ess-indent-prev-call-chains . t)
      (ess-indent-with-fancy-comments . t))
@@ -1005,7 +993,7 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-nested-calls . ("ifelse"))
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
-     (ess-align-blocks . (if-else))
+     (ess-align-blocks . (control-flow))
      (ess-indent-prev-call-lhs . t)
      (ess-indent-prev-call-chains . t)
      (ess-indent-with-fancy-comments . t))
@@ -1019,7 +1007,7 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-nested-calls . ("ifelse"))
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
-     (ess-align-blocks . (if-else))
+     (ess-align-blocks . (control-flow))
      (ess-indent-prev-call-lhs . t)
      (ess-indent-prev-call-chains . t)
      (ess-indent-with-fancy-comments . t))
@@ -1033,7 +1021,7 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-nested-calls . ("ifelse"))
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
-     (ess-align-blocks . (if-else))
+     (ess-align-blocks . (control-flow))
      (ess-indent-prev-call-lhs . t)
      (ess-indent-prev-call-chains . t)
      (ess-indent-with-fancy-comments . t))
@@ -1048,7 +1036,7 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-nested-calls . ("ifelse"))
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
-     (ess-align-blocks . (if-else))
+     (ess-align-blocks . (control-flow))
      (ess-indent-prev-call-lhs . t)
      (ess-indent-prev-call-chains . t)
      (ess-indent-with-fancy-comments . t))
@@ -1110,9 +1098,6 @@ Offsets:
  - `ess-offset-continued': offset for continuation lines in
    multiline statements
 
- - `ess-offset-continued-first': extra offset for first
-   continuation line (i.e. second line of a multiline expression)
-
 Overrides (implies vertical alignment):
 
  - `ess-align-nested-calls': functions whose nested calls
@@ -1124,9 +1109,8 @@ Overrides (implies vertical alignment):
  - `ess-align-continuations-in-calls': calls where
    `ess-offset-continued' should be ignored.
 
- - `ess-align-blocks': whether to ignore
-   `ess-offset-blocks' for function declarations or if-else
-   branches.
+ - `ess-align-blocks': whether to ignore `ess-offset-blocks' for
+   function declarations or control flow statements .
 
 Control variables:
 

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -1583,8 +1583,8 @@ Returns nil if line starts inside a string, t if in a comment."
   (let* ((to (or to (point)))
          (to-line (line-number-at-pos to))
          (from-line (progn
-                       (goto-char (1+ (or from containing-sexp)))
-                       (line-number-at-pos)))
+                      (goto-char (1+ (or from containing-sexp)))
+                      (line-number-at-pos)))
          (prev-pos (1- (point)))
          max-col)
     (while (< prev-pos (min (point) to) )
@@ -1592,14 +1592,20 @@ Returns nil if line starts inside a string, t if in a comment."
       (ess-forward-sexp)
       ;; Ignore the line with the function call and the line to be
       ;; indented.
-      (unless (or (= (line-number-at-pos) from-line)
-                  (>= (line-number-at-pos) to-line))
-        ;; Handle lines starting with a comma
-        (let ((indent (if (save-excursion
-                            (ess-back-to-indentation)
-                            (looking-at ","))
-                          (+ (current-indentation) 2)
-                        (current-indentation))))
+      (unless (or (>= (line-number-at-pos) to-line))
+        (let ((indent (cond
+                       ;; First line: minimum indent is right after (
+                       ((= (line-number-at-pos) from-line)
+                        (save-excursion
+                          (goto-char (1+ containing-sexp))
+                          (current-column)))
+                       ;; Handle lines starting with a comma
+                       ((save-excursion
+                          (ess-back-to-indentation)
+                          (looking-at ","))
+                        (+ (current-indentation) 2))
+                       (t
+                        (current-indentation)))))
           (setq max-col (min indent (or max-col indent))))))
     max-col))
 

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -1113,13 +1113,13 @@ be advised"
   ;; Move back over chars that have whitespace syntax but have the p flag.
   (backward-prefix-chars))
 
-(defun ess-skip-blanks-backward (&optional N)
+(defun ess-climb-blanks (&optional N)
   "Skip blanks and newlines, taking eol comments into account."
   (skip-chars-backward " \t")
   (when (and (> (or N 0) 0)
              (= (point) (line-beginning-position)))
     (ess-backward-to-noncomment (line-beginning-position 0))
-    (ess-skip-blanks-backward (1- N))))
+    (ess-climb-blanks (1- N))))
 
 (defmacro ess-save-excursion-when-nil (&rest body)
   (declare (indent 0)
@@ -1215,7 +1215,7 @@ be advised"
 (defun ess-climb-object ()
   (ess-save-excursion-when-nil
     (let (climbed)
-      (ess-skip-blanks-backward)
+      (ess-climb-blanks)
       ;; Backquoted names can contain any character
       (if (eq (char-before) ?`)
           (progn
@@ -1308,10 +1308,9 @@ without curly braces."
                            (ess-up-list -1))))
                    ;; Climb unbraced body
                    ((ess-save-excursion-when-nil
-                      (and (or (ess-climb-call)
-                               (progn
-                                 (ess-skip-blanks-backward 1)
-                                 (ess-climb-object)))))))
+                      (ess-climb-blanks 1)
+                      (or (ess-climb-call)
+                          (ess-climb-object)))))
               ;; If successfully climbed body, climb call
               (ess-climb-if-else-call recurse)))))
     (prog1 t

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -772,7 +772,7 @@ list of strings."
     ad-do-it)
    ;; Filling of call arguments
    ((and ess-fill-calls
-         (ess-call-p))
+         (ess-point-in-call-p))
     (ess-fill-args))
    ;; Filling of code comments in @examples roxy field
    ((and (ess-roxy-entry-p)
@@ -810,7 +810,9 @@ list of strings."
               (while (< (point) (point-max))
                 (ess-roxy-maybe-indent-line)
                 ad-do-it
-                (forward-paragraph))))))))))
+                (forward-paragraph))))))))
+   (t
+    ad-do-it)))
 
 (defadvice move-beginning-of-line (around ess-roxy-beginning-of-line)
   "move to start"

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -596,8 +596,8 @@ else
 object <-
     if (condition)
         fun_call()[index]
-else
-    stuff
+    else
+        stuff
 
 
 ### Continuation lines

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -371,6 +371,22 @@ fun_call1(
 }
 )
 
+## 17
+fun_call(argument, function(argument1,
+                            argument2) {
+    body
+}
+)
+
+## 18
+fun_call(
+    argument,
+    function(argument1,
+             argument2) {
+    body
+}
+)
+
 
 ### Bracket indexing
 

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -825,6 +825,12 @@ object[index] %>%
 fun_call(argument) <-
     hop
 
+## 25
+fun_call1(argument, fun_call2(
+                        stuff1
+                    ) +
+                        stuff2)
+
 
 ### Comments
 

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -68,8 +68,8 @@ object <- function()
 ## 10
 fun_call(
     function() {
-        stuff
-    }
+    stuff
+}
 )
 
 ## 11

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -226,6 +226,10 @@ fun_call({
     stuff3
 })
 
+## 18
+fun_call(argument1 %>%
+             stuff,
+         argument2)
 
 
 ### Blocks

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -585,12 +585,19 @@ while(condition)
     stuff
 
 ## 18
-if (cond1)
+if (condition1)
     stuff1
 else
-    if (cond2) {
+    if (condition2) {
         stuff2
     }
+
+## 19
+object <-
+    if (condition)
+        fun_call()[index]
+else
+    stuff
 
 
 ### Continuation lines

--- a/test/styles/GNU.R
+++ b/test/styles/GNU.R
@@ -371,6 +371,22 @@ fun_call1(
 }
 )
 
+## 17
+fun_call(argument, function(argument1,
+                            argument2) {
+  body
+}
+)
+
+## 18
+fun_call(
+    argument,
+    function(argument1,
+             argument2) {
+      body
+    }
+)
+
 
 ### Bracket indexing
 

--- a/test/styles/GNU.R
+++ b/test/styles/GNU.R
@@ -585,12 +585,19 @@ while(condition)
   stuff
 
 ## 18
-if (cond1)
+if (condition1)
   stuff1
 else
-  if (cond2) {
+  if (condition2) {
     stuff2
   }
+
+## 19
+object <-
+  if (condition)
+    fun_call()[index]
+else
+  stuff
 
 
 ### Continuation lines

--- a/test/styles/GNU.R
+++ b/test/styles/GNU.R
@@ -825,6 +825,12 @@ object[index] %>%
 fun_call(argument) <-
   hop
 
+## 25
+fun_call1(argument, fun_call2(
+                        stuff1
+                    ) +
+                      stuff2)
+
 
 ### Comments
 

--- a/test/styles/GNU.R
+++ b/test/styles/GNU.R
@@ -226,6 +226,10 @@ fun_call({
   stuff3
 })
 
+## 18
+fun_call(argument1 %>%
+           stuff,
+         argument2)
 
 
 ### Blocks

--- a/test/styles/GNU.R
+++ b/test/styles/GNU.R
@@ -596,8 +596,8 @@ else
 object <-
   if (condition)
     fun_call()[index]
-else
-  stuff
+  else
+    stuff
 
 
 ### Continuation lines

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -596,8 +596,8 @@ else
 object <-
     if (condition)
         fun_call()[index]
-else
-    stuff
+    else
+        stuff
 
 
 ### Continuation lines

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -825,6 +825,12 @@ object[index] %>%
 fun_call(argument) <-
     hop
 
+## 25
+fun_call1(argument, fun_call2(
+                        stuff1
+                    ) +
+                        stuff2)
+
 
 ### Comments
 

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -585,20 +585,19 @@ while(condition)
     stuff
 
 ## 18
-if (cond1)
+if (condition1)
     stuff1
 else
-    if (cond2) {
+    if (condition2) {
         stuff2
     }
 
 ## 19
-skip <-
-    if(condition)
-        ## replacing the next line by 'stuff1' or even dropping '[-i]]    ``solves the issue''
-        ff(x)[-i]
+object <-
+    if (condition)
+        fun_call()[index]
 else
-    stuff2
+    stuff
 
 
 ### Continuation lines
@@ -903,5 +902,3 @@ fun_call(
     ifelse(condition2, argument2,
            ifelse))
 )
-
-

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -371,6 +371,22 @@ fun_call1(
 }
 )
 
+## 17
+fun_call(argument, function(argument1,
+                            argument2) {
+    body
+}
+)
+
+## 18
+fun_call(
+    argument,
+    function(argument1,
+             argument2) {
+        body
+    }
+)
+
 
 ### Bracket indexing
 

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -226,6 +226,10 @@ fun_call({
     stuff3
 })
 
+## 18
+fun_call(argument1 %>%
+             stuff,
+         argument2)
 
 
 ### Blocks

--- a/test/styles/RStudio.R
+++ b/test/styles/RStudio.R
@@ -579,10 +579,10 @@ object <- fun_call(argument,
 
 ## 16
 object <- fun_call(argument, if (condition)
-                               stuff1
-                   else if (condition2)
-                     stuff2
-                   )
+  stuff1
+  else if (condition2)
+    stuff2
+  )
 
 ## 17
 while(condition)

--- a/test/styles/RStudio.R
+++ b/test/styles/RStudio.R
@@ -371,6 +371,22 @@ fun_call1(
 }
 )
 
+## 17
+fun_call(argument, function(argument1,
+                            argument2) {
+  body
+}
+)
+
+## 18
+fun_call(
+  argument,
+  function(argument1,
+           argument2) {
+    body
+  }
+)
+
 
 ### Bracket indexing
 

--- a/test/styles/RStudio.R
+++ b/test/styles/RStudio.R
@@ -585,12 +585,19 @@ while(condition)
   stuff
 
 ## 18
-if (cond1)
+if (condition1)
   stuff1
 else
-  if (cond2) {
+  if (condition2) {
     stuff2
   }
+
+## 19
+object <-
+  if (condition)
+    fun_call()[index]
+else
+  stuff
 
 
 ### Continuation lines

--- a/test/styles/RStudio.R
+++ b/test/styles/RStudio.R
@@ -825,6 +825,12 @@ object[index] %>%
 fun_call(argument) <-
   hop
 
+## 25
+fun_call1(argument, fun_call2(
+  stuff1
+) +
+  stuff2)
+
 
 ### Comments
 

--- a/test/styles/RStudio.R
+++ b/test/styles/RStudio.R
@@ -226,6 +226,10 @@ fun_call({
   stuff3
 })
 
+## 18
+fun_call(argument1 %>%
+           stuff,
+         argument2)
 
 
 ### Blocks

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -226,6 +226,10 @@ fun_call({
             stuff3
          })
 
+## 18
+fun_call(argument1 %>%
+            stuff,
+   argument2)
 
 
 ### Blocks

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -145,11 +145,11 @@ fun_call(argument1
  , argument2
  , argument3,
    argument4, (
-            stuff1
-         ),
+      stuff1
+   ),
    argument5, (
-            stuff2
-         )
+      stuff2
+   )
   ,
    argument6
 )
@@ -521,7 +521,7 @@ object <-
 {
    fun_call(parameter =
                if (condition)
-                  stuff1
+               stuff1
       else
          stuff2
    )
@@ -559,7 +559,7 @@ fun_call(
          argument,
          parameter =
             if (condition1)
-               stuff1
+            stuff1
          else if (condition2)
             stuff3
          else
@@ -569,17 +569,17 @@ fun_call(
 ## 15
 object <- fun_call(argument,
              parameter = if (condition1) {
-                      stuff1
-                   } else if (condition2) {
-                      stuff3
-                   } else {
-                      stuff2
-                   }
+                stuff1
+             } else if (condition2) {
+                stuff3
+             } else {
+                stuff2
+             }
           )
 
 ## 16
 object <- fun_call(argument, if (condition)
-                                stuff1
+                      stuff1
              else if (condition2)
                 stuff2
           )
@@ -672,9 +672,9 @@ ggplot() +
    ggplot() +
       geom1(argument1,
          argument2 = (
-               stuff1
-            ) -
-               stuff2) +
+            stuff1
+         ) -
+            stuff2) +
          geom2() +
             geom3()
 }

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -371,6 +371,22 @@ fun_call1(
 }
 )
 
+## 17
+fun_call(argument, function(argument1,
+                      argument2) {
+                      body
+                   }
+)
+
+## 18
+fun_call(
+         argument,
+         function(argument1,
+            argument2) {
+            body
+         }
+         )
+
 
 ### Bracket indexing
 

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -825,6 +825,12 @@ object[index] %>%
 fun_call(argument) <-
    hop
 
+## 25
+fun_call1(argument, fun_call2(
+                              stuff1
+                              ) +
+                       stuff2)
+
 
 ### Comments
 

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -585,12 +585,19 @@ while(condition)
    stuff
 
 ## 18
-if (cond1)
+if (condition1)
    stuff1
 else
-   if (cond2) {
+   if (condition2) {
       stuff2
    }
+
+## 19
+object <-
+   if (condition)
+      fun_call()[index]
+else
+   stuff
 
 
 ### Continuation lines

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -53,38 +53,38 @@ object <- function()
 ## 8
 {
   fun_call(parameter = function()
-    {
-      body
-    })
+  {
+    body
+  })
 }
 
 ## 9
 {
   fun_call(parameter = function() {
-      body
-    })
+    body
+  })
 }
 
 ## 10
 fun_call(
   function() {
-    stuff
-  }
+  stuff
+}
 )
 
 ## 11
 {
   fun_call1(fun_call2(argument, function() {
-      stuff
-    })
+    stuff
+  })
   )
 }
 
 ## 12
 {
   fun_call1(argument, fun_call2(function() {
-                          stuff
-                        })
+                        stuff
+                      })
   )
 }
 
@@ -177,13 +177,13 @@ argument
         argument3,
         argument4
       ), function(x) {
-        body
-      },
-      argument5,
-      fun_call4(
-        argument6
-      ),
-      argument7
+      body
+    },
+    argument5,
+    fun_call4(
+      argument6
+    ),
+    argument7
     ), {
     stuff
   },
@@ -307,11 +307,11 @@ argument
 
 ## 8
 fun_call(function(x) {
-    body1
-  },
-  function(x) {
-    body2
-  })
+  body1
+},
+function(x) {
+  body2
+})
 
 ## 9
 fun_call(
@@ -521,9 +521,9 @@ object <-
 {
   fun_call(parameter =
              if (condition)
-               stuff1
-           else
-             stuff2
+    stuff1
+    else
+    stuff2
   )
 }
 
@@ -559,11 +559,11 @@ fun_call(
   argument,
   parameter =
     if (condition1)
-      stuff1
+  stuff1
   else if (condition2)
-    stuff3
+  stuff3
   else
-    stuff2
+  stuff2
 )
 
 ## 15
@@ -579,9 +579,9 @@ object <- fun_call(argument,
 
 ## 16
 object <- fun_call(argument, if (condition)
-                               stuff1
-                   else if (condition2)
-                     stuff2
+  stuff1
+  else if (condition2)
+  stuff2
 )
 
 ## 17

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -159,7 +159,7 @@ fun_call(parameter =
            fun_argument(
              sub_argument
            ),
-           argument
+         argument
 )
 
 ## 10
@@ -226,6 +226,10 @@ fun_call({
   stuff3
 })
 
+## 18
+fun_call(argument1 %>%
+           stuff,
+         argument2)
 
 
 ### Blocks
@@ -518,8 +522,8 @@ object <-
   fun_call(parameter =
              if (condition)
                stuff1
-             else
-               stuff2
+           else
+             stuff2
   )
 }
 
@@ -576,8 +580,8 @@ object <- fun_call(argument,
 ## 16
 object <- fun_call(argument, if (condition)
                                stuff1
-                               else if (condition2)
-                                 stuff2
+                   else if (condition2)
+                     stuff2
 )
 
 ## 17

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -585,12 +585,19 @@ while(condition)
   stuff
 
 ## 18
-if (cond1)
+if (condition1)
   stuff1
 else
-  if (cond2) {
+  if (condition2) {
     stuff2
   }
+
+## 19
+object <-
+  if (condition)
+    fun_call()[index]
+else
+  stuff
 
 
 ### Continuation lines

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -825,6 +825,12 @@ object[index] %>%
 fun_call(argument) <-
   hop
 
+## 25
+fun_call1(argument, fun_call2(
+  stuff1
+) +
+  stuff2)
+
 
 ### Comments
 

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -371,6 +371,22 @@ fun_call1(
 }
 )
 
+## 17
+fun_call(argument, function(argument1,
+                            argument2) {
+  body
+}
+)
+
+## 18
+fun_call(
+  argument,
+  function(argument1,
+           argument2) {
+  body
+}
+)
+
 
 ### Bracket indexing
 


### PR DESCRIPTION
This fixes a few bugs and refactors indentation of blocks, which I splitted in several functions to make things more manageable. Indentation of blocks at `open-delim` and `prev-call` should be a bit more consistent now (though sometimes uglier, but there are switches like `ess-align-blocks` to prevent this).