### PR TITLE
Add new indentation setting: ess-indent-block-lhs

### DIFF
--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -36,11 +36,25 @@ function()
 
     function() body
 
-## 6
+## 6a
 object <- function()
 {
     body
 }
+
+## 6b
+object <-
+    function()
+    {
+        body
+    }
+
+## 6c
+object =
+    function()
+    {
+        body
+    }
 
 ## 7
 {
@@ -87,6 +101,13 @@ fun_call(
                         })
               )
 }
+
+## 13
+fun_call(object :=
+             function()
+             {
+                 body
+             })
 
 
 ### Function calls

--- a/test/styles/GNU.R
+++ b/test/styles/GNU.R
@@ -36,11 +36,25 @@ function()
 
   function() body
 
-## 6
+## 6a
 object <- function()
 {
   body
 }
+
+## 6b
+object <-
+  function()
+  {
+    body
+  }
+
+## 6c
+object =
+  function()
+  {
+    body
+  }
 
 ## 7
 {
@@ -87,6 +101,13 @@ fun_call(
   })
   )
 }
+
+## 13
+fun_call(object :=
+           function()
+           {
+             body
+           })
 
 
 ### Function calls

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -36,11 +36,25 @@ function()
 
     function() body
 
-## 6
+## 6a
 object <- function()
 {
     body
 }
+
+## 6b
+object <-
+    function()
+    {
+        body
+    }
+
+## 6c
+object =
+    function()
+    {
+        body
+    }
 
 ## 7
 {
@@ -87,6 +101,13 @@ fun_call(
     })
     )
 }
+
+## 13
+fun_call(object :=
+             function()
+             {
+                 body
+             })
 
 
 ### Function calls

--- a/test/styles/RStudio.R
+++ b/test/styles/RStudio.R
@@ -36,11 +36,25 @@ function()
 
   function() body
 
-## 6
+## 6a
 object <- function()
 {
   body
 }
+
+## 6b
+object <-
+  function()
+  {
+    body
+  }
+
+## 6c
+object =
+  function()
+  {
+    body
+  }
 
 ## 7
 {
@@ -87,6 +101,13 @@ fun_call(
   })
   )
 }
+
+## 13
+fun_call(object :=
+           function()
+           {
+             body
+           })
 
 
 ### Function calls

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -6,8 +6,8 @@
 {
    fun <- function(argument1,
              argument2) {
-             body
-          }
+      body
+   }
 }
 
 ## 2
@@ -36,18 +36,32 @@ function()
 
    function() body
 
-## 6
+## 6a
 object <- function()
-          {
-             body
-          }
+{
+   body
+}
+
+## 6b
+object <-
+   function()
+   {
+      body
+   }
+
+## 6c
+object =
+   function()
+   {
+      body
+   }
 
 ## 7
 {
    object <- function()
-             {
-                body
-             }
+   {
+      body
+   }
 }
 
 ## 8
@@ -87,6 +101,13 @@ fun_call(
                                  })
    )
 }
+
+## 13
+fun_call(object :=
+            function()
+            {
+               body
+            })
 
 
 ### Function calls

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -36,11 +36,25 @@ function()
 
   function() body
 
-## 6
+## 6a
 object <- function()
 {
   body
 }
+
+## 6b
+object <-
+  function()
+  {
+    body
+  }
+
+## 6c
+object =
+  function()
+  {
+    body
+  }
 
 ## 7
 {
@@ -87,6 +101,13 @@ fun_call(
                       })
   )
 }
+
+## 13
+fun_call(object :=
+           function()
+           {
+             body
+           })
 
 
 ### Function calls


### PR DESCRIPTION
Hello,
I'm opening a pull request for this one because it adds a new setting, `ess-indent-block-lhs`.

This controls whether to indent assigned function blocks from the lhs. When set to t (default ESS):

```r
  object <-
      function(argument)
  {
      body
  }
```

When set to nil (default RStudio):
```r
  object <-
      function(argument)
      {
          body
      }
```

 cc @vspinu @mmaechler 