### PR TITLE
New hanging/stretched style

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -731,7 +731,7 @@ the closest function call:
                            ))
 
 You can control the details of indentation at `prev-call' with
-`ess-indent-prev-call-lhs' and `ess-indent-prev-call-chains'.
+`ess-indent-from-lhs' and `ess-indent-from-chain-start'.
 
 
 When set to `prev-line', arguments on a new line are indented
@@ -779,7 +779,7 @@ closest function call:
                  }))
 
 You can control the details of indentation at `prev-call' with
-`ess-indent-prev-call-lhs' and `ess-indent-prev-call-chains'.
+`ess-indent-from-lhs' and `ess-indent-from-chain-start'.
 
 
 When set to `prev-line', blocks are indented relative to the
@@ -893,7 +893,7 @@ aligned vertically. With `fun-decl', the body of a function
 declaration will always be aligned with the call to
 `function'.")
 
-(defvar ess-indent-prev-call-lhs nil
+(defvar ess-indent-from-lhs nil
   "When non-nil, indent arguments from the left-hand side of an assignment.
 
 This setting only has an effect when indentation of arguments or
@@ -926,16 +926,16 @@ If t:
 
 See `ess-style-alist' for for an overview of ESS indentation.")
 
-(defvar ess-indent-prev-call-chains t
+(defvar ess-indent-from-chain-start t
   "This switch adjusts the behaviour of
 ess-offset-arguments(-newline) and ess-offset-block when they are
 set to `t'. In this case, arguments are indented starting from
-the function call. When ess-indent-prev-call-chains is
+the function call. When ess-indent-from-chain-start is
 `prev-call' as well, chained calls will be treated as if they
 were one call and indentation will start from the first one.
 
 For example, with ess-offset-arguments-newline set to `prev-call'
-and ess-indent-prev-call-chains set to `nil', we have:
+and ess-indent-from-chain-start set to `nil', we have:
 
   some_function(other_function(
                     argument
@@ -955,7 +955,7 @@ See `ess-style-alist' for for an overview of ESS indentation."
   :group 'ess-edit)
 
 (define-obsolete-variable-alias 'ess-fancy-comments 'ess-indent-with-fancy-comments "15.09")
-(define-obsolete-variable-alias 'ess-arg-function-offset 'ess-indent-prev-call-lhs "15.09")
+(define-obsolete-variable-alias 'ess-arg-function-offset 'ess-indent-from-lhs "15.09")
 (define-obsolete-variable-alias 'ess-arg-function-offset-new-line 'ess-offset-arguments-newline "15.09")
 (define-obsolete-variable-alias 'ess-first-continued-statement-offset 'ess-offset-continued "15.09")
 (define-obsolete-variable-alias 'ess-continued-statement-offset 'ess-offset-continued "15.09")
@@ -974,8 +974,8 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
      (ess-align-blocks . (control-flow))
-     (ess-indent-prev-call-lhs . t)
-     (ess-indent-prev-call-chains . t)
+     (ess-indent-from-lhs . t)
+     (ess-indent-from-chain-start . t)
      (ess-indent-with-fancy-comments . t))
 
     (C++
@@ -988,8 +988,8 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
      (ess-align-blocks . (control-flow))
-     (ess-indent-prev-call-lhs . t)
-     (ess-indent-prev-call-chains . t)
+     (ess-indent-from-lhs . t)
+     (ess-indent-from-chain-start . t)
      (ess-indent-with-fancy-comments . t))
 
     ;; CLB added rmh 2Nov97 at request of Terry Therneau
@@ -1003,8 +1003,8 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
      (ess-align-blocks . (control-flow))
-     (ess-indent-prev-call-lhs . t)
-     (ess-indent-prev-call-chains . t)
+     (ess-indent-from-lhs . t)
+     (ess-indent-from-chain-start . t)
      (ess-indent-with-fancy-comments . t))
 
     (GNU
@@ -1017,8 +1017,8 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
      (ess-align-blocks . (control-flow))
-     (ess-indent-prev-call-lhs . t)
-     (ess-indent-prev-call-chains . t)
+     (ess-indent-from-lhs . t)
+     (ess-indent-from-chain-start . t)
      (ess-indent-with-fancy-comments . t))
 
     (K&R
@@ -1031,8 +1031,8 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
      (ess-align-blocks . (control-flow))
-     (ess-indent-prev-call-lhs . t)
-     (ess-indent-prev-call-chains . t)
+     (ess-indent-from-lhs . t)
+     (ess-indent-from-chain-start . t)
      (ess-indent-with-fancy-comments . t))
 
     ;; R added ajr 17Feb04 to match "common R" use
@@ -1046,8 +1046,8 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
      (ess-align-blocks . (control-flow))
-     (ess-indent-prev-call-lhs . t)
-     (ess-indent-prev-call-chains . t)
+     (ess-indent-from-lhs . t)
+     (ess-indent-from-chain-start . t)
      (ess-indent-with-fancy-comments . t))
 
     (RRR-aligned
@@ -1060,8 +1060,8 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
      (ess-align-blocks . (control-flow))
-     (ess-indent-prev-call-lhs . t)
-     (ess-indent-prev-call-chains . nil)
+     (ess-indent-from-lhs . t)
+     (ess-indent-from-chain-start . nil)
      (ess-indent-with-fancy-comments . t))
 
     (RStudio
@@ -1074,8 +1074,8 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-align-arguments-in-calls . ("function[ \t]*("))
      (ess-align-continuations-in-calls . nil)
      (ess-align-blocks . nil)
-     (ess-indent-prev-call-lhs . t)
-     (ess-indent-prev-call-chains . t)
+     (ess-indent-from-lhs . t)
+     (ess-indent-from-chain-start . t)
      (ess-indent-with-fancy-comments . nil))
 
     (DEFAULT
@@ -1088,8 +1088,8 @@ See `ess-style-alist' for for an overview of ESS indentation."
       (ess-align-arguments-in-calls . ,(default-value 'ess-align-arguments-in-calls))
       (ess-align-continuations-in-calls . ,(default-value 'ess-align-continuations-in-calls))
       (ess-align-blocks . ,(default-value 'ess-align-blocks))
-      (ess-indent-prev-call-lhs . ,(default-value 'ess-indent-prev-call-lhs))
-      (ess-indent-prev-call-chains . ,(default-value 'ess-indent-prev-call-chains))
+      (ess-indent-from-lhs . ,(default-value 'ess-indent-from-lhs))
+      (ess-indent-from-chain-start . ,(default-value 'ess-indent-from-chain-start))
       (ess-indent-with-fancy-comments . ,(default-value 'ess-indent-with-fancy-comments))))
 
   "Predefined formatting styles for ESS code.
@@ -1137,10 +1137,10 @@ Overrides (implies vertical alignment):
 
 Control variables:
 
- - `ess-indent-prev-call-lhs': whether to indent arguments from
+ - `ess-indent-from-lhs': whether to indent arguments from
    left-hand side of an assignment or parameter declaration.
 
- - `ess-indent-prev-call-chains': whether to indent arguments from
+ - `ess-indent-from-chain-start': whether to indent arguments from
    the first of several consecutive calls.
 
  - `ess-indent-with-fancy-comments': whether to indent #,## and ### comments

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -894,13 +894,9 @@ declaration will always be aligned with the call to
 `function'.")
 
 (defvar ess-indent-from-lhs nil
-  "When non-nil, indent arguments from the left-hand side of an assignment.
-
-This setting only has an effect when indentation of arguments or
-blocks is relative to the innermost function call. That is, when
-`ess-offset-arguments', `ess-offset-arguments-newline' or
-`ess-offset-block' are set to a number N as opposed to nil or
-'(N).
+  "When non-nil, indent arguments from the left-hand side of an
+assignment. This setting currently only has an effect for
+offsets set to `prev-call'.
 
 If nil:
 
@@ -927,21 +923,18 @@ If t:
 See `ess-style-alist' for for an overview of ESS indentation.")
 
 (defvar ess-indent-from-chain-start t
-  "This switch adjusts the behaviour of
-ess-offset-arguments(-newline) and ess-offset-block when they are
-set to `t'. In this case, arguments are indented starting from
-the function call. When ess-indent-from-chain-start is
-`prev-call' as well, chained calls will be treated as if they
-were one call and indentation will start from the first one.
+  "When non-nil, chained calls will be treated as if they were
+one call and indentation will start from the first one. This
+setting currently only has an effect for offsets set to
+`prev-call'.
 
-For example, with ess-offset-arguments-newline set to `prev-call'
-and ess-indent-from-chain-start set to `nil', we have:
+If `nil':
 
   some_function(other_function(
                     argument
                 ))
 
-And when the latter is set to `t' instead:
+If `t':
 
   some_function(other_function(
       argument

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1050,6 +1050,20 @@ See `ess-style-alist' for for an overview of ESS indentation."
      (ess-indent-prev-call-chains . t)
      (ess-indent-with-fancy-comments . t))
 
+    (RRR-aligned
+     (ess-indent-offset . 4)
+     (ess-offset-arguments . open-delim)
+     (ess-offset-arguments-newline . prev-call)
+     (ess-offset-block . open-delim)
+     (ess-offset-continued . straight)
+     (ess-align-nested-calls . ("ifelse"))
+     (ess-align-arguments-in-calls . ("function[ \t]*("))
+     (ess-align-continuations-in-calls . ("[ \t]*(" "if[ \t]*(" "[^ \t]+\\["))
+     (ess-align-blocks . (control-flow))
+     (ess-indent-prev-call-lhs . t)
+     (ess-indent-prev-call-chains . nil)
+     (ess-indent-with-fancy-comments . t))
+
     (RStudio
      (ess-indent-offset . 2)
      (ess-offset-arguments . open-delim)

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -367,10 +367,10 @@ Variables controlling indentation style:
     Calls in which continuations should be aligned.
  `ess-align-blocks'
     Blocks that should always be aligned vertically.
- `ess-indent-prev-call-lhs'
+ `ess-indent-from-lhs'
     Whether function calls given as argument should be indented from the
     parameter name.
- `ess-indent-prev-call-chains'
+ `ess-indent-from-chain-start'
     Whether to indent arguments from the first of several consecutive calls.
  `ess-indent-with-fancy-comments'
     Non-nil means distinguish between #, ##, and ### for indentation.
@@ -1691,12 +1691,12 @@ Returns nil if line starts inside a string, t if in a comment."
   ;; Handle brackets chains such as ][ (cf data.table)
   (ess-climb-chained-brackets)
   ;; Handle call chains
-  (if ess-indent-prev-call-chains
+  (if ess-indent-from-chain-start
       (while (and (ess-backward-sexp)
                   (when (looking-back "[[(][ \t,]*" (line-beginning-position))
                     (goto-char (match-beginning 0)))))
     (ess-backward-sexp))
-  (when ess-indent-prev-call-lhs
+  (when ess-indent-from-lhs
     (ess-climb-lhs))
   (if (and nil
            (eq block 'fun-decl)

--- a/test/ess-tests.el
+++ b/test/ess-tests.el
@@ -68,8 +68,8 @@
      (ess-align-arguments-in-calls . nil)
      (ess-align-continuations-in-calls . nil)
      (ess-align-blocks . (fun-decl bare-blocks))
-     (ess-indent-prev-call-lhs . nil)
-     (ess-indent-prev-call-chains . nil)
+     (ess-indent-from-lhs . nil)
+     (ess-indent-from-chain-start . nil)
      (ess-indent-with-fancy-comments . t))
     (misc2
      ,@(cdr (assq 'RStudio ess-style-alist))

--- a/test/ess-tests.el
+++ b/test/ess-tests.el
@@ -65,7 +65,7 @@
      (ess-align-nested-calls . ("ifelse"))
      (ess-align-arguments-in-calls . nil)
      (ess-align-continuations-in-calls . nil)
-     (ess-align-blocks . (fun-decl))
+     (ess-align-blocks . (fun-decl bare-blocks))
      (ess-indent-prev-call-lhs . nil)
      (ess-indent-prev-call-chains . nil)
      (ess-indent-with-fancy-comments . t))

--- a/test/ess-tests.el
+++ b/test/ess-tests.el
@@ -50,6 +50,8 @@
   ;; interfere with tests
   `((RRR
      ,@(cdr (assq 'RRR ess-style-alist)))
+    (RRR-aligned
+     ,@(cdr (assq 'RRR-aligned ess-style-alist)))
     (GNU
      ,@(cdr (assq 'GNU ess-style-alist)))
     (RStudio

--- a/test/styles/C++.R
+++ b/test/styles/C++.R
@@ -408,6 +408,13 @@ fun_call(
 }
 )
 
+## 19
+fun_call1(
+    fun_call2(argument, function(x) {
+        body
+    })
+)
+
 
 ### Bracket indexing
 

--- a/test/styles/GNU.R
+++ b/test/styles/GNU.R
@@ -408,6 +408,13 @@ fun_call(
     }
 )
 
+## 19
+fun_call1(
+    fun_call2(argument, function(x) {
+      body
+    })
+)
+
 
 ### Bracket indexing
 

--- a/test/styles/RRR-aligned.R
+++ b/test/styles/RRR-aligned.R
@@ -1,0 +1,981 @@
+
+
+### Function declarations
+
+## 1
+{
+    fun <- function(argument1,
+                    argument2) {
+        body
+    }
+}
+
+## 2
+{
+    function(
+             argument1,
+             argument2
+             )
+    {
+        body
+    }
+}
+
+## 3
+function(argument_fun(sub_argument1,
+                      sub_argument2),
+         argument) {}
+
+## 4
+function(argument1, parameter = fun_call(
+                        sub_argument),
+         argument2) {}
+
+## 5
+function()
+
+    function() body
+
+## 6a
+object <- function()
+{
+    body
+}
+
+## 6b
+object <-
+    function()
+    {
+        body
+    }
+
+## 6c
+object =
+    function()
+    {
+        body
+    }
+
+## 7
+{
+    object <- function()
+    {
+        body
+    }
+}
+
+## 8
+{
+    fun_call(parameter = function()
+             {
+                 body
+             })
+}
+
+## 9
+{
+    fun_call(parameter = function() {
+                 body
+             })
+}
+
+## 10
+fun_call(
+    function() {
+        stuff
+    }
+)
+
+## 11
+{
+    fun_call1(fun_call2(argument, function() {
+                            stuff
+                        })
+              )
+}
+
+## 12
+{
+    fun_call1(argument, fun_call2(function() {
+                                      stuff
+                                  })
+              )
+}
+
+## 13
+fun_call(object :=
+             function()
+             {
+                 body
+             })
+
+
+### Function calls
+
+## 1
+fun_call(argument1,
+         argument2)
+
+## 2
+fun_call(
+    argument1,
+    argument2
+)
+
+## 3
+fun_call(parameter = (
+             stuff
+         ),
+         argument)
+
+## 4
+fun_call(parameter = fun_argument(
+             argument1
+         ),
+         argument2)
+
+## 5
+fun_call(parameter = fun_argument(argument1,
+                                  argument2
+                                  )
+        ,
+         argument3)
+
+## 6
+`fun_call`(argument1,
+           argument2)
+
+## 6b
+`:=`(argument1,
+     argument2)
+
+## 7
+`fun_call`(
+    argument1,
+    argument2
+)
+
+## 7b
+`:=`(
+    argument1,
+    argument2
+)
+
+## 8
+fun_call(argument1
+       , argument2
+       , argument3,
+         argument4, (
+             stuff1
+         ),
+         argument5, (
+             stuff2
+         )
+        ,
+         argument6
+         )
+
+## 9
+fun_call(parameter =
+             fun_argument(
+                 sub_argument
+             ),
+         argument
+         )
+
+## 10
+fun_call(parameter = fun_argument(
+             sub_argument
+         ),
+         argument
+         )
+
+## 11
+{
+    fun_call1(
+        fun_call2 (argument1, argument2,
+                   parameter = fun_call3(
+                       argument3,
+                       argument4
+                   ), function(x) {
+                       body
+                   },
+                   argument5,
+                   fun_call4(
+                       argument6
+                   ),
+                   argument7
+                   ), {
+            stuff
+        },
+        argument8
+    )
+}
+
+## 12
+object <- fun_call(
+    arg1,
+    arg2
+)
+
+## 13
+fun_call1(fun_call2(
+              argument
+          ))
+
+## 14
+some_function <- fun_call1(fun_call2(
+                               argument
+                           ))
+
+## 15
+object[, fun_call(
+             argument
+         )]
+
+## 16
+fun_call1(argument1, fun_call2(fun_call3(
+                                   argument2
+                               ))
+          )
+
+## 17
+fun_call({
+             stuff1
+             stuff2
+
+             stuff3
+         })
+
+## 18
+fun_call(argument1 %>%
+             stuff,
+         argument2)
+
+
+### Blocks
+
+## 1
+{
+    function()
+    {
+        body
+    }
+}
+
+## 2
+{
+    fun_call({
+                 stuff1
+             },
+             {
+                 stuff2
+             }
+             )
+}
+
+## 3
+fun_call({
+             stuff1
+         }, {
+             stuff2
+         })
+
+## 4
+fun_call(
+    parameter1 = {
+        stuff1
+    },
+    parameter2 = {
+        stuff2
+    }
+)
+
+## 5
+fun_call(parameter1 = {
+             stuff1
+         },
+         {
+             stuff2
+         }, parameter2 = {
+             stuff3
+         }, {
+             stuff4
+         },
+         parameter3 =
+             stuff5 ~
+                 stuff6 +
+                 stuff7,
+         argument)
+
+## 6
+fun <- fun_call({
+                    stuff1
+                }, {
+                    stuff2
+                },
+                {
+                    stuff3
+                }
+                )
+
+## 7
+fun <- fun_call({
+                    stuff
+                },
+                argument
+                )
+
+## 8
+fun_call(function(x) {
+             body1
+         },
+         function(x) {
+             body2
+         })
+
+## 9
+fun_call(
+         {
+             stuff
+         }, {
+             stuff
+         }
+)
+
+## 10
+object <-
+    fun_call({
+                 stuff
+             }, {
+                 stuff
+             })
+
+## 11
+object <-
+    fun_call(     {
+                 body
+             }
+             )
+
+## 12
+fun_call1(
+    fun_call2({
+                  stuff
+              }
+              )
+)
+
+## 13
+{
+    stuff1
+
+    {
+        stuff2
+    }
+}
+
+## 14
+{{
+    stuff
+}
+}
+
+## 15
+({
+    stuff
+})
+
+## 16
+( {
+    stuff
+}
+)
+
+## 17
+fun_call(argument, function(argument1,
+                            argument2) {
+             body
+         }
+         )
+
+## 18
+fun_call(
+    argument,
+    function(argument1,
+             argument2) {
+        body
+    }
+)
+
+## 19
+fun_call1(
+    fun_call2(argument, function(x) {
+                  body
+              })
+)
+
+
+### Bracket indexing
+
+## 1
+object[
+    argument1,
+    argument2
+]
+
+## 2
+object[argument1,
+       argument2
+       ]
+
+## 3
+object[(
+           argument1
+       )]
+
+## 4
+{
+    object[
+        fun_call(
+            body
+        ),
+        argument[
+                 (
+                     sub_argument
+                 )
+        ]
+    ]
+}
+
+## 5
+{
+    object[
+        argument1,
+        argument2,
+        by = argument3
+    ][
+        argument4,
+        fun_call1(argument1,
+                  argument2)
+        argument5
+    ][
+        argument6,
+        fun_call2(
+            argument1,
+            argument2
+        )
+    ]
+}
+
+
+### Control flow
+
+## 1
+{
+    if (condition) {
+        stuff1
+    } else {
+        stuff2
+    }
+}
+
+## 2
+{
+    if (condition) {
+        stuff1
+    }
+    else {
+        stuff2
+    }
+}
+
+## 3
+{
+    if (condition)
+    {
+        stuff1
+    } else
+    {
+        stuff2
+    }
+}
+
+## 4
+{
+    if (condition)
+    {
+        stuff1
+    }
+    else
+    {
+        stuff2
+    }
+}
+
+## 5
+{
+    for (sequence)
+    {
+        stuff
+    }
+}
+
+## 6
+{
+    for (sequence) {
+        stuff
+    }
+}
+
+## 7
+if (condition)
+    stuff
+
+## 8
+for (sequence)
+    stuff
+
+## 9
+object <-
+    if (condition) {
+        stuff1
+    } else {
+        stuff2
+    }
+
+## 10
+{
+    object <-
+        if (condition) stuff1
+        else stuff2
+}
+
+## 10
+{
+    object <-
+        if (condition) fun_call(
+                           argument1,
+                           argument2
+                       )
+        else stuff
+}
+
+## 11
+{
+    fun_call(parameter =
+                 if (condition)
+                     stuff1
+                 else
+                     stuff2
+             )
+}
+
+## 12
+{
+    if (condition1) {
+        stuff1
+    }
+    else if (condition2)
+        stuff2
+    else if (condition3) {
+        stuff3
+    } else if (condition4)
+        stuff4
+    else
+        stuff5
+}
+
+## 13
+fun_call(
+    argument,
+    parameter = if (condition1) {
+                    stuff1
+                } else if (condition2) {
+                    stuff3
+                } else {
+                    stuff2
+                }
+)
+
+## 14
+fun_call(
+    argument,
+    parameter =
+        if (condition1)
+            stuff1
+        else if (condition2)
+            stuff3
+        else
+            stuff2
+)
+
+## 15
+object <- fun_call(argument,
+                   parameter = if (condition1) {
+                                   stuff1
+                               } else if (condition2) {
+                                   stuff3
+                               } else {
+                                   stuff2
+                               }
+                   )
+
+## 16
+object <- fun_call(argument, if (condition)
+                                 stuff1
+                             else if (condition2)
+                                 stuff2
+                   )
+
+## 17
+while(condition)
+    stuff
+
+## 18
+if (condition1)
+    stuff1
+else
+    if (condition2) {
+        stuff2
+    }
+
+## 19
+object <-
+    if (condition)
+        fun_call()[index]
+    else
+        stuff
+
+## 20
+funcall({
+            if (test1)
+                stuff1
+            if (test2)
+                stuff2
+        })
+
+
+### Continuation lines
+
+## 1
+stuff1 %>%
+    stuff2 %>%
+    stuff3
+
+## 2
+{
+    stuff1 %>%
+        stuff2 %>%
+        stuff3
+} %>%
+    stuff4 %>%
+    stuff5
+
+## 3
+(
+    stuff1 %>%
+    stuff2 %>%
+    stuff3
+) %>%
+    stuff4 %>%
+    stuff5
+
+## 4
+object[
+    stuff1 %>%
+    stuff2 %>%
+    stuff3
+] %>%
+    stuff4 %>%
+    stuff5
+
+## 5
+stuff1 %>%
+    stuff2 %>%
+    if (condition) {
+        stuff3 %>%
+            stuff4 %>%
+            stuff5
+    } else {
+        stuff6 %>%
+            stuff7 %>%
+            stuff8
+    } %>%
+    stuff9 %>%
+    stuff10
+
+## 6
+stuff[stuff1 %>%
+      stuff2 %>%
+      stuff3] %>%
+    stuff4 %>%
+    stuff5
+
+## 7
+ggplot() +
+    geom(lhs -
+             rhs
+         ) +
+    geom()
+
+## 8
+{
+    ggplot() +
+        geom1(argument1,
+              argument2 = (
+                  stuff1
+              ) -
+                  stuff2) +
+        geom2() +
+        geom3()
+}
+
+## 9
+stuff +
+    fun_call(parameter = argument1,
+             fun_call((stuff1 - stuff2 +
+                       stuff3
+                      ) /
+                          stuff4)
+             ) /
+    stuff5
+
+fun_call(arg1 +
+             arg2, arg3 +
+                       arg4)
+
+## 10
+fun_call(argument1 %>%
+             stuff1, argument2 %>%
+                         stuff2, {
+             stuff3 %>%
+                 stuff4
+         } %>%
+             stuff5,
+         argument3
+         )
+
+## 11
+object1 <- object2 %>%
+    fun_call1() %>%
+    fun_call2()
+
+## 12
+object1 <-
+    object2%>%fun_call1() %>%
+    fun_call2()%>%
+    fun_call3()
+
+## 13
+{
+    (stuff) %>%
+        fun_call()
+
+    {stuff} %>%
+        fun_call()
+}
+
+## 14
+{
+    object + (
+        stuff
+    ) %>%
+        fun_call()
+
+    object + {
+        stuff
+    } %>%
+        fun_call()
+}
+
+## 15
+object <-
+    stuff1 +
+    stuff2 ~
+        stuff3 +
+        stuff4 :=
+            stuff5 +
+            stuff6 =
+                stuff7 +
+                stuff8
+
+## 16
+object <- stuff1 +
+    stuff2 + stuff3 +
+    stuff4 ~ stuff5 +
+        stuff6 + stuff7 +
+        stuff8 := stuff9 +
+            stuff10 + stuff11 +
+            stuff12 = stuff13 +
+                stuff14 + stuff15 +
+                stuff16
+
+## 17
+object %>%
+    {
+        stuff1
+    } %>% object[index] %>% {stuff2} %>% fun_call1() +
+    if (condition1) stuff3 else stuff4 +
+    if (condition2) {
+        stuff5
+    } else if (condition3) {
+        stuff6
+    } else {
+        stuff7
+    } %>%
+    (fun_call2()) %>% fun_call3() %>%
+    fun_call3()
+
+## 18
+`object`$`elem` <- stuff1 +
+    stuff2
+`object`@`elem` <- stuff1 +
+    stuff2
+
+## 19
+{
+    ## comment
+    object1 <-
+        object2
+}
+
+## 20
+fun_call(stuff1 + stuff2 +
+             stuff3 +
+             (stuff4 + stuff5 +
+              stuff6) +
+             object[stuff7 +
+                    stuff8] +
+             {stuff9 +
+                  stuff10})
+
+
+## 21
+object %>% fun_call({
+                        stuff1
+                    }) %>%
+    stuff2
+
+## 22
+"string1" %>%
+    'string2' %>%
+    `stuff1` %>%
+    stuff2
+
+## 23
+object[index] %>%
+    fun_call1(
+        argument1
+    )[index2] %>%
+    fun_call2(
+        argument2
+    )[[index3]] %>%
+    stuff
+
+## 24
+fun_call(argument) <-
+    hop
+
+## 25
+fun_call1(argument, fun_call2(
+                        stuff1
+                    ) +
+                        stuff2)
+
+## 26
+object <-
+    {
+        stuff
+    } %>%
+    (
+        stuff
+    )
+
+
+### Comments
+
+## 1
+                                        # Side comment
+
+## 2
+{
+    ## Hanging comment 1
+    fun_call(
+             {
+                 ## Hanging comment 2
+             }
+    )
+}
+
+## 3
+{
+### Section comment
+}
+
+## 4
+fun_call(
+    ## Comment
+    argument
+)
+
+
+### Logical operators
+
+## 1
+stuff1 &&
+    stuff2 ||
+    stuff3
+
+## 2
+(stuff1 &&
+ stuff2 ||
+ stuff3)
+
+## 3
+if (condition1 &&
+    condition2 ||
+    (condition3 && condition4) ||
+    (condition5 &&
+     condition6 &&
+     condition7) ||
+    condition8) {
+    stuff
+} && condition8 ||
+    condition9 ||
+    condition10
+
+## 4
+stuff1 == stuff2 ||
+    condition
+
+## 5
+(stuff1 == stuff2 ||
+     condition
+)
+
+## 6
+(stuff1 != stuff2 ||
+ condition
+)
+
+## 7
+object <-
+    condition1 | condition2 |
+    condition3 | condition4
+
+## 8
+if (condition1 || object1 %op% object2 ||
+    condition3) {
+    stuff
+}
+
+
+### Specific situations and overrides
+
+## 1
+fun_call(
+    ifelse(condition1, argument1,
+    ifelse(condition2, argument2,
+           ifelse))
+)

--- a/test/styles/RRR.R
+++ b/test/styles/RRR.R
@@ -408,6 +408,13 @@ fun_call(
     }
 )
 
+## 19
+fun_call1(
+    fun_call2(argument, function(x) {
+        body
+    })
+)
+
 
 ### Bracket indexing
 

--- a/test/styles/RStudio.R
+++ b/test/styles/RStudio.R
@@ -408,6 +408,13 @@ fun_call(
   }
 )
 
+## 19
+fun_call1(
+  fun_call2(argument, function(x) {
+    body
+  })
+)
+
 
 ### Bracket indexing
 

--- a/test/styles/misc1.R
+++ b/test/styles/misc1.R
@@ -408,6 +408,13 @@ fun_call(
          }
          )
 
+## 19
+fun_call1(
+          fun_call2(argument, function(x) {
+                                 body
+                              })
+          )
+
 
 ### Bracket indexing
 
@@ -643,9 +650,9 @@ else
 ## 20
 funcall({
            if (test1)
-           stuff1
+              stuff1
            if (test2)
-           stuff2
+              stuff2
         })
 
 

--- a/test/styles/misc2.R
+++ b/test/styles/misc2.R
@@ -408,6 +408,13 @@ fun_call(
 }
 )
 
+## 19
+fun_call1(
+  fun_call2(argument, function(x) {
+    body
+  })
+)
+
 
 ### Bracket indexing
 


### PR DESCRIPTION
Here is the new indentation style we've talked about.

Compared to RRR, it doesn't try to save horizontal space as much. For example prefixed blocks such as lambda functions are indented from the opening parenthesis:
```r
list <- lapply(list, function(x) {
                  body
              },
              argument)
```

Bare blocks are indented from the nearest function call:
```r
some_call(other_call({
              stuff
          },
          {
              stuff
          }))
```

These can be even more shifted to the right by adding `fun-decl` and `bare-blocks` to `ess-align-blocks`. In that case you get:
```r
list <- lapply(list, function(x) {
                        body
                     },
               argument)

some_call(other_call({
                         stuff
                     },
                     {
                         stuff
                     }))
```

We still need to figure out the name. I quite like "hanging". This term is used in the Latex world for bullet lists. The idea is that the body of the block seems to "hang" from the block opening (in the example above, `function(`). An alternative is "stretched" but, thinking about it more, I don't like it because I think it evokes a change of shape rather than position. Other ideas: "rightmost", "easterly", ...

Also, maybe the style should include either `bare-blocks` or `fun-decl` into `ess-align-blocks`?

It'd be nice to have opinions from others on this. Cc @eddelbuettel and @kevinushey since you were interested in a style that doesn't save horizontal space. It must be a C++ thing ;)
