### PR TITLE
Fix for using cl functions

### DIFF
--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -32,8 +32,7 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
+(require 'cl)
 
 (autoload 'ess-turn-on-eldoc            "ess-r-d" "" nil)
 ;; (autoload 'ess-ddeclient-p              "ess-inf" "(autoload)" nil)

--- a/lisp/ess.el
+++ b/lisp/ess.el
@@ -111,8 +111,7 @@
 (require 'ess-mode)
 (require 'ess-inf)
 
-(eval-when-compile
-  (require 'cl))
+(require 'cl)
 
 
  ; ess-mode: editing S/R/XLS/SAS source


### PR DESCRIPTION
ess.el and ess-mode.el use cl functions such as copy-list, some.
So "(require 'cl)" should not be wrapped by "eval-after-load".