### PR TITLE
make refcard reproducible (cf #173)

### DIFF
--- a/doc/refcard/refcard.tex
+++ b/doc/refcard/refcard.tex
@@ -3,7 +3,7 @@
 \usepackage{parskip}
 \usepackage{verbatim}
 \usepackage{fullpage}% +- ok for paper 'A4' as well
-\usepackage{svn}% and {fullpage} are both in debian/ubuntu pkg 'texlive-latex-extra'
+%\usepackage{svn}% and {fullpage} are both in debian/ubuntu pkg 'texlive-latex-extra'
 
 \addtolength{\textheight}{20mm}
 \addtolength{\topmargin}{-16mm}
@@ -24,7 +24,7 @@
 \pagestyle{empty}
 
 \begin{document}
-\SVN $Date$
+%\SVN $Date$
 %\begin{multicols}{1}
 \begin{center}
   {\LARGE ESS \ \ \ \ {\large
@@ -34,7 +34,7 @@
   \smallskip
 
   {\small updated for ESS 12.09-1}% {\footnotesize --- needs \em{more} updating!}}
-  \\[1ex] {\tiny \SVNDate}
+  \\[1ex] {\tiny September 2012}
            % \footnotesize --- as of \today
 \end{center}
 % takes a lot of space


### PR DESCRIPTION
Simple change to 
- comment-out `\usepackage{svn}`
- replace titlepage use of svn-derived date by a constant date of last change (ie Sep 2012)

This will help with reproducible builds.