### PR TITLE
Insert argument offset before delimiter on newline

### DIFF
--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -2197,6 +2197,18 @@ otherwise nil."
                             (ess-climb-name)
                             (setq finished t))))))))
 
+(defadvice newline-and-indent (around ess-newline-and-indent)
+  ad-do-it
+  (when (and (eq major-mode 'ess-mode)
+             (string= ess-dialect "R")
+             (looking-at ")")
+             (ess-point-in-call-p)
+             (save-excursion
+               (ess-skip-blanks-backward t)
+               (eq (char-before) ?,)))
+    (let ((offset (ess-offset 'arguments)))
+      (insert (make-string offset ? )))))
+
 
 ;;;*;;; Predefined indentation styles
 


### PR DESCRIPTION
A huge frustration of mine when I write R code is that `(newline-and-indent)` inside a call rarely does what I want. The advice in that PR fixes that.

It adds an offset only when:
* point is in a call
* the char after point is a `)`
* the line ends with a `,` so we know a new argument is incoming

This way, a newline at:
```r
  fun_call(argument,|)
```
produces:
```r
fun_call(argument,
  |)
```
instead of:
```r
fun_call(argument,
|)
```

Do we need to add a setting to turn this advice off, in case this would interfere with other package or user advices?