### PR TITLE
Update Makefile

### DIFF
--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -51,7 +51,7 @@ ELC = $(CORE) ess-comp.elc ess-custom.elc \
 	ess-eldoc.elc ess-roxy.elc ess-rutils.elc ess-r-completion.elc \
 	ess-s-l.elc ess-s3-d.elc ess-s4-d.elc \
 	ess-sp3-d.elc ess-sp4-d.elc ess-sp5-d.elc ess-sp6-d.elc \
-	ess-rdired.elc ess-r-args.elc ess-r-d.elc ess-rd.elc \
+	ess-rdired.elc ess-r-args.elc ess-r-syntax.elc ess-r-d.elc ess-rd.elc \
 	ess-developer.elc ess-tracebug.elc ess-julia.elc\
 	julia-mode.elc\
 	ess-sp6w-d.elc msdos.elc


### PR DESCRIPTION
There is an error for user relying on Makefile to install ESS on their system. The file ess-r-syntax.el need to be compiled to solve this problem on my setup. Someone can confirm that this change solves this problem and doesn't break anything ?