### PR TITLE
names -> fieldnames in Julia 0.4.

### DIFF
--- a/etc/ess-julia.jl
+++ b/etc/ess-julia.jl
@@ -27,7 +27,7 @@ function fun_args(m::Method)
     e = Base.uncompressed_ast(li)
     argnames = e.args[1]
     print(io, "(")
-    print_joined(io, [isempty(d[2]) ? d[1] : d[1]*"::"*d[2] for d in decls], ",", ",")    
+    print_joined(io, [escape_string(isempty(d[2]) ? d[1] : d[1]*"::"*d[2]) for d in decls], ",", ",")    
     print(io, ")")
 end 
 

--- a/etc/ess-julia.jl
+++ b/etc/ess-julia.jl
@@ -1,4 +1,5 @@
 module ESS
+using Compat
 
 function all_help_topics()
     Base.Help.init_help()
@@ -12,8 +13,9 @@ function all_help_topics()
 end
 
 function help(topic::AbstractString)
-    ##Base.Help.help(topic) ## v0.3 and earlier?
-    eval(current_module(), parse("@doc $topic")) ##v0.4
+    VERSION >= v"0.4-" ?
+    eval(current_module(), parse("@doc $topic")) :
+    Base.Help.help(topic)
 end    
 
 ## modified version of function show(io::IO, m::Method)
@@ -31,25 +33,25 @@ function fun_args(m::Method)
     print(io, ")")
 end 
 
+VERSION >= v"0.4-" && (Base.function_module(f::Function)=f.env.module)
+
 ## modified versionof show(io::IO, mt::MethodTable)
 function fun_args(f::Function)
     mt = f.env
-    mod = mt.module
+    mod = Base.function_module(f)
     if mod == Main
         mod = "nil"
     end 
     print("(list \"$mod\" nil '(")
     d = mt.defs
-    while d != nothing
+    while d != nothing && d != ()
         print("\"")
         ## method
         fun_args(d)
         print("\" ")
         d = d.next
-        if d == nothing
-            print("))")
-        end
     end
+    print("))")
 end
 
 function fun_args(s::ASCIIString)

--- a/etc/ess-julia.jl
+++ b/etc/ess-julia.jl
@@ -65,7 +65,7 @@ end
 
 function fun_args(t::DataType)
     print("(list nil nil '(")
-    for d = names(t)
+    for d = fieldnames(t)
         print("\"$d\" ")
     end
     print("))")
@@ -83,7 +83,7 @@ function components(m::Module)
 end
 
 function components(t::DataType)
-    for v in sort(names(t))
+    for v in sort(fieldnames(t))
         println(rpad(string(v), 30), "field")
     end
 end


### PR DESCRIPTION
Fixed another Julia v0.4 compatibility issue.