### PR TITLE
Put Info node as subtopic for the Emacs menu

### DIFF
--- a/doc/info/dir
+++ b/doc/info/dir
@@ -14,5 +14,6 @@ File: dir,	Node: Top,	This is the top of the INFO tree
 
 * Menu:
 
+Emacs
 * ESS: (ess).	Emacs Speaks Statistics
 		(S/S+/R, SAS, BUGS, Stata, XLisp-Stat).


### PR DESCRIPTION
This commit puts the ESS Info documentation in the Emacs group instead of leaving it floating around in the directory node. It'll look like this:

```
Emacs
* ESS: (ess).	                Emacs Speaks Statistics
		                          (S/S+/R, SAS, BUGS, Stata, XLisp-Stat).
* Org Mode: (org).              Outline-based notes management and organizer
* Emacs: (emacs).               The extensible self-documenting text editor.
* Emacs FAQ: (efaq).            Frequently Asked Questions about Emacs.
...
```