### PR TITLE
Add autoloads for R-mode and opening *.R files

### DIFF
--- a/ess-autoloads.el
+++ b/ess-autoloads.el
@@ -54,6 +54,9 @@ Optional prefix (C-u) allows to set command line arguments, such as
 If you have certain command line arguments that should always be passed
 to R, put them in the variable `inferior-R-args'." t)
 
+(autoload 'R-mode "ess-site.el" "Major mode for editing R source." t)
+(add-to-list 'auto-mode-alist '("\\.R$" . R-mode))
+
 (autoload 'S "ess-site" "Call 'S'." t)
 
  ; Local variables section


### PR DESCRIPTION
With this you should just be able to install ess via `package.el` and it all "just work" when you open an R file.

Hopefully fixes #42 

I tested it by building the ess package with melpa and loading it, and it worked nicely.