### PR TITLE
Update .rutils.help.start() to match R's help.start()

### DIFF
--- a/etc/ess-rutils-help-start.R
+++ b/etc/ess-rutils-help-start.R
@@ -1,15 +1,14 @@
 ## Hacked help.start() to use with ess-rutils.el
 .rutils.help.start <- function (update=FALSE, remote=NULL) {
     home <- if (is.null(remote)) {
-        if (tools:::httpdPort == 0L)
-            tools::startDynamicHelp()
-        if (tools:::httpdPort > 0L) {
-            if (update)
-                make.packages.html()
-            paste("http://127.0.0.1:", tools:::httpdPort, sep="")
-        }
-        else stop(".rutils.help.start() requires the HTTP server to be running",
-                  call.=FALSE)
-    } else remote
-    paste(home, "/doc/html/index.html", sep="")
+                port <- tools::startDynamicHelp(NA)
+                if (port > 0L) {
+                    if (update)
+                        make.packages.html(temp=TRUE)
+                    paste0("http://127.0.0.1:", port)
+                }
+                else stop(".rutils.help.start() requires the HTTP server to be running",
+                          call.=FALSE)
+            } else remote
+    paste0(home, "/doc/html/index.html")
 }


### PR DESCRIPTION
R's `help.start()` has changed considerably, so our modified version was
lagging behind for a few releases. This only affects the RUtils package.