### PR TITLE
Support filling Roxygen blocks that contain backtick characters

### DIFF
--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -741,8 +741,8 @@ list of strings."
          (paragraph-start (concat "\\(" ess-roxy-re "\\(" paragraph-start
                                   "\\|[ \t]*@" "\\)" "\\)\\|\\(" paragraph-start "\\)"))
          (temp-table (if ,examples
-			 (make-syntax-table S-syntax-table)
-		       Rd-mode-syntax-table)))
+                         (make-syntax-table S-syntax-table)
+                       Rd-mode-syntax-table)))
      (when ,examples
        ;; Prevent the roxy prefix to be interpreted as comment or string
        ;; starter

--- a/test/literate/roxy.R
+++ b/test/literate/roxy.R
@@ -79,9 +79,11 @@ NULL
 ### 3 ----------------------------------------------------------------
 
 ##' @param¶ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor `incididunt' ut labore et ``dolore'' magna aliqua.
+NULL
 
 ##! (fill-paragraph)
 
 ##' @param¶ Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 ##'     sed do eiusmod tempor `incididunt' ut labore et ``dolore''
 ##'     magna aliqua.
+NULL

--- a/test/literate/roxy.R
+++ b/test/literate/roxy.R
@@ -78,20 +78,10 @@ NULL
 
 ### 3 ----------------------------------------------------------------
 
-##' Title
-##'
 ##' @param¶ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor `incididunt' ut labore et ``dolore'' magna aliqua.
-##' @param Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-NULL
 
 ##! (fill-paragraph)
 
-##' Title
-##'
 ##' @param¶ Lorem ipsum dolor sit amet, consectetur adipiscing elit,
 ##'     sed do eiusmod tempor `incididunt' ut labore et ``dolore''
 ##'     magna aliqua.
-##' @param Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-##'     sed do eiusmod tempor incididunt ut labore et dolore magna
-##'     aliqua.
-NULL

--- a/test/literate/roxy.R
+++ b/test/literate/roxy.R
@@ -74,3 +74,24 @@ NULL
 
 ##'
 ##' ¶
+
+
+### 3 ----------------------------------------------------------------
+
+##' Title
+##'
+##' @param¶ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor `incididunt' ut labore et ``dolore'' magna aliqua.
+##' @param Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+NULL
+
+##! (fill-paragraph)
+
+##' Title
+##'
+##' @param¶ Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+##'     sed do eiusmod tempor `incididunt' ut labore et ``dolore''
+##'     magna aliqua.
+##' @param Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+##'     sed do eiusmod tempor incididunt ut labore et dolore magna
+##'     aliqua.
+NULL


### PR DESCRIPTION
I've run the tests and it didn't seem to break anything.