### PR TITLE
Differentiate checking from testing

### DIFF
--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -213,7 +213,7 @@ Root is determined by locating `ess-r-package-root-file'."
   "Interface for `devtools::check()'."
   (interactive "P")
   (ess-r-package-send-process "devtools::check(%s)\n"
-                              "Testing %s"
+                              "Checking %s"
                               (when alt "vignettes = FALSE")))
 
 (defun ess-r-devtools-test-package (&optional alt)


### PR DESCRIPTION
Minor modification, use message "Checking" instead of "Testing" when using devtools::check().

Thanks for adding this devtools integration!