### PR TITLE
Fixes git tag for new release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ tag:
 	git tag -a -m'release tagging' v$(ESSVERSION)
 	 #svn cp -m'release tagging' $(SVN_URL)/trunk $(SVN_URL)/tags/$(ESSVERSION)
 	@echo '** Pushing the 	v$(ESSVERSION)  upstream ...'
-	git push
+	git push v$(ESSVERSION)
 
 homepage:
 	@echo "** Updating ESS Webpage **"


### PR DESCRIPTION
By default git push doesn't push new tags. This is why the last release wasn't pushed to MELPA-stable (see #356) 