### PR TITLE
Passing data via MPI

### DIFF
--- a/etc/ESSR/R/mpi.R
+++ b/etc/ESSR/R/mpi.R
@@ -17,4 +17,7 @@
     .ess_mpi_send("eval", expr, callback)
 }
 
+.ess_mpi_error <- function(msg, ...) {
+    .ess_mpi_send("error", sprintf(msg, ...))
+}
 

--- a/etc/ESSR/R/mpi.R
+++ b/etc/ESSR/R/mpi.R
@@ -21,3 +21,11 @@
     .ess_mpi_send("error", sprintf(msg, ...))
 }
 
+.ess_mpi_data <- function(data) {
+    if (!is.character(data)) {
+        .ess_mpi_error("MPI expected character vector")
+    } else {
+        data <- paste(data, collapse = "")
+        .ess_mpi_send("data", data)
+    }
+}

--- a/etc/ESSR/R/pkg.R
+++ b/etc/ESSR/R/pkg.R
@@ -1,0 +1,25 @@
+
+.ess_keep <- function(.x, .f, ...) {
+  is_true <- vapply(.x, .f, logical(1), ...)
+  .x[is_true]
+}
+
+.ess_devtools_functions <- function() {
+  if (!requireNamespace("devtools")) {
+    .ess_mpi_error("devtools is not installed")
+  }
+  devtools_env <- asNamespace("devtools")
+  exports <- getNamespaceExports("devtools")
+  funs_exported <- as.list(devtools_env)[exports]
+
+  is_first_arg <- function(f, arg) {
+    args <- names(formals(f))
+    length(args) && args[[1]] == arg
+  }
+
+  funs_pkg <- .ess_keep(funs_exported, is.function)
+  funs_pkg <- .ess_keep(funs_pkg, is_first_arg, "pkg")
+  funs_names <- sort(names(funs_pkg))
+
+  .ess_mpi_data(funs_names)
+}

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -318,48 +318,13 @@ Default location is determined by `ess-r-package-library-path'."
          (path (read-directory-name "Path: " default-path)))
     (ess-eval-linewise (format command path))))
 
-;; # R code for fetching all pkg functions:
-;;
-;; library("purrr")
-;;
-;; devtools_env <- asNamespace("devtools")
-;; exports <- getNamespaceExports("devtools")
-;; funs_exported <- as.list(devtools_env)[exports]
-;;
-;; is_first_arg <- function(f, arg) {
-;;   args <- names(formals(f))
-;;   length(args) && args[[1]] == arg
-;; }
-;;
-;; funs_pkg <- funs_exported %>%
-;;   keep(is.function) %>%
-;;   keep(is_first_arg, "pkg") %>%
-;;   names() %>%
-;;   sort()
-;;
-;; funs_pkg_list <- paste0("\"", funs_pkg, "\"", collapse = " ")
-;; cat(funs_pkg_list, "\n")
-
-(defvar ess-r-devtools-package-functions
-  '("bash" "build" "build_vignettes" "build_win" "check" "check_man" "clean_dll"
-    "clean_vignettes" "compile_dll" "dev_package_deps" "document" "imports_env"
-    "install" "install_deps" "install_dev_deps" "lint" "load_all" "load_code"
-    "load_data" "load_dll" "missing_s3" "ns_env" "package_deps" "parse_ns_file"
-    "pkg_env" "release" "release_checks" "reload" "revdep" "revdep_check"
-    "revdep_check_print_problems" "revdep_check_reset" "revdep_check_resume"
-    "revdep_check_save_summary" "revdep_email" "revdep_maintainers"
-    "run_examples" "show_news" "spell_check" "submit_cran" "test" "uninstall"
-    "unload" "use_appveyor" "use_code_of_conduct" "use_coverage"
-    "use_cran_badge" "use_cran_comments" "use_data_raw" "use_dev_version"
-    "use_github_links" "use_mit_license" "use_news_md" "use_package_doc"
-    "use_rcpp" "use_readme_md" "use_readme_rmd" "use_revdep" "use_rstudio"
-    "use_testthat" "use_travis" "uses_testthat" "wd"))
-
 (defun ess-r-devtools-ask (&optional alt)
   "Asks with completion for a devtools command.
 When called with prefix, also asks for additional arguments."
   (interactive "P")
-  (let* ((fun (completing-read "Function: " ess-r-devtools-package-functions))
+  (ess-force-buffer-current "Process to use: ")
+  (let* ((devtools-funs (car (ess-data-command ".ess_devtools_functions()\n")))
+         (fun (completing-read "Function: " devtools-funs))
          (command (format "devtools::%s(%s)\n" fun "%s")))
     (ess-r-package-send-process command
                                 (format "Running %s" fun)

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -318,6 +318,53 @@ Default location is determined by `ess-r-package-library-path'."
          (path (read-directory-name "Path: " default-path)))
     (ess-eval-linewise (format command path))))
 
+;; # R code for fetching all pkg functions:
+;;
+;; library("purrr")
+;;
+;; devtools_env <- asNamespace("devtools")
+;; exports <- getNamespaceExports("devtools")
+;; funs_exported <- as.list(devtools_env)[exports]
+;;
+;; is_first_arg <- function(f, arg) {
+;;   args <- names(formals(f))
+;;   length(args) && args[[1]] == arg
+;; }
+;;
+;; funs_pkg <- funs_exported %>%
+;;   keep(is.function) %>%
+;;   keep(is_first_arg, "pkg") %>%
+;;   names() %>%
+;;   sort()
+;;
+;; funs_pkg_list <- paste0("\"", funs_pkg, "\"", collapse = " ")
+;; cat(funs_pkg_list, "\n")
+
+(defvar ess-r-devtools-package-functions
+  '("bash" "build" "build_vignettes" "build_win" "check" "check_man" "clean_dll"
+    "clean_vignettes" "compile_dll" "dev_package_deps" "document" "imports_env"
+    "install" "install_deps" "install_dev_deps" "lint" "load_all" "load_code"
+    "load_data" "load_dll" "missing_s3" "ns_env" "package_deps" "parse_ns_file"
+    "pkg_env" "release" "release_checks" "reload" "revdep" "revdep_check"
+    "revdep_check_print_problems" "revdep_check_reset" "revdep_check_resume"
+    "revdep_check_save_summary" "revdep_email" "revdep_maintainers"
+    "run_examples" "show_news" "spell_check" "submit_cran" "test" "uninstall"
+    "unload" "use_appveyor" "use_code_of_conduct" "use_coverage"
+    "use_cran_badge" "use_cran_comments" "use_data_raw" "use_dev_version"
+    "use_github_links" "use_mit_license" "use_news_md" "use_package_doc"
+    "use_rcpp" "use_readme_md" "use_readme_rmd" "use_revdep" "use_rstudio"
+    "use_testthat" "use_travis" "uses_testthat" "wd"))
+
+(defun ess-r-devtools-ask (&optional alt)
+  "Asks with completion for a devtools command.
+When called with prefix, also asks for additional arguments."
+  (interactive "P")
+  (let* ((fun (completing-read "Function: " ess-r-devtools-package-functions))
+         (command (format "devtools::%s(%s)\n" fun "%s")))
+    (ess-r-package-send-process command
+                                (format "Running %s" fun)
+                                alt)))
+
 
 ;;;*;;; Minor Mode
 

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -1145,8 +1145,12 @@ Kill the *ess.dbg.[R_name]* buffer."
 
 (defvar ess-mpi-alist
   '(("message" . message)
+    ("error" . ess-mpi:error)
     ("eval" . ess-mpi:eval)
     ("y-or-n" . ess-mpi:y-or-n)))
+
+(defun ess-mpi:error (msg)
+  (message (format "Error in inferior: %s" msg)))
 
 (defun ess-mpi:eval (expr &optional callback)
   "Evaluate EXP as emacs expression.

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -1146,6 +1146,7 @@ Kill the *ess.dbg.[R_name]* buffer."
 (defvar ess-mpi-alist
   '(("message" . message)
     ("error" . ess-mpi:error)
+    ("data" . ess-mpi:data)
     ("eval" . ess-mpi:eval)
     ("y-or-n" . ess-mpi:y-or-n)))
 
@@ -1168,9 +1169,18 @@ value from EXPR and then sent to the subprocess."
     (when callback
       (ess-send-string (ess-get-process) (format callback result)))))
 
+(define-error 'ess-mpi-data "MPI data")
+(defun ess-mpi:data (&rest data)
+  "Signal that DATA should be returned from the MPI handlers."
+  (signal 'ess-mpi-data data))
+
 (defun ess-mpi-handle-messages (buf)
-  "Handle all mpi messages in BUF and delete them."
-  (let ((obuf (current-buffer)))
+  "Handle all mpi messages in BUF and delete them.
+Returns a list of elements sent to ESS via `.ess_mpi_data()'. The
+list is as long as the number of times the data MPI handler is
+called (typically only once)."
+  (let ((obuf (current-buffer))
+        output-data)
     (with-current-buffer buf
       (goto-char (point-min))
       ;; This should be smarter because emacs might cut it in the middle of the
@@ -1186,12 +1196,14 @@ value from EXPR and then sent to the subprocess."
               (condition-case-unless-debug err
                   (with-current-buffer obuf
                     (apply handler payload))
+                (ess-mpi-data (push (cdr err) output-data))
                 (error (message (format "Error in mpi `%s' handler: %%s" head)
                                 (error-message-string err))))
-            ;; don't throw error here. The buffer must be cleaned first.
+            ;; Don't throw error here. The buffer must be cleaned first.
             (message "Now handler defined for MPI message '%s" head))
           (goto-char mbeg)
-          (delete-region mbeg mend))))))
+          (delete-region mbeg mend))))
+    output-data))
 
 (defun ess--flush-process-output-cache (proc)
   (let ((pbuf (get-buffer-create (process-get proc 'accum-buffer-name))))


### PR DESCRIPTION
@vspinu could you check the approach here?

This adds an MPI handler to pass data from R, and `ess-data-command` to retrieve it.

I use these facilities to prompt for a devtools command with completion. The completion set is dynamically populated from all devtools functions taking `pkg` as argument.