### PR TITLE
Add functions for pipes

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1960,6 +1960,33 @@ for `ess-eval-region'."
         (forward-line 1)
       (ess-next-code-line 1))))
 
+(defun ess-beginning-of-pipe-or-end-of-line ()
+  "Find point position of end of line or beginning of pipe %>%"
+  (if (search-forward "%>%" (line-end-position) t)
+      (let ((pos (progn
+                   (beginning-of-line)
+                   (search-forward "%>%" (line-end-position))
+                   (backward-char 3)
+                   (point))))
+        (goto-char pos))
+    (end-of-line)))
+
+(defun ess-eval-pipe-through-line (vis)
+  "Like `ess-eval-paragraph' but only evaluates up to the pipe on this line.
+
+If no pipe, evaluate paragraph through the end of current line.
+
+Prefix arg VIS toggles visibility of ess-code as for `ess-eval-region'."
+  (interactive "P")
+  (save-excursion
+    (let ((end (progn
+                 (ess-beginning-of-pipe-or-end-of-line)
+                 (point)))
+          (beg (progn (backward-paragraph)
+                      (ess-skip-blanks-forward 'multiline)
+                      (point))))
+      (ess-eval-region beg end vis))))
+
  ; Inferior S mode
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; In this section:

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -83,6 +83,7 @@
     (define-key map "\C-c\C-j"   'ess-eval-line)
     (define-key map [(control return)] 'ess-eval-region-or-line-and-step)
     (define-key map "\C-c\M-j"   'ess-eval-line-and-go)
+    (define-key map (kbd "C-|")  'ess-eval-pipe-through-line)
     ;; the next three can only work in S/R - mode {FIXME}
     (define-key map "\C-\M-a"    'ess-goto-beginning-of-function-or-para)
     (define-key map "\C-\M-e"    'ess-goto-end-of-function-or-para)


### PR DESCRIPTION
I oftentimes run into the situation where I have a pipe:

```R
library(tidyverse)
mtcars %>%
  group_by(cyl) %>% 
  summarize(mean = mean(mpg),
|           n = n()) %>%
    filter(cyl > 4)
```

where `|` represents point and I only want to evaluate the pipe through that line. C-RET only evals that line and C-c C-c evals the whole paragraph. This is a function I came up with to help out with that situation. Hopefully someone else finds it useful. 

I also bound it to C-|