### PR TITLE
fixed: .ess_mpi_send called with unescaped percents, sprintf error

### DIFF
--- a/etc/ESSR/R/mpi.R
+++ b/etc/ESSR/R/mpi.R
@@ -5,8 +5,8 @@
     cat(sprintf("%s%s", head, payload))
 }
 
-.ess_mpi_message <- function(msg, ...){
-    .ess_mpi_send("message", sprintf(msg, ...))
+.ess_mpi_message <- function(msg){
+    .ess_mpi_send("message", msg)
 }
 
 .ess_mpi_y_or_n <- function(prompt, callback){
@@ -17,7 +17,7 @@
     .ess_mpi_send("eval", expr, callback)
 }
 
-.ess_mpi_error <- function(msg, ...) {
-    .ess_mpi_send("error", sprintf(msg, ...))
+.ess_mpi_error <- function(msg) {
+    .ess_mpi_send("error", msg)
 }
 


### PR DESCRIPTION
[`.ess_mpi_message`](https://github.com/emacs-ess/ESS/blob/1e3944954fa84cf38ba5ad00bce5086bb1577882/etc/ESSR/R/mpi.R#L8-L10) is defined with two arguments: `msg` and ellipses `...`. In [`.ess.ns_source`](https://github.com/emacs-ess/ESS/blob/c83eed18866e3a14e75c3faf3028edca97cd1359/etc/ESSR/R/ns-eval.R#L246) (and in `debug.R`) it is being called with just the first, thereby breaking the call to `sprintf` when a function includes a percent sign:

```r
[mypkg] Sourced file /path/to/helperfuncs.R
Error in sprintf(msg, ...) : too few arguments
```

This is being triggered when I source a package-file that defines a SPECIAL function that has braces (sounds odd). I get the error with:

```r
`%||%` <- function(x, y) { if (is.null(x)) y else x ; }
```

but no error with:

```r
`%||%` <- function(x, y) if (is.null(x)) y else x
```

The problem is in the assignment to `msgs` in `.ess.ns_source`, where the special function name (`%==%`) retains the unescaped percents.

This patch changes the `.ess_mpi_message` and `.ess_mpi_error` functions so that they do not attempt to use `sprintf`. I could not find any call to `.ess_mpi_message` (or `_error`) that makes use of anything beyond the first argument.

Alternatives:

- in `.ess_mpi_send`, augment `payload <- paste(.., sep = "^^")` with `payload <- gsub("%", "%%", payload)` (though, if `.ess_mpi_message` still uses `.ess_mpi_send("message", sprintf(msg, ...))`, you'll still have problems, so it should probably be done before `.ess_mpi_send`
- escape percents in `msg` in both `_message` and `_error`