### PR TITLE
fix for startup issues. closes #387

### DIFF
--- a/lisp/ess-r-d.el
+++ b/lisp/ess-r-d.el
@@ -481,8 +481,8 @@ Executed in process buffer."
   ;; carefully set "pager" option  "when needed":
   (ess-eval-linewise
    (format
-    "if(identical(getOption('pager'), file.path(R.home('bin'), 'pager'))) # rather take the ESS one
-      options(pager='%s')\n" inferior-ess-pager)
+    "if(identical(getOption('pager'), file.path(R.home('bin'), 'pager'))) options(pager='%s') # rather take the ESS one \n"
+    inferior-ess-pager)
    ;; Even more careful / sophisticated :
    ;;  "if(identical(getOption('pager'), file.path(R.home('bin'), 'pager')) &&
    ;;  grepl('\\<more\\>', .P <- Sys.getenv('PAGER'))) {  # rather take the ESS one


### PR DESCRIPTION
this change fixes the startup issue of #387 reported [here](https://emacs.stackexchange.com/questions/28382/ess-freezes-on-startup-with-ess-tracebug-mode-enabled) too. I don't know why (no experience with lisp/ess machinery) but now it works again.

I know it could break max line characters rules (OTOH makes ESS usable again). i've tried removing the R comment only but without success; the only way (i've found) was to put `if` and `options` on the same line..

best, Luca

