### PR TITLE
Provide feature ess-rd in library ess-rd.el

### DIFF
--- a/lisp/ess-rd.el
+++ b/lisp/ess-rd.el
@@ -537,6 +537,8 @@ temporary one in `temporary-file-directory'.
 
 
 ;; Provide ourself
+(provide 'ess-rd)
+;; Legacy feature
 (provide 'essddr)
 
 ;; ess-rd.el ends here


### PR DESCRIPTION
Previously ess-rd.el only provided the mismatched essddr.  To play it
safe this only adds the ess-rd feature, without removing the essddr
feature.