### PR TITLE
Provide better display format for "size" in rdired

### DIFF
--- a/lisp/ess-rdired.el
+++ b/lisp/ess-rdired.el
@@ -91,7 +91,7 @@
   length <- sapply(objs, function(my.x) {
     eval( parse( text=sprintf('length(get(\"%s\"))', my.x))) })
   size <- sapply(objs, function(my.x) {
-    eval( parse( text=sprintf('object.size(get(\"%s\"))', my.x))) })
+    eval( parse( text=sprintf('format(object.size(get(\"%s\")), units=\"auto\")', my.x))) })
   d <- data.frame(mode, length, size)
 
   var.names <- row.names(d)


### PR DESCRIPTION
Wrap size display in `format(object.size(), units="auto")`, so that object sizes for data.frames are displayed in "xxx Mb" or "xxx Gb" by default.