### PR TITLE
julia: set EDITOR environment variable to emacsclient

### DIFF
--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -409,6 +409,7 @@ to julia, put them in the variable `inferior-julia-args'."
       (add-hook 'completion-at-point-functions 'ess-julia-object-completion nil 'local)
       (add-hook 'completion-at-point-functions 'ess-filename-completion nil 'local)
       (setq comint-input-sender 'ess-julia-input-sender)
+      (setenv "EDITOR" ess-editor)
 
       (ess--tb-start)
       (set (make-local-variable 'ess-julia-basic-offset) 4)


### PR DESCRIPTION
Trivial one-liner, but it makes `@edit sin(pi)` do the job (without, the EDITOR variable is unset and it calls nano, which messes with the terminal)