### PR TITLE
remove unmatched parenthesis from julia logo

### DIFF
--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -416,6 +416,11 @@ to julia, put them in the variable `inferior-julia-args'."
       (goto-char (point-min))
       (while (re-search-forward "`" nil t)
         (replace-match "'"))
+      ;; remove an offending unmatched parenthesis
+      (goto-char (point-min))
+      (forward-line 4)
+      (when (re-search-forward "(" nil t)
+        (replace-match "|"))
       (goto-char (point-max))
       ;; --> julia helpers from ../etc/ess-julia.jl :
       (ess--inject-code-from-file (format "%sess-julia.jl" ess-etc-directory))


### PR DESCRIPTION
Julia's logo has an unmatched parenthesis, which wrecks havoc with modes like autopair. This removes it.