### PR TITLE
fix latexsub completion

### DIFF
--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -119,8 +119,11 @@ VISIBLY is not currently used."
 
 ;;; COMPLETION
 (defun ess-julia-latexsub-completion ()
-  "Return completions for latex input in a format required by `completion-at-point-functions'."
-  #'julia-latexsub)
+  "Complete latex input, and returns in a format required by `completion-at-point-functions'."
+  (if (julia-latexsub) ; julia-latexsub returns nil if it performed a completion, the point otherwise
+      nil
+    (lambda () t) ;; bypass other completion methods
+    ))
 
 (defun ess-julia-object-completion ()
   "Return completions at point in a format required by `completion-at-point-functions'. "


### PR DESCRIPTION
As it turns out, https://github.com/emacs-ess/ESS/pull/420 was wrong and broke completion. completion-at-point-functions has a weird interface! This should hopefully fix it.