### PR TITLE
replace ASCIIString with AbstractString in julia module

### DIFF
--- a/etc/ess-julia.jl
+++ b/etc/ess-julia.jl
@@ -18,39 +18,34 @@ function fun_args(m::Method)
     if !isempty(tv)
         Base.show_delim_array(io, tv, '{', ',', '}', false)
     end
-    li = m.func.code
-    e = Base.uncompressed_ast(li)
-    argnames = e.args[1]
     print(io, "(")
-    print_joined(io, [escape_string(isempty(d[2]) ? d[1] : d[1]*"::"*d[2]) for d in decls], ",", ",")    
+    join(io, [escape_string(isempty(d[2]) ? d[1] : d[1]*"::"*d[2]) for d in decls], ",", ",")    
     print(io, ")")
 end 
 
-VERSION >= v"0.4-" && (Base.function_module(f::Function)=f.env.module)
+VERSION >= v"0.4-" && (Base.function_module(f::Function)=typeof(f).name.module)
 
 ## modified versionof show(io::IO, mt::MethodTable)
 function fun_args(f::Function)
-    mt = f.env
+    mt = Base.MethodList(methods(f).mt)
     mod = Base.function_module(f)
     if mod == Main
         mod = "nil"
     end 
     print("(list \"$mod\" nil '(")
-    d = mt.defs
-    while d != nothing && d != ()
+    for d in mt
         print("\"")
         ## method
         fun_args(d)
         print("\" ")
-        d = d.next
     end
     print("))")
 end
 
-function fun_args(s::ASCIIString)
+function fun_args(s::AbstractString)
     try
         m = eval(current_module(), parse(s))
-        if typeof(m) != ASCIIString
+        if ! isa(m, String)
             fun_args(m)
         end
     catch


### PR DESCRIPTION
Replaces ASCIIString with AbstractString in the julia module.
ASCIIString is gone from v0.6, so the completion module stopped
working.  Eldoc still seems not to work. -- #441 