### PR TITLE
Update essd-els.el: remote-inferior-ess-pager

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -836,8 +836,8 @@ Returns the name of the selected process."
   (setq ess-dialect (or ess-dialect
                         (ess-completing-read
                          "Set `ess-dialect'"
-                         (delete-dups (list "R" "S+" S+-dialect-name
-                                            "stata" STA-dialect-name
+                         (delete-dups (list "R" "S+" (if (boundp 'S+-dialect-name) S+-dialect-name "S+")
+                                            "stata" (if (boundp 'STA-dialect-name) STA-dialect-name "stata")
                                             "julia" "SAS" "XLS"  "ViSta")))))
 
   (let* ((pname-list (delq nil ;; keep only those mathing dialect

--- a/lisp/essd-els.el
+++ b/lisp/essd-els.el
@@ -161,7 +161,7 @@ buffer on the local computer."
       (add-to-list 'ess-process-name-list
                    (list ess-current-process-name)))))
 
-(defcustom remote-inferior-ess-pager "cat"
+(defcustom inferior-ess-remote-pager "cat"
   "Remote pager to use for reporting help files and similar things."
   :group 'ess-proc
   :type 'string)
@@ -203,7 +203,7 @@ DIALECT is the desired ess-dialect. If nil, ask for dialect"
 
     (when (equal ess-dialect "R")
       ;; ugly fix for evn variable. What can we do :(
-      (ess-eval-linewise (format "options(pager='%s')\n" remote-inferior-ess-pager)
+      (ess-eval-linewise (format "options(pager='%s')\n" (or inferior-ess-remote-pager inferior-ess-pager))
                          nil nil nil 'wait)
       (inferior-ess-r-load-ESSR))
 

--- a/lisp/essd-els.el
+++ b/lisp/essd-els.el
@@ -161,6 +161,11 @@ buffer on the local computer."
       (add-to-list 'ess-process-name-list
                    (list ess-current-process-name)))))
 
+(defcustom remote-inferior-ess-pager "cat"
+  "Remote pager to use for reporting help files and similar things."
+  :group 'ess-proc
+  :type 'string)
+
 (defvar ess-remote nil
   "Indicator, t in ess-remote buffers.")
 
@@ -198,7 +203,7 @@ DIALECT is the desired ess-dialect. If nil, ask for dialect"
 
     (when (equal ess-dialect "R")
       ;; ugly fix for evn variable. What can we do :(
-      (ess-eval-linewise (format "options(pager='%s')\n" inferior-ess-pager)
+      (ess-eval-linewise (format "options(pager='%s')\n" remote-inferior-ess-pager)
                          nil nil nil 'wait)
       (inferior-ess-r-load-ESSR))
 

--- a/lisp/essd-els.el
+++ b/lisp/essd-els.el
@@ -161,8 +161,9 @@ buffer on the local computer."
       (add-to-list 'ess-process-name-list
                    (list ess-current-process-name)))))
 
-(defcustom inferior-ess-remote-pager "cat"
-  "Remote pager to use for reporting help files and similar things."
+(defcustom inferior-ess-remote-pager nil
+  "Remote pager to use for reporting help files and similar things.
+The default value is nil."
   :group 'ess-proc
   :type 'string)
 


### PR DESCRIPTION
remote-inferior-ess-pager: If we work on Windows and SSH to a unix server, the pager should not be console (as default for Windows).