### PR TITLE
Only activate package mode in editing buffers

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -6,6 +6,10 @@ Changes and New Features in development version:
 
 @item ESS modes now inherit from @code{prog-mode}.
 
+@item @ESS{[R]}: The package development minor mode now only activates
+within editing buffers, i.e. ones that inherit from @code{prog-mode} or
+@code{text-mode}.
+
 @end itemize
 
 

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -426,9 +426,7 @@ disable the mode line entirely."
   "Activate developer if current file is part of a package."
   (when (and ess-r-package-auto-activate
              (derived-mode-p 'text-mode 'prog-mode)
-             (not (memq major-mode '(minibuffer-inactive-mode fundamental-mode)))
-             (or (buffer-file-name)
-                 default-directory))
+             (or (buffer-file-name) default-directory))
     ;; FIXME Emacs 25.1: Use `when-let'
     (let ((pkg-info (ess-r-package-project)))
       (when pkg-info

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -425,7 +425,7 @@ disable the mode line entirely."
 (defun ess-r-package-auto-activate ()
   "Activate developer if current file is part of a package."
   (when (and ess-r-package-auto-activate
-             (or (provided-mode-derived-p major-mode 'text-mode 'prog-mode))
+             (derived-mode-p 'text-mode 'prog-mode)
              (not (memq major-mode '(minibuffer-inactive-mode fundamental-mode)))
              (or (buffer-file-name)
                  default-directory))

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -425,6 +425,7 @@ disable the mode line entirely."
 (defun ess-r-package-auto-activate ()
   "Activate developer if current file is part of a package."
   (when (and ess-r-package-auto-activate
+             (or (provided-mode-derived-p major-mode 'text-mode 'prog-mode))
              (not (memq major-mode '(minibuffer-inactive-mode fundamental-mode)))
              (or (buffer-file-name)
                  default-directory))

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -51,7 +51,7 @@
 
 ;;; ess-r-package-mode
 
-(ert-deftest ess-r-package-auto-activate ()
+(ert-deftest ess-r-package-auto-activation ()
   (with-temp-buffer
     (text-mode)
     (hack-local-variables)
@@ -59,6 +59,12 @@
   (with-r-file "dummy-pkg/R/test.R"
     (hack-local-variables)
     (should ess-r-package-mode)))
+
+(ert-deftest ess-r-package-no-auto-activation ()
+  (with-r-file "dummy-pkg/R/test.R"
+    (eshell)
+    (should (not ess-r-package-mode))
+    (kill-buffer)))
 
 
 ;;; Namespaced evaluation


### PR DESCRIPTION
Closes #466 

With this patch `ess-r-package-mode` only auto-activates in editing buffers, i.e. ones whose major mode inherits from `text-mode` or `prog-mode`. Note that ESS modes now inherit from `prog-mode` since https://github.com/emacs-ess/ESS/commit/b439eb34ddaf01d336bd70c482436f665ea7cefe.

I agree with @mmaechler that this makes more sense. WDYT @vspinu?