### PR TITLE
Add an Xref backend for R mode

### DIFF
--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -44,6 +44,7 @@
 (require 'ess-r-completion)
 (require 'ess-r-syntax)
 (require 'ess-r-package)
+(when (>= emacs-major-version 25) (require 'ess-r-xref)) ;; Xref API was added in Emacs 25.1
 
 (ess-message "[ess-r-mode:] (require 'ess-s-lang)")
 (autoload 'ess-r-args-show      "ess-r-args" "(Autoload)" t)
@@ -566,6 +567,8 @@ will be prompted to enter arguments interactively."
     (remove-hook 'completion-at-point-functions 'ess-filename-completion 'local) ;; should be first
     (add-hook 'completion-at-point-functions 'ess-r-object-completion nil 'local)
     (add-hook 'completion-at-point-functions 'ess-filename-completion nil 'local)
+    (when (>= emacs-major-version 25)
+      (add-hook 'xref-backend-functions #'ess-r-xref-backend nil 'local))
     (setq comint-input-sender 'inferior-ess-r-input-sender)
 
     (if gdbp
@@ -613,6 +616,8 @@ Executed in process buffer."
   (remove-hook 'completion-at-point-functions 'ess-filename-completion 'local) ;; should be first
   (add-hook 'completion-at-point-functions 'ess-r-object-completion nil 'local)
   (add-hook 'completion-at-point-functions 'ess-filename-completion nil 'local)
+  (when (>= emacs-major-version 25)
+    (add-hook 'xref-backend-functions #'ess-r-xref-backend nil 'local))
 
   (if (fboundp 'ess-add-toolbar) (ess-add-toolbar))
   (when ess-imenu-use-S

--- a/lisp/ess-r-xref.el
+++ b/lisp/ess-r-xref.el
@@ -94,13 +94,66 @@ they are loaded via byte-compiled packages."
   (let ((cmd (format "cat(\"%s <- \"); print.function(%s)\n"
                      fn fn))
         (buff (get-buffer-create
-               (format "*definition[R]:%s*" fn))))
+               (format "*definition[R]:%s*" fn)))
+        (proc ess-local-process-name))
     (with-current-buffer (ess-command cmd buff)
-      ;; TODO: This should probably have its own bespoke mode, just using the
-      ;; syntax of `r-mode', so as to avoid pullin in all of ESS's hooks.
-      (r-mode)
-      (setq buffer-read-only t))
+      (ess-r-source-mode)
+      (setq-local ess-local-process-name proc))
     (list (xref-make (format "%s" fn) (xref-make-buffer-location buff 0)))))
+
+
+;;; R Function Source Viewer Mode
+
+(defun ess-r-xref--parse-byte-compiled-p (buff)
+  "Determine whether the R function printed in BUFF is byte-compiled.
+
+This also erases the metadata once the compilation status has
+been determined."
+  (with-current-buffer buff
+    (goto-char (point-max))
+    (when (re-search-backward "^<bytecode" nil 'noerror)
+      ;; Delete the metadata, if it's there.
+      (beginning-of-line)
+      (kill-whole-line)
+      t)))
+
+(defun ess-r-xref--parse-environment (buff)
+  "Determine the environment of the R function printed in BUFF.
+
+This also erases the metadata once the environment has been
+determined."
+  (with-current-buffer buff
+    (goto-char (point-max))
+    (let* ((found (re-search-backward "^<environment: \\(.*\\)>$" nil 'noerror))
+           (env (or (when found (match-string-no-properties 1)) ".GlobalEnv")))
+      ;; Delete the metadata, if it's there.
+      (when found (beginning-of-line) (kill-whole-line))
+      env)))
+
+;; Defined in ess-r-mode.
+(defvar ess-r-syntax-table)
+
+(defvar-local ess-r-source-byte-compiled-p nil
+  "Indicates whether the R function on display is byte-compiled.")
+
+(defvar-local ess-r-source-environment nil
+  "The environment the R function on display belongs to.")
+
+(define-derived-mode ess-r-source-mode special-mode "R Source"
+  "Major mode for navigating the source of local/byte-compiled R functions."
+  :syntax-table nil
+  (setq buffer-read-only nil)
+  ;; Use R's syntax table.
+  (set-syntax-table ess-r-syntax-table)
+  ;; Move metadata to the header line.
+  (let ((compiled (ess-r-xref--parse-byte-compiled-p (current-buffer)))
+        (env (ess-r-xref--parse-environment (current-buffer))))
+    (setq-local ess-r-source-byte-compiled-p compiled)
+    (setq-local ess-r-source-environment env)
+    (setq header-line-format
+          (concat "Environment: " env (when compiled " (byte-compiled)"))))
+  (add-hook 'xref-backend-functions #'ess-r-xref-backend nil 'local)
+  (setq buffer-read-only t))
 
 (provide 'ess-r-xref)
 

--- a/lisp/ess-r-xref.el
+++ b/lisp/ess-r-xref.el
@@ -1,0 +1,85 @@
+;;; ess-r-xref.el --- An xref backend for R. -*- lexical-binding: t -*-
+;;
+;; Author: Aaron Jacobs
+;; Created: 21 January 2018
+;; Maintainer: ESS-core <ESS-core@r-project.org>
+;;
+;; Keywords: languages, statistics, xref
+;; Package-Requires: ((emacs "25"))
+;;
+;; This file is part of ESS.
+;;
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; A copy of the GNU General Public License is available at
+;; http://www.r-project.org/Licenses/
+
+;;; Commentary:
+
+;; This file contains an xref backend for `R-mode'.
+
+;;; Code:
+
+(require 'subr-x)
+(require 'xref)
+(require 'ess)
+
+
+;;; Xref API
+
+(defun ess-r-xref-backend ()
+  "An `xref-backend-functions' implementation for `R-mode'."
+  'ess-r)
+
+(cl-defmethod xref-backend-identifier-at-point ((_backend (eql ess-r)))
+  (ess-symbol-at-point))
+
+(cl-defmethod xref-backend-definitions ((_backend (eql ess-r)) symbol)
+  (inferior-ess-r-force)
+  (when (ess-r-xref--exists symbol)
+    (if (ess-r-xref--has-srcfile symbol)
+        (ess-r-xref--find-srcfile symbol)
+      ;; TODO: Implement non-srcfile references.
+      nil)))
+
+
+;;; Source File Locations
+
+(defun ess-r-xref--exists (symbol)
+  "Check whether SYMBOL is a known R symbol."
+  (ess-boolean-command (format "exists(\"%s\")\n" symbol)))
+
+(defun ess-r-xref--has-srcfile (symbol)
+  "Checks that the R symbol SYMBOL has a valid source file reference.
+
+Most functions will not have source file references, either
+because they were sent to the interpreter directly, or because
+they are loaded via byte-compiled packages."
+  (ess-boolean-command
+   (format
+    "!is.null(utils::getSrcref(%s)) && file.exists(utils::getSrcFilename(%s))\n"
+    symbol symbol)))
+
+(defun ess-r-xref--find-srcfile (symbol)
+  "Creates an xref for the source file reference of R symbol SYMBOL."
+  (let ((file (ess-string-command
+               (format "cat(utils::getSrcFilename(%s)[1], \"\\n\")\n" symbol)))
+        (line (ess-string-command
+               (format "cat(utils::getSrcLocation(%s, which = \"line\")[1], \"\\n\")\n" symbol))))
+    (list (xref-make (format "%s" symbol)
+                     (xref-make-file-location
+                      (expand-file-name (string-trim file))
+                      (string-to-number line)
+                      0)))))
+
+(provide 'ess-r-xref)
+
+;;; ess-r-xref.el ends here

--- a/lisp/ess-r-xref.el
+++ b/lisp/ess-r-xref.el
@@ -53,8 +53,7 @@
   (inferior-ess-r-force)
   ;; Ignore non-functions.
   (when (ess-r-xref--fn-exists-p symbol)
-    (or (ess-r-xref--srcfile-xref symbol)
-        (ess-r-xref--body-xref symbol))))
+    (ess-r-xref--srcfile-xref symbol)))
 
 (cl-defmethod xref-backend-apropos ((_backend (eql ess-r)))
   ;; Not yet supported.
@@ -118,83 +117,6 @@ they are loaded via byte-compiled packages."
                           (expand-file-name fname) line 0)))))))
 
 
-;;; Local/Byte-compiled Locations
-
-(defun ess-r-xref--body-xref (symbol)
-  "Creates an xref to a buffer containing the body of the R function SYMBOL."
-  (let ((cmd (format "base::cat(\"%s <- \"); base::print.function(%s)\n"
-                     (if (listp symbol)
-                         (concat (car symbol) "::" (cadr symbol))
-                       symbol)
-                     (ess-r-xref--get-symbol symbol)))
-        (buff (get-buffer-create
-               (format "*definition[R]:%s*"
-                       (if (listp symbol)
-                           (concat (car symbol) "::" (cadr symbol))
-                         symbol))))
-        (proc ess-local-process-name))
-    (with-current-buffer (ess-command cmd buff)
-      (ess-r-source-mode)
-      (setq-local ess-local-process-name proc))
-    (list (xref-make (if (listp symbol)
-                         (concat (car symbol) "::" (cadr symbol))
-                       symbol)
-                     (xref-make-buffer-location buff 0)))))
-
-
-;;; R Function Source Viewer Mode
-
-(defun ess-r-xref--parse-byte-compiled-p (buff)
-  "Determine whether the R function printed in BUFF is byte-compiled.
-
-This also erases the metadata once the compilation status has
-been determined."
-  (with-current-buffer buff
-    (goto-char (point-max))
-    (when (re-search-backward "^<bytecode" nil 'noerror)
-      ;; Delete the metadata, if it's there.
-      (beginning-of-line)
-      (kill-whole-line)
-      t)))
-
-(defun ess-r-xref--parse-environment (buff)
-  "Determine the environment of the R function printed in BUFF.
-
-This also erases the metadata once the environment has been
-determined."
-  (with-current-buffer buff
-    (goto-char (point-max))
-    (let* ((found (re-search-backward "^<environment: \\(.*\\)>$" nil 'noerror))
-           (env (or (when found (match-string-no-properties 1)) ".GlobalEnv")))
-      ;; Delete the metadata, if it's there.
-      (when found (beginning-of-line) (kill-whole-line))
-      env)))
-
-;; Defined in ess-r-mode.
-(defvar ess-r-syntax-table)
-
-(defvar-local ess-r-source-byte-compiled-p nil
-  "Indicates whether the R function on display is byte-compiled.")
-
-(defvar-local ess-r-source-environment nil
-  "The environment the R function on display belongs to.")
-
-(define-derived-mode ess-r-source-mode special-mode "R Source"
-  "Major mode for navigating the source of local/byte-compiled R functions."
-  :syntax-table nil
-  (setq buffer-read-only nil)
-  ;; Use R's syntax table.
-  (set-syntax-table ess-r-syntax-table)
-  ;; Move metadata to the header line.
-  (let ((compiled (ess-r-xref--parse-byte-compiled-p (current-buffer)))
-        (env (ess-r-xref--parse-environment (current-buffer))))
-    (setq-local ess-r-source-byte-compiled-p compiled)
-    (setq-local ess-r-source-environment env)
-    (setq header-line-format
-          (concat "Environment: " env (when compiled " (byte-compiled)"))))
-  (add-hook 'xref-backend-functions #'ess-r-xref-backend nil 'local)
-  (setq buffer-read-only t))
-
 (provide 'ess-r-xref)
 
 ;;; ess-r-xref.el ends here


### PR DESCRIPTION
These changes implement the `xref` API for R mode, providing a "jump to definition" implementation for functions. R stores the source code location of functions that are read into the interpreter (via `source` or similar), so I use that when it's available. Otherwise, the function definition is dumped into a buffer with the special major mode `ess-r-source-mode`, which is a read-only mode with the same font lock as the other R modes. It also decorates the header with the namespace and byte compilation info, if that's appropriate.

I've set the hooks to enable the backend by default, so `M-.` and `M-,` should work out of the box in Emacs 25 and later.

I've read the discussion of this topic in #307, and while this implementation is not exactly what was envisioned there I believe it's broadly consistent, and would close #307.

The one outstanding issue I'm having is that `(set-syntax-table ess-r-syntax-table)` does not seem to be working correctly. I'd welcome any hypothesis as to why.

Any further comments or questions are welcome.