### PR TITLE
Remove cl

### DIFF
--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -38,14 +38,13 @@
  ; Requires and autoloads
 
 (eval-when-compile
+  (require 'cl-lib)
   (require 'tramp)
   (require 'reporter)
   (require 'ess-inf)
   (require 'info))
 
 (require 'ess-mode)
-;; We can't use cl-lib whilst supporting Emacs <= 24.2 users
-(with-no-warnings (require 'cl))
 
  ; ess-help-mode
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -53,7 +53,7 @@
         (when (featurep 'julia-mode)
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (autoload 'inferior-ess "ess-inf" "Run an ESS process.")
 (autoload 'ess-mode     "ess-mode" "Edit an ESS process.")

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -710,7 +710,7 @@ The default of `ess-tab-complete-in-script' is nil.  Also see
                      ))
         (if (>= emacs-major-version 24)
             (completion-at-point)
-          (comint-dynamic-complete)
+          (completion-at-point)
           )))))
 
 (defun ess-indent-exp ()

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -32,8 +32,8 @@
 
 ;;; Code:
 
-;; We can't use cl-lib whilst supporting Emacs <= 24.2 users
-(with-no-warnings (require 'cl))
+(eval-when-compile
+  (require 'cl-lib))
 (require 'ess-custom)
 (require 'ess-utils)
 (require 'ess-generics)

--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -30,7 +30,8 @@
 
 ;;; ElDoc
 
-(require 'cl)
+(eval-when-compile
+  (require 'cl-lib))
 (require 'ess-utils)
 
 (defun ess-r-eldoc-function ()

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -33,7 +33,8 @@
 
 ;;; Code:
 
-(with-no-warnings (require 'cl)) ; instead of cl-lib so we support Emacs 24.2
+(eval-when-compile
+  (require 'cl-lib))
 (require 'compile)
 (require 'easymenu)
 (require 'eldoc)
@@ -533,7 +534,7 @@ will be prompted to enter arguments interactively."
                  start-args)
                 ((and start-args
                       (listp start-args)
-                      (every 'stringp start-args))
+                      (cl-every 'stringp start-args))
                  (mapconcat 'identity start-args " "))
                 (start-args
                  (read-string
@@ -1594,7 +1595,8 @@ Returns nil if line starts inside a string, t if in a comment."
                      (when (ess-at-containing-sexp
                              (looking-at "{"))
                        (ess-escape-prefixed-block))))
-                   (some 'looking-at (ess-overridden-blocks)))
+                   (cl-some 'looking-at
+                            (ess-overridden-blocks)))
           (+ (current-column) offset))))))
 
 (defun ess-calculate-indent--block-relatively ()
@@ -1725,7 +1727,8 @@ Returns nil if line starts inside a string, t if in a comment."
          (override (and ess-align-arguments-in-calls
                         (save-excursion
                           (ess-climb-object)
-                          (some 'looking-at ess-align-arguments-in-calls))))
+                          (cl-some 'looking-at
+                                   ess-align-arguments-in-calls))))
          (type-sym (cond (block 'block)
                          ((looking-at "[[:blank:]]*[([][[:blank:]]*\\($\\|#\\)")
                           'arguments-newline)

--- a/lisp/ess-r-syntax.el
+++ b/lisp/ess-r-syntax.el
@@ -30,7 +30,8 @@
 (require 'ess-utils)
 (require 'regexp-opt)
 
-(with-no-warnings (require 'cl)) ; instead of cl-lib so we support Emacs 24.2
+(eval-when-compile
+  (require 'cl-lib))
 
 
 ;;*;; Utils
@@ -126,7 +127,7 @@ side-effects. FORMS follows the same syntax as arguments to
 `(cond)'."
   (declare (indent 0) (debug nil))
   `(let ((forms (list ,@(mapcar (lambda (form) `(progn ,@form)) forms))))
-     (some 'identity (mapcar 'eval forms))))
+     (cl-some 'identity (mapcar 'eval forms))))
 
 (defun ess-char-syntax (string)
   (char-to-string (char-syntax (string-to-char string))))
@@ -925,7 +926,7 @@ into account."
 (defun ess-behind-prefixed-block-p (&optional call)
   (if call
       (looking-at (concat call "[ \t]*("))
-    (some 'looking-at ess-prefixed-block-patterns)))
+    (cl-some 'looking-at ess-prefixed-block-patterns)))
 
 (defun ess-unbraced-block-p (&optional ignore-ifelse)
   "This indicates whether point is in front of an unbraced
@@ -937,7 +938,7 @@ position of the control flow function (if, for, while, etc)."
                   (not ignore-ifelse))
              (and (looking-at "(")
                   (ess-backward-sexp)
-                  (some 'looking-at ess-prefixed-block-patterns)
+                  (cl-some 'looking-at ess-prefixed-block-patterns)
                   (if ignore-ifelse
                       (not (looking-at "if\\b"))
                     t)))
@@ -1492,10 +1493,10 @@ without curly braces."
   (save-excursion
     (and (ess-behind-call-p)
          (ess-jump-inside-call)
-         (some (lambda (arg)
-                 (string-match "^function\\b"
-                               (cdr arg)))
-               (ess-args-alist)))))
+         (cl-some (lambda (arg)
+                    (string-match "^function\\b"
+                                  (cdr arg)))
+                  (ess-args-alist)))))
 
 
 ;;;*;;; Names / Objects / Expressions
@@ -1511,9 +1512,9 @@ without curly braces."
       (if (and (memq (char-before) '(?` ?\" ?\'))
                (ess-backward-sexp))
           (setq climbed t)
-        (while (some (apply-partially '/= 0)
-                     `(,(skip-syntax-backward "w_")
-                       ,(skip-chars-backward "\"'")))
+        (while (cl-some (apply-partially '/= 0)
+                        `(,(skip-syntax-backward "w_")
+                          ,(skip-chars-backward "\"'")))
           (setq climbed t)))
       ;; Recurse if we find an indexing char
       (when (memq (char-before) '(?$ ?@))

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -68,8 +68,7 @@
 (require 'hideshow)
 (require 'outline)
 (eval-when-compile
-  ;; We can't use cl-lib whilst supporting Emacs <= 24.2 users
-  (with-no-warnings (require 'cl)))
+  (require 'cl-lib))
 (autoload 'Rd-preview-help "ess-rd" "[autoload]" t)
 (require 'essddr "ess-rd.el")
 

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -54,8 +54,8 @@
 (require 'tramp)
 (require 'compile)
 (require 'overlay)
-;; We can't use cl-lib whilst supporting Emacs <= 24.2 users
-(with-no-warnings (require 'cl))
+(eval-when-compile
+  (require 'cl-lib))
 (require 'ess-utils)
 
 (autoload 'ess-helpobjs-at-point        "ess-help" "[autoload]" nil) ;;todo: rename and put into a more neutral place

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -28,8 +28,7 @@
 
 (eval-when-compile
   (require 'tramp)
-  ;; We can't use cl-lib whilst supporting Emacs <= 24.2 users
-  (with-no-warnings (require 'cl)))
+  (require 'cl-lib))
 
 
 ;;*;; Internal ESS tools and variables
@@ -668,7 +667,7 @@ See also `ess-use-ido'."
                  ess-use-company))
       (when ess-company-backends
         (set (make-local-variable 'company-backends)
-             (copy-list (append ess-company-backends company-backends)))
+             (cl-copy-list (append ess-company-backends company-backends)))
         (delq 'company-capf company-backends)))
 
     ;; eldoc)

--- a/lisp/ess.el
+++ b/lisp/ess.el
@@ -126,8 +126,8 @@
 (require 'ess-custom)
 (require 'ess-mode)
 (require 'ess-inf)
-;; We can't use cl-lib whilst supporting Emacs <= 24.2 users
-(with-no-warnings (require 'cl))
+(eval-when-compile
+  (require 'cl-lib))
 
 
 


### PR DESCRIPTION
The cl package was obsoleted in Emacs 24.3. ESS currently requires 24.4+, so this shouldn't negatively affect anyone.