### PR TITLE
Fixes "Invalid slot type: xref-item, summary, string"

### DIFF
--- a/lisp/ess-r-xref.el
+++ b/lisp/ess-r-xref.el
@@ -40,7 +40,7 @@
   'ess-r)
 
 (cl-defmethod xref-backend-identifier-at-point ((_backend (eql ess-r)))
-  (ess-symbol-at-point))
+  (symbol-name (ess-symbol-at-point)))
 
 (cl-defmethod xref-backend-definitions ((_backend (eql ess-r)) symbol)
   (let ((xref (ess-r-xref--xref symbol)))


### PR DESCRIPTION
I'm having an issue with the changes to xref -- whenever I try to jump to a definition, I get the error

    eieio--validate-slot-value: Invalid slot type: xref-item, summary, string, test_fn_odd_alignment

This seems to be due to the fact that `(ess-symbol-at-point)` returns a symbol, but calls to `xref-make` expect a string as the summary. I've fixed this by using the name of the symbol at point instead of the symbol itself. Alternatively, we could call `symbol-name` inside `xref-make`.

It may also be a good idea to remove any text properties from the symbol, but they don't seem to be causing any harm in my testing.

For reference, I'm on 25.3.1. There may have been an API change at some point that permitted symbols instead of strings.