### PR TITLE
Improves support for jumping to R xrefs inside packages

### DIFF
--- a/etc/ESSR/R/completion.R
+++ b/etc/ESSR/R/completion.R
@@ -25,6 +25,12 @@
     cat(out)
 }
 
+.ess_pkg_name <- function(name) {
+    fn <- .ess_eval(name)
+    env_name <- base::environmentName(base::environment(fn))
+    cat(sprintf("%s\n", env_name[1]))
+}
+
 .ess_funargs <- function(funname) {
     if(.ess.Rversion > '2.14.1') {
         ## temporarily disable JIT compilation and errors


### PR DESCRIPTION
This is a follow-up on some of the conversation in #475. When `options(keep.source.pkgs = TRUE)`, R will keep source references for newly installed packages, but it doesn't actually ensure that the downloaded packages are kept around. So `srcref` attributes point to non-existent files. Since the filenames are still (partially) accurate, and the line and column numbers are correct, all we really need is to point Emacs towards the package source directory and it can jump to the correct location.

This PR takes an approach inspired by `find-function-C-source`, simply prompting the user for the location of the source code of package XXX. This makes sense to me, because it is then clear to the user that they will need to download the source code for things to work correctly, and it is entirely voluntary. I can imagine adding a customization variable that will download the appropriate source code in the background, too.

I've added two customization variables that allow the user to point ESS towards package sources, either on an individual package basis, or inside a global package source directory. The first of these is also re-purposed as a cache.

Known limitations: (1) does not support namespaced evaluation; and (2) doesn't identify base R packages for special treatment. Both of these can be addressed if the overall approach makes sense to others.