### PR TITLE
Add --quiet option to wget

### DIFF
--- a/Makeconf
+++ b/Makeconf
@@ -87,7 +87,7 @@ UNINSTALL = rm -f
 DOCDIR=$(PREFIX)/share/doc/ess
 
 # N.B. $(shell) is a GNU-ism: we need a workaround to be UNIX make friendly
-DOWNLOAD=$(shell which wget > /dev/null && echo 'wget -O -' || which curl)
+DOWNLOAD=$(shell which wget > /dev/null && echo 'wget -qO -' || which curl)
 ##DOWNLOAD = wget -O -
 ##DOWNLOAD = curl
 


### PR DESCRIPTION
Otherwise wget writes output (loading CA cert, etc) along with
julia-mode.el

Also, why does ESS handle julia-mode this way? It seems like it would be better to use Emacs's built-in way of declaring package dependencies. 