### PR TITLE
Look for xref symbols within the namespace of current package

### DIFF
--- a/etc/ESSR/R/completion.R
+++ b/etc/ESSR/R/completion.R
@@ -11,8 +11,13 @@
     else x
 }
 
-.ess_srcref <- function(name) {
-    fn <- .ess_eval(name)
+.ess_srcref <- function(name, pkg) {
+    if (!is.null(pkg) && requireNamespace(pkg)) {
+        env <- asNamespace(pkg)
+    } else {
+        env <- globalenv()
+    }
+    fn <- .ess_eval(name, env)
     out <- "()\n"
     if (is.function(fn) && !is.null(utils::getSrcref(fn))) {
         file <- utils::getSrcFilename(fn, full.names = TRUE)

--- a/etc/ESSR/R/completion.R
+++ b/etc/ESSR/R/completion.R
@@ -1,8 +1,8 @@
 ## Do *NOT* use  1L -- it gives  parse errors in historical versions of R
 
-.ess_eval <- function(str) {
+.ess_eval <- function(str, env = globalenv()) {
     ## don't remove; really need eval(parse(  here!!
-    tryCatch(base::eval(base::parse(text=str)),
+    tryCatch(base::eval(base::parse(text=str), envir = env),
              error=function(e) NULL) ## also works for special objects containing @:$ etc
 }
 

--- a/lisp/ess-r-xref.el
+++ b/lisp/ess-r-xref.el
@@ -65,11 +65,16 @@ srcrefs point to temporary locations."
 
 (defun ess-r-xref--srcref (symbol)
   (inferior-ess-r-force)
-  (with-current-buffer (ess-command (format ".ess_srcref(\"%s\")\n" symbol))
-    (goto-char (point-min))
-    (when (re-search-forward "(" nil 'noerror)
-      (goto-char (match-beginning 0))
-      (read (current-buffer)))))
+  ;; Look for `symbol' inside the package namespace
+  (let* ((pkg (ess-r-package-name))
+         (pkg (if pkg
+                  (concat "\"" pkg "\"")
+                "NULL")))
+    (with-current-buffer (ess-command (format ".ess_srcref(\"%s\", %s)\n" symbol pkg))
+      (goto-char (point-min))
+      (when (re-search-forward "(" nil 'noerror)
+        (goto-char (match-beginning 0))
+        (read (current-buffer))))))
 
 (defun ess-r-xref--pkg-srcfile (symbol r-src-file)
   "Look in the source directory of the R package containing symbol SYMBOL for R-SRC-FILE."


### PR DESCRIPTION
This way:

* we can find non-exported functions
* we can find functions from other packages imported to the namespace
* there is no need to attach the package to the search path

This should make xref much more useful to ESS users allergic to `devtools::load_all()` ;)

cc @atheriel 