### PR TITLE
Show ess-dialect in the mode-line rather than ess-language

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -29,6 +29,9 @@ in the process buffer.
 @item @ESS{[R]}: The startup screen has been cleaned up and displays
 the startup directory with an explicit @code{setwd()}.
 
+@item ESS now displays the language dialect in the mode-line
+So, for example, R buffers will now show ESS[R] rather than ESS[S].
+
 @end itemize
 
 

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -344,7 +344,7 @@ indentation style. At present, predefined style are `BSD', `GNU', `K&R', `C++',
    (format "(ess-mode-1.5): alist=%s \n" alist))
   (unless is-derived
     (setq major-mode 'ess-mode)
-    (setq mode-name (concat "ESS[" ess-language "]"))) ; was ess-dialect
+    (setq mode-name (concat "ESS[" (or ess-dialect ess-language) "]")))
   ;; The following line does the next 20 or so :-).
   (ess-write-to-dribble-buffer
    (format "(ess-mode-1.6): editing-alist=%s \n"


### PR DESCRIPTION
I'm going through and updating the manual (#496) so that it talks about R and mentions the S family rather than talking about S and mentioning R as a special case. 

This PR changes it so that `ess-language` is `R` rather than `S` in R/S/S+ buffers. The most user-visible effect is that we now display `ESS[R]` rather than `ESS[S]` in the modeline.