### PR TITLE
Use display-buffer-alist instead of obsolete variables

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2883,10 +2883,16 @@ Possible values are:
   'one: All help buffers are shown in one dedicated frame.
      t: Each help buffer gets its own frame.
 
+Note if you set this to t you should also set
+`ess-help-reuse-window' to nil to ensure that help buffers are
+displayed in a new frame.
+
 The parameters of this frame are stored in `ess-help-frame-alist'.
 See also `inferior-ess-own-frame'."
   :group 'ess-help
-  :type '(choice (const nil) (const one) (const t)))
+  :type '(choice (const :tag "Display in current frame" nil)
+                 (const :tag "Display in one frame" one)
+                 (const :tag "Display in a new frame" t)))
 
 (defcustom ess-help-reuse-window t
   "If t, ESS tries to display new help buffers in the existing help window"

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -185,11 +185,7 @@ Alternatively, it can appear in its own frame if
 
       (let* ((infargs (or ess-start-args
                           inferior-ess-start-args))
-             (special-display-regexps nil)
-             (special-display-frame-alist inferior-ess-frame-alist)
              (proc (get-process procname)))
-        (if inferior-ess-own-frame
-            (setq special-display-regexps '(".")))
         ;; If ESS process NAME is running, switch to it
         (if (and proc (comint-check-proc (process-buffer proc)))
             (progn ;; fixme: when does this happen? -> log:
@@ -290,9 +286,16 @@ Alternatively, it can appear in its own frame if
           (with-current-buffer buf
             (rename-buffer buf-name-str t))
 
-          (if (and inferior-ess-same-window (not inferior-ess-own-frame))
-              (switch-to-buffer buf)
-            (pop-to-buffer buf)))))))
+          ;; Show the buffer in a new frame, window, or selected
+          ;; window depending on user settings:
+          (cond (inferior-ess-own-frame
+                 (progn
+                   (make-frame inferior-ess-frame-alist)
+                   (switch-to-buffer buf)))
+                (inferior-ess-same-window
+                 (progn
+                   (switch-to-buffer buf)))
+                (t (pop-to-buffer buf))))))))
 
 
 (defvar inferior-ess-objects-command nil
@@ -3185,8 +3188,11 @@ search path related variables."
 (defun ess-display-temp-buffer (buff)
   "Display the buffer BUFF using `temp-buffer-show-function' and respecting
 `ess-display-buffer-reuse-frames'."
-  (let ((display-buffer-reuse-frames ess-display-buffer-reuse-frames))
-    (funcall (or temp-buffer-show-function 'display-buffer) buff)))
+  (if temp-buffer-show-function
+      (when (fboundp 'temp-buffer-show-function)
+        (temp-buffer-show-function buff))
+    (display-buffer buff :frame `(when ess-display-buffer-reuse-frames
+                                   (reusable-frames . t)))))
 
 ;;*;; Error messages
 


### PR DESCRIPTION
`display-buffer-alist' obsoleted many variables like
`special-display-regexps' in Emacs 24.3, and the byte compiler
complains about this.