### PR TITLE
Make writing to the dribble buffer optional

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -35,6 +35,9 @@ So, for example, R buffers will now show ESS[R] rather than ESS[S].
 @item @ESS{[R]}: @code{Makevars} files are now automatically opened
 with @code{makefile-mode}.
 
+@item New varaible @code{ess-write-to-dribble}.
+This allows users to disable the dribble (@code{*ESS*}) buffer if they wish.
+
 @end itemize
 
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -3116,13 +3116,19 @@ Created for each process."
 (defvar ess-error-regexp-alist nil
   "List of symbols which are looked up in `compilation-error-regexp-alist-alist'.")
 
+(defcustom ess-write-to-dribble t
+  "Non-nil means write to `ess-dribble-buffer'.
+See also `ess-verbose'."
+  :group 'ess-proc
+  :type 'boolean)
+
 (defcustom ess-verbose nil
   "Non-nil means write more information to `ess-dribble-buffer' than usual."
   :group 'ess-proc
   :type 'boolean)
 
-(defvar ess-dribble-buffer (generate-new-buffer "*ESS*")
-  "Buffer for temporary use for setting default variable values.
+(defvar ess-dribble-buffer "*ESS*"
+  "Name of buffer for temporary use for setting default variable values.
 Used for recording status of the program, mainly for debugging.")
 
 (defvar ess-customize-alist nil

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -29,7 +29,7 @@
 (eval-when-compile
   (require 'tramp)
   (require 'cl-lib))
-
+(require 'ess-custom)
 (defvar ac-modes)
 (declare-function evil-visual-state-p "evil")
 (declare-function evil-normal-state "evil")
@@ -1520,16 +1520,17 @@ If not `nil' and not `t', query for each instance."
 
 ;;*;; Debugging tools
 
-(defvar ess-dribble-buffer nil)
+(defvar ess-dribble-buffer)
 (defun ess-write-to-dribble-buffer (text)
   "Write TEXT to dribble ('*ESS*') buffer."
-  (unless (buffer-live-p ess-dribble-buffer)
-    ;; ESS dribble buffer must be re-created.
-    (setq ess-dribble-buffer (get-buffer-create "*ESS*")))
-  (let (deactivate-mark)
-    (with-current-buffer ess-dribble-buffer
-      (goto-char (point-max))
-      (insert-before-markers text))))
+  (unless (or ess-verbose ess-write-to-dribble)
+    (unless (buffer-live-p ess-dribble-buffer)
+      ;; ESS dribble buffer must be re-created.
+      (setq ess-dribble-buffer (get-buffer-create "*ESS*")))
+    (let (deactivate-mark)
+      (with-current-buffer ess-dribble-buffer
+        (goto-char (point-max))
+        (insert-before-markers text)))))
 
 ;; Shortcut to render "dribbling" statements less cluttering:
 (defun ess-if-verbose-write (text)


### PR DESCRIPTION
I'm betting most users never look at this buffer. Since its stated use is for debugging, it should probably not be on by default. You can keep the old behavior by setting the new variable to non-nil (and if you've previously set `ess-verbose`, the behavior won't change). 