### PR TITLE
Improvements to fontification

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -7,9 +7,10 @@ Changes and New Features in development version:
 @item @ESS{[R]}: Fontification of roxygen @code{@@param} keywords now
 supports comma-separated parameters.
 
-@item @ESS{[R]}: Function-like keywords such as @code{if} or @code{stop}
-are no longer fontified as keyword if not followed by an opening
-parenthesis.
+@item @ESS{[R]}: Function-like keywords such as @code{if ()} or
+@code{stop()} are no longer fontified as keyword if not followed by an
+opening parenthesis. The same holds for search path modifiers like
+@code{library()} or @code{require()}.
 
 @item ESS modes now inherit from @code{prog-mode}.
 

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -10,7 +10,8 @@ supports comma-separated parameters.
 @item @ESS{[R]}: Function-like keywords such as @code{if ()} or
 @code{stop()} are no longer fontified as keyword if not followed by an
 opening parenthesis. The same holds for search path modifiers like
-@code{library()} or @code{require()}.
+@code{library()} or @code{require()}. This feature is only available in
+Emacs >= 25.
 
 @item ESS modes now inherit from @code{prog-mode}.
 

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,10 @@
 Changes and New Features in development version:
 @itemize @bullet
 
+@item @ESS{[R]}: Function-like keywords such as @code{if} or @code{stop}
+are no longer fontified as keyword if not followed by an opening
+parenthesis.
+
 @item ESS modes now inherit from @code{prog-mode}.
 
 @item @ESS{[R]}: The package development minor mode now only activates

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,9 @@
 Changes and New Features in development version:
 @itemize @bullet
 
+@item @ESS{[R]}: Fontification of roxygen @code{@@param} keywords now
+supports comma-separated parameters.
+
 @item @ESS{[R]}: Function-like keywords such as @code{if} or @code{stop}
 are no longer fontified as keyword if not followed by an opening
 parenthesis.

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2633,16 +2633,16 @@ This variable has no effect. Customize
   (append ess-RS-constants
           '("T" "F")))
 
-(defvar ess-r--keywords
-  '("in" "else" "break" "next"))
+(defvar ess-R-bare-keywords
+  '("in" "else" "break" "next")
+  "Keywords that do not precede an opening parenthesis.")
 
-(defvar ess-r--fn-like-keywords
+(defvar ess-R-keywords
   '("while" "for" "if" "switch" "function" "return" "message" "warning" "stop")
   "Keywords that precedece an opening parenthesis.")
-(defvaralias 'ess-R-keywords 'ess-r--fn-like-keywords)
 
 (defvar ess-S-keywords
-  (append ess-r--keywords '("terminate")))
+  (append ess-R-keywords '("terminate")))
 
 ;; only some of these keywords "look like functions but are not":
 (defvar ess-S-non-functions
@@ -2771,13 +2771,15 @@ default or not."
         '(1 font-lock-function-name-face nil))
   "Font-lock keyword - function defintions for R.")
 
-(defconst ess-r--fl-keyword:keywords
-  (cons (regexp-opt ess-r--keywords 'words)
-        'ess-keyword-face))
+(defconst ess-R-fl-keyword:bare-keywords
+  (cons (regexp-opt ess-R-bare-keywords 'words)
+        'ess-keyword-face)
+  "Font-lock keywords that do not precede an opening parenthesis.")
 
-(defconst ess-r--fl-keyword:fn-like-keywords
-  (cons (concat (regexp-opt ess-r--fn-like-keywords 'words) "\\s-*(")
-        'ess-keyword-face))
+(defconst ess-R-fl-keyword:keywords
+  (cons (concat (regexp-opt ess-R-keywords 'words) "\\s-*(")
+        'ess-keyword-face)
+  "Font-lock keywords that precede an opening parenthesis.")
 
 (defvar ess-R-fl-keyword:assign-ops
   (cons (regexp-opt ess-R-assign-ops) 'ess-assignment-face)
@@ -2798,8 +2800,8 @@ default or not."
 (defcustom ess-R-font-lock-keywords
   '((ess-R-fl-keyword:modifiers  . t)
     (ess-R-fl-keyword:fun-defs   . t)
-    (ess-r--fl-keyword:keywords . t)
-    (ess-r--fl-keyword:fn-like-keywords . t)
+    (ess-R-fl-keyword:bare-keywords . t)
+    (ess-R-fl-keyword:keywords . t)
     (ess-R-fl-keyword:assign-ops . t)
     (ess-R-fl-keyword:constants  . t)
     (ess-fl-keyword:fun-calls)
@@ -2854,8 +2856,8 @@ system described in `inferior-ess-font-lock-keywords'.")
     (ess-R-fl-keyword:messages  . t)
     (ess-R-fl-keyword:modifiers . t)
     (ess-R-fl-keyword:fun-defs  . t)
-    (ess-r--fl-keyword:keywords . t)
-    (ess-r--fl-keyword:fn-like-keywords . t)
+    (ess-R-fl-keyword:bare-keywords . t)
+    (ess-R-fl-keyword:keywords . t)
     (ess-R-fl-keyword:assign-ops	. t)
     (ess-R-fl-keyword:constants . t)
     (ess-fl-keyword:matrix-labels	. t)

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2635,11 +2635,11 @@ This variable has no effect. Customize
 
 (defvar ess-r--keywords
   '("in" "else" "break" "next"))
-(defvaralias 'ess-R-keywords 'ess-r--keywords)
 
 (defvar ess-r--fn-like-keywords
   '("while" "for" "if" "switch" "function" "return" "message" "warning" "stop")
   "Keywords that precedece an opening parenthesis.")
+(defvaralias 'ess-R-keywords 'ess-r--fn-like-keywords)
 
 (defvar ess-S-keywords
   (append ess-r--keywords '("terminate")))

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2762,7 +2762,7 @@ default or not."
 
 ;;; fl-keywords R
 (defvar ess-R-fl-keyword:modifiers
-  (cons (regexp-opt ess-R-modifyiers 'words)
+  (cons (concat (regexp-opt ess-R-modifyiers 'words) "\\s-*(")
         'ess-modifiers-face)     ; modify search list or source (i.e. directives)
   "Font-lock keyword R modifiers.")
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2633,14 +2633,16 @@ This variable has no effect. Customize
   (append ess-RS-constants
           '("T" "F")))
 
-(defvar ess-R-keywords
-  ;; "Reserved Words" -- part 2 --
-  '("while" "for" "in" "repeat" "if" "else" "switch" "break" "next" "function"
-    ;; note that these are *NOT* reserved words in R:
-    "return" "message" "warning" "stop"))
+(defconst ess-r--keywords
+  '("in" "else" "break" "next"))
+(defvaralias 'ess-R-keywords 'ess-r--keywords)
+
+(defconst ess-r--fn-like-keywords
+  '("while" "for" "if" "switch" "function" "return" "message" "warning" "stop")
+  "Keywords that precedece an opening parenthesis.")
 
 (defvar ess-S-keywords
-  (append ess-R-keywords '("terminate")))
+  (append ess-r--keywords '("terminate")))
 
 ;; only some of these keywords "look like functions but are not":
 (defvar ess-S-non-functions
@@ -2769,8 +2771,12 @@ default or not."
         '(1 font-lock-function-name-face nil))
   "Font-lock keyword - function defintions for R.")
 
-(defvar ess-R-fl-keyword:keywords
-  (cons (regexp-opt ess-R-keywords 'words)
+(defconst ess-r--fl-keyword:keywords
+  (cons (regexp-opt ess-r--keywords 'words)
+        'ess-keyword-face))
+
+(defconst ess-r--fl-keyword:fn-like-keywords
+  (cons (concat (regexp-opt ess-r--fn-like-keywords 'words) "\\s-*(")
         'ess-keyword-face))
 
 (defvar ess-R-fl-keyword:assign-ops
@@ -2792,7 +2798,8 @@ default or not."
 (defcustom ess-R-font-lock-keywords
   '((ess-R-fl-keyword:modifiers  . t)
     (ess-R-fl-keyword:fun-defs   . t)
-    (ess-R-fl-keyword:keywords   . t)
+    (ess-r--fl-keyword:keywords . t)
+    (ess-r--fl-keyword:fn-like-keywords . t)
     (ess-R-fl-keyword:assign-ops . t)
     (ess-R-fl-keyword:constants  . t)
     (ess-fl-keyword:fun-calls)
@@ -2847,7 +2854,8 @@ system described in `inferior-ess-font-lock-keywords'.")
     (ess-R-fl-keyword:messages  . t)
     (ess-R-fl-keyword:modifiers . t)
     (ess-R-fl-keyword:fun-defs  . t)
-    (ess-R-fl-keyword:keywords  . t)
+    (ess-r--fl-keyword:keywords . t)
+    (ess-r--fl-keyword:fn-like-keywords . t)
     (ess-R-fl-keyword:assign-ops	. t)
     (ess-R-fl-keyword:constants . t)
     (ess-fl-keyword:matrix-labels	. t)

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2767,36 +2767,25 @@ default or not."
         '(1 font-lock-function-name-face nil))
   "Font-lock keyword - function defintions for R.")
 
-;; FIXME Emacs 25: Use `seq-group-by'.
-(if (< emacs-major-version 25)
-    (defun ess--seq-group-by (function sequence)
-      (reduce
-       (lambda (acc elt)
-         (let* ((key (funcall function elt))
-                (cell (assoc key acc)))
-           (if cell
-               (setcdr cell (push elt (cdr cell)))
-             (push (list key elt) acc))
-           acc))
-       (reverse sequence)
-       :initial-value nil))
-  (require 'seq)
-  (defalias 'ess--seq-group-by #'seq-group-by))
-
-(let* ((keywords (ess--seq-group-by (lambda (x) (if (member x '("in" "else" "break" "next"))
-                                               'bare
-                                             'normal))
-                                    ess-R-keywords))
-       (bare-keywords (cdr (assq 'bare keywords)))
-       (function-keywords (cdr (assq 'normal keywords))))
-  (defvar ess-R-fl-keyword:bare-keywords
-    (cons (regexp-opt bare-keywords 'words)
-          'ess-keyword-face)
-    "Font-lock keywords that do not precede an opening parenthesis.")
-  (defvar ess-R-fl-keyword:keywords
-    (cons (concat (regexp-opt function-keywords 'words) "\\s-*(")
-          'ess-keyword-face)
-    "Font-lock keywords that precede an opening parenthesis."))
+;; FIXME Emacs 25: Remove guard
+(eval-and-compile
+  (let* ((keywords (if (< emacs-major-version 25)
+                       (list (append (list 'bare) ess-R-keywords) (list 'normal))
+                     (require 'seq)
+                     (seq-group-by (lambda (x) (if (member x '("in" "else" "break" "next"))
+                                              'bare
+                                            'normal))
+                                   ess-R-keywords)))
+         (bare-keywords (cdr (assq 'bare keywords)))
+         (function-keywords (cdr (assq 'normal keywords))))
+    (defvar ess-R-fl-keyword:bare-keywords
+      (cons (regexp-opt bare-keywords 'words)
+            'ess-keyword-face)
+      "Font-lock keywords that do not precede an opening parenthesis.")
+    (defvar ess-R-fl-keyword:keywords
+      (cons (concat (regexp-opt function-keywords 'words) "\\s-*(")
+            'ess-keyword-face)
+      "Font-lock keywords that precede an opening parenthesis.")))
 
 (defvar ess-R-fl-keyword:assign-ops
   (cons (regexp-opt ess-R-assign-ops) 'ess-assignment-face)

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2633,11 +2633,11 @@ This variable has no effect. Customize
   (append ess-RS-constants
           '("T" "F")))
 
-(defconst ess-r--keywords
+(defvar ess-r--keywords
   '("in" "else" "break" "next"))
 (defvaralias 'ess-R-keywords 'ess-r--keywords)
 
-(defconst ess-r--fn-like-keywords
+(defvar ess-r--fn-like-keywords
   '("while" "for" "if" "switch" "function" "return" "message" "warning" "stop")
   "Keywords that precedece an opening parenthesis.")
 

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -101,7 +101,7 @@
               (regexp-opt '("param" "importFrom" "importClassesFrom"
                             "importMethodsFrom")
                           'words)
-              "\\)\\(?:[ \t]+\\(\\sw+\\)\\)")
+              "\\)\\(?:[ \t]+\\(\\(?:\\sw+,?\\)+\\)\\)")
      (1 'font-lock-keyword-face prepend)
      (3 'font-lock-variable-name-face prepend))
     (,(concat "[@\\]" (regexp-opt ess-roxy-tags-noparam t) "\\>")

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -97,11 +97,11 @@
               (regexp-opt ess-roxy-tags-param t)
               "\\)\\>")
      (1 'font-lock-keyword-face prepend))
-    (,(concat ess-roxy-re " *\\([@\\]"
+    (,(concat ess-roxy-re " *\\(@"
               (regexp-opt '("param" "importFrom" "importClassesFrom"
                             "importMethodsFrom")
-                          t)
-              "\\)\\>\\(?:[ \t]+\\(\\sw+\\)\\)?")
+                          'words)
+              "\\)\\(?:[ \t]+\\(\\sw+\\)\\)")
      (1 'font-lock-keyword-face prepend)
      (3 'font-lock-variable-name-face prepend))
     (,(concat "[@\\]" (regexp-opt ess-roxy-tags-noparam t) "\\>")

--- a/test/ess-literate-tests.el
+++ b/test/ess-literate-tests.el
@@ -217,6 +217,8 @@
     (goto-char (point-max))
     (search-backward "¶")
     (delete-char 1)
+    ;; Fontification must take place after removing "¶"
+    (font-lock-ensure)
     ;; Reset Emacs state
     (unless keep-state
       (setq last-command nil)

--- a/test/ess-literate-tests.el
+++ b/test/ess-literate-tests.el
@@ -221,7 +221,8 @@
     (search-backward "¶")
     (delete-char 1)
     ;; Fontification must take place after removing "¶"
-    (font-lock-ensure)
+    ;; FIXME after Emacs 24.3: Use `font-lock-ensure'
+    (font-lock-default-fontify-buffer)
     ;; Reset Emacs state
     (unless keep-state
       (setq last-command nil)

--- a/test/ess-literate-tests.el
+++ b/test/ess-literate-tests.el
@@ -20,6 +20,9 @@
 (ert-deftest test-ess-r-tokens ()
   (ess-ltest-check "tokens.R"))
 
+(ert-deftest test-ess-r-tokens ()
+  (ess-ltest-check "fontification.R"))
+
 
 (defvar ess-ltest-R-chunk-pattern "^###[ \t]*\\([0-9]+[a-zA-Z]*\\) \\([^\n]*\\)$")
 (defvar ess-ltest-R-code-start-pattern "^##!")

--- a/test/generate-literate-cases
+++ b/test/generate-literate-cases
@@ -17,4 +17,4 @@
 
 (mapc (lambda (file)
         (ess-ltest-do 'regenerate (expand-file-name file ess-literate-path)))
-      '("roxy.R" "code-fill.R" "misc.R" "syntax.R" "tokens.R"))
+      '("roxy.R" "code-fill.R" "misc.R" "syntax.R" "tokens.R" "fontification.R"))

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -4,15 +4,14 @@
 ### 1 Bare function-like keywords are not fontified ------------------
 
 ¶while for if switch function return message warning stop
-signalCondition invokeRestart tryCatch withRestarts withCallingHandlers
 
 ##! (while (not (eolp))
-##>   (should (not (face-at-point)))
+##>   (when (>= emacs-major-version 25)
+##>     (should (not (face-at-point))))
 ##>   (forward-word)
 ##>   (ignore-errors (forward-char)))
 
-while for if switch function return message warning stop
-signalCondition invokeRestart tryCatch withRestarts withCallingHandlers¶
+while for if switch function return message warning stop¶
 
 
 ### 2 Function-like keywords are fontified ---------------------------
@@ -44,7 +43,8 @@ in else break next¶
 ¶library attach detach source require
 
 ##! (while (not (eolp))
-##>   (should (not (face-at-point)))
+##>   (when (>= emacs-major-version 25)
+##>     (should (not (face-at-point))))
 ##>   (forward-word)
 ##>   (ignore-errors (forward-char)))
 

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -4,13 +4,15 @@
 ### 1 Bare function-like keywords are not fontified ------------------
 
 ¶while for if switch function return message warning stop
+signalCondition invokeRestart tryCatch withRestarts withCallingHandlers
 
 ##! (while (not (eolp))
 ##>   (should (not (face-at-point)))
 ##>   (forward-word)
 ##>   (ignore-errors (forward-char)))
 
-while for if switch function return message warning stop¶
+while for if switch function return message warning stop
+signalCondition invokeRestart tryCatch withRestarts withCallingHandlers¶
 
 
 ### 2 Function-like keywords are fontified ---------------------------

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -1,0 +1,38 @@
+
+##### Keywords
+
+### 1 Bare function-like keywords are not fontified ------------------
+
+¶while for if switch function return message warning stop
+
+##! (while (not (eolp))
+##>   (should (not (face-at-point)))
+##>   (forward-word)
+##>   (ignore-errors (forward-char)))
+
+while for if switch function return message warning stop¶
+
+
+### 2 Function-like keywords are fontified ---------------------------
+
+¶while() for() if() switch() function() return() message() warning() stop()
+
+##! (while (not (eolp))
+##>   (should (eq (face-at-point) 'ess-keyword-face))
+##>   (forward-word)
+##>   (ignore-errors (forward-char 3)))
+
+while() for() if() switch() function() return() message() warning() stop()¶
+
+
+### 3 Simple keywords are always fontified ---------------------------
+
+¶in else break next
+
+##! (while (not (eolp))
+##>   (should (eq (face-at-point) 'ess-keyword-face))
+##>   (forward-word)
+##>   (ignore-errors (forward-char)))
+
+in else break next¶
+

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -36,3 +36,27 @@ while() for() if() switch() function() return() message() warning() stop()¶
 
 in else break next¶
 
+
+### 4 Search list modifiers are not fontified if not in function position
+
+¶library attach detach source require
+
+##! (while (not (eolp))
+##>   (should (not (face-at-point)))
+##>   (forward-word)
+##>   (ignore-errors (forward-char)))
+
+library attach detach source require¶
+
+
+### 5 Search list modifiers are fontified if in function position ----
+
+¶library() attach() detach() source() require()
+
+##! (while (not (eolp))
+##>   (should (eq (face-at-point) 'ess-modifiers-face))
+##>   (forward-word)
+##>   (ignore-errors (forward-char 3)))
+
+library() attach() detach() source() require()¶
+

--- a/test/literate/fontification.el
+++ b/test/literate/fontification.el
@@ -1,0 +1,3 @@
+
+(defun face-at-point ()
+  (get-char-property (point) 'face))

--- a/test/literate/roxy.R
+++ b/test/literate/roxy.R
@@ -116,3 +116,33 @@ NULL
 ##' @param ¶foo
 NULL
 
+
+### 2 Comma-separated params -----------------------------------------
+
+##' @param ¶foo,bar baz
+NULL
+
+##! (should (memq 'font-lock-variable-name-face (faces-at-point)))
+
+##' @param ¶foo,bar baz
+NULL
+
+##> (forward-word)
+##> (should (memq 'font-lock-variable-name-face (faces-at-point)))
+
+##' @param foo¶,bar baz
+NULL
+
+##> (forward-char)
+##> (should (memq 'font-lock-variable-name-face (faces-at-point)))
+
+##' @param foo,¶bar baz
+NULL
+
+##> (forward-word)
+##> (forward-char)
+##> (should (not (memq 'font-lock-variable-name-face (faces-at-point))))
+
+##' @param foo,bar ¶baz
+NULL
+

--- a/test/literate/roxy.R
+++ b/test/literate/roxy.R
@@ -88,3 +88,31 @@ NULL
 ##'     magna aliqua.
 NULL
 
+
+
+##### Fontification of roxy blocks
+
+### 1 Param keyword --------------------------------------------------
+
+##' ¶@param foo
+NULL
+
+##! (should (memq 'font-lock-keyword-face (faces-at-point)))
+
+##' ¶@param foo
+NULL
+
+##> (forward-char)
+##> (should (memq 'font-lock-keyword-face (faces-at-point)))
+
+##' @¶param foo
+NULL
+
+##> (forward-word)
+##> (forward-char)
+##> (should (not (memq 'font-lock-keyword-face (faces-at-point))))
+##> (should (memq 'font-lock-variable-name-face (faces-at-point)))
+
+##' @param ¶foo
+NULL
+

--- a/test/literate/roxy.el
+++ b/test/literate/roxy.el
@@ -1,0 +1,9 @@
+
+(defun face-at-point ()
+  (get-char-property (point) 'face))
+
+(defun faces-at-point ()
+  (let ((face (get-char-property (point) 'face)))
+    (if (listp face)
+        face
+      (list face))))


### PR DESCRIPTION
* Distinguish between function-like keywords that take parameters such as `if` or `for` and simple keywords like `break` or `next`. Only fontify the former if they precede an opening parenthesis. This should fix many spurious fontifications. The same fix is also applied to search path modifiers such as `require()` and `library()`.

* Fontify comma-separated `@param` keywords in roxygen blocks properly.

* Fontify `tryCatch()`, `invokeRestart()`, `withRestarts()`, `withCallingHandlers()` and `signalCondition()` as keywords since these functions (at least potentially) affect control flow.

* Add literate unit tests for fontification. Fix an issue in the roxy font-lock regexps in the process.

* ~~Start moving font-lock regexp variables to the private namespace `ess-r--`. It should be clear to our users that modifying these regexps might require some maintenance when updating ESS in case we change things.~~