### PR TITLE
Respect Emacs keybinding conventions

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -43,6 +43,15 @@ with @code{makefile-mode}.
 @item New varaible @code{ess-write-to-dribble}.
 This allows users to disable the dribble (@code{*ESS*}) buffer if they wish.
 
+@item ESS now respects Emacs conventions for keybindings.
+This means that The @code{C-c [letter]} bindings have been
+removed. This affects @code{C-c h}, which was bound to
+@code{ess-eval-line-and-step-invisibly} in @code{sas-mode-local-map};
+@code{C-c f}, which was bound to @code{ess-insert-function-outline} in
+@code{ess-add-MM-keys}; and @code{C-c h}, which was bound to
+@code{ess-handy-commands} in @code{Rd-mode-map},
+@code{ess-noweb-minor-mode-map}, and @code{ess-help-mode-map}
+
 @end itemize
 
 

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -611,7 +611,6 @@ For internal use.  Take into account variable `ess-help-own-frame'."
     (define-key map "k" 'kill-this-buffer)
     (define-key map "?" 'ess-describe-help-mode)
     ;;-- those should be "inherited" from ess-mode-map ( ./ess-mode.el )
-    (define-key map "\C-ch"   'ess-handy-commands)
     (define-key map "\C-c\C-s" 'ess-switch-process)
     (define-key map "\C-c\C-r" 'ess-eval-region)
     (define-key map "\C-c\M-r" 'ess-eval-region-and-go)

--- a/lisp/ess-noweb-mode.el
+++ b/lisp/ess-noweb-mode.el
@@ -272,7 +272,6 @@ replaced by sequences of '*'.")
           (define-key map "@" 'ess-noweb-electric-@)
           (define-key map "<" 'ess-noweb-electric-<)))
     (define-key map "\M-q" 'ess-noweb-fill-paragraph-chunk)
-    (define-key map "\C-ch" 'ess-handy-commands)
     (define-key map [(control meta ?\\)] 'ess-noweb-indent-region)
     ;;(define-key map "\C-c\C-n" 'ess-noweb-indent-line) ; Override TeX-normal!
     (define-key map "\t" 'ess-noweb-indent-line)

--- a/lisp/ess-rd.el
+++ b/lisp/ess-rd.el
@@ -189,7 +189,6 @@ All Rd mode abbrevs start with a grave accent (`).")
     ;;  ^C^F ^L : \link{ . }
     ;;  ^C^F  L : \code{\link{ . }}  etc
     (define-key map "\C-c\C-s" 'Rd-mode-insert-section)
-    (define-key map "\C-ch" 'ess-handy-commands)
     (define-key map "\C-c\C-n" 'ess-eval-line-and-step)
     (define-key map "\C-c\C-r" 'ess-eval-region)
     (define-key map "\C-c\C-c" 'ess-eval-region-or-function-or-paragraph-and-step)

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -747,7 +747,6 @@ underscore character."
   (interactive)
   (require 'ess-mode); typically unnecessary
   (require 'ess-inf); dito
-  (define-key ess-mode-map          "\C-cf" 'ess-insert-function-outline)
   (define-key inferior-ess-mode-map "\C-cw" 'ess-execute-screen-options)
 
   ;; Make M-- : [Alt] + [-] (in addition to / instead of  "_" = (on US-keyboard) [Shift]+ [-]

--- a/lisp/ess-sas-d.el
+++ b/lisp/ess-sas-d.el
@@ -200,7 +200,6 @@ Better logic needed!  (see 2 uses, in this file).")
     (if ess-sas-local-pc-keys (ess-sas-local-pc-keys))
     (if ess-sas-global-unix-keys (ess-sas-global-unix-keys))
     (if ess-sas-global-pc-keys (ess-sas-global-pc-keys)))
-  (define-key sas-mode-local-map "\C-ci" 'ess-eval-line-and-step-invisibly)
   (define-key sas-mode-local-map ";" 'ess-electric-run-semicolon)
 
   ;; this is a mess


### PR DESCRIPTION
- Don't bind keys to C-c [letter]
- Remove ess-add-MM-keys (not referenced elsewhere in docs/code)

Closes #539 