### PR TITLE
Obsolete ess-r-args.el

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -85,7 +85,6 @@ removed. This affects @code{C-c h}, which was bound to
 @code{ess-handy-commands} in @code{Rd-mode-map},
 @code{ess-noweb-minor-mode-map}, and @code{ess-help-mode-map}
 
-
 @item prettify-symbols-mode no longer breaks indentation
 This is accomplished by having the pretty symbols occupy the same
 number of characters as their non-pretty cousins.  You may customize
@@ -94,6 +93,9 @@ behavior.
 
 @item Variable @code{ess-s-versions-list} is obsolete and ignored.
 Use @code{ess-s-versions} instead.  You may pass arguments by starting the inferior process with the universal argument.
+
+@item The @code{ess-r-args.el} library has obsoleted and will be removed in a future release.
+Use @code{eldoc-mode} instead, which is on by default.
 
 @item All of the @code{*-program-name} variables have been renamed to @code{*-program}.
 Users who previously customized e.g. @code{inferior-ess-R-program-name}

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -51,7 +51,7 @@ ELC = $(CORE) ess-comp.elc ess-custom.elc \
 	ess-eldoc.elc ess-roxy.elc ess-rutils.elc ess-r-completion.elc \
 	ess-s-lang.elc ess-s3-d.elc ess-s4-d.elc \
 	ess-sp3-d.elc ess-sp4-d.elc ess-sp5-d.elc ess-sp6-d.elc \
-	ess-rdired.elc ess-r-args.elc ess-r-syntax.elc ess-r-mode.elc ess-rd.elc \
+	ess-rdired.elc ess-r-syntax.elc ess-r-mode.elc ess-rd.elc \
 	ess-r-flymake.elc ess-r-package.elc ess-r-xref.elc ess-tracebug.elc ess-julia.elc\
 	julia-mode.elc\
 	ess-generics.elc ess-r-gui.elc\

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -3150,29 +3150,6 @@ S+ for details of the format that should be returned.")
   "Holds a dialect specific eldoc function.
 See `ess-r-eldoc-function' and `ess-julia-eldoc-function' for examples.")
 
-(defvar ess-r-args-noargsmsg "No args found."
-  "Message returned if \\[ess-r-args-get] cannot find a list of arguments.")
-(make-obsolete-variable 'ess-r-args-noargsmsg "Use `eldoc-mode' instead." "2018-05-22")
-
-(defvar ess-r-args-show-prefix "ARGS: "
-  "A prefix string that is shown before the arguments list.")
-(make-obsolete-variable 'ess-r-args-show-prefix "Use `eldoc-mode' instead." "2018-05-22")
-
-(defvar ess-r-args-show-as 'message
-  "How ess-r-args-show should show the argument list. Possible values
-are: 'message' (the default) or 'tooltip'.")
-(make-obsolete-variable 'ess-r-args-show-as "Use `eldoc-mode' instead." "2018-05-22")
-
-(defvar ess-r-args-keep-silent ess-S-non-functions
-  "List of functions names which should *not* trigger \\[ess-r-args-show];
-Defaults to `ess-S-non-functions'.")
-(make-obsolete-variable 'ess-r-args-keep-silent "Use `eldoc-mode' instead." "2018-05-22")
-
-(defvar ess-r-args-electric-paren nil
-  "Non-nil means re-assign \"(\" to \\[ess-r-args-auto-show].")
-(make-obsolete-variable 'ess-r-args-electric-paren "Use `eldoc-mode' instead." "2018-05-22")
-
-
  ; System variables
 ;;;=====================================================
 ;;; Users note: You will rarely have to change these

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -3150,34 +3150,27 @@ S+ for details of the format that should be returned.")
   "Holds a dialect specific eldoc function.
 See `ess-r-eldoc-function' and `ess-julia-eldoc-function' for examples.")
 
-(defcustom ess-r-args-noargsmsg "No args found."
-  "Message returned if \\[ess-r-args-get] cannot find a list of arguments."
-  :group 'ess-R
-  :type 'string)
+(defvar ess-r-args-noargsmsg "No args found."
+  "Message returned if \\[ess-r-args-get] cannot find a list of arguments.")
+(make-obsolete-variable 'ess-r-args-noargsmsg "Use `eldoc-mode' instead." "2018-05-22")
 
-(defcustom ess-r-args-show-prefix "ARGS: "
-  "A prefix string that is shown before the arguments list."
-  :group 'ess-R
-  :type 'string)
+(defvar ess-r-args-show-prefix "ARGS: "
+  "A prefix string that is shown before the arguments list.")
+(make-obsolete-variable 'ess-r-args-show-prefix "Use `eldoc-mode' instead." "2018-05-22")
 
-(defcustom ess-r-args-show-as 'message
+(defvar ess-r-args-show-as 'message
   "How ess-r-args-show should show the argument list. Possible values
-are: 'message' (the default) or 'tooltip'."
-  :group 'ess-R
-  :type '(choice
-          (const :tag "message" :value message)
-          (const :tag "tooltip" :value tooltip)))
+are: 'message' (the default) or 'tooltip'.")
+(make-obsolete-variable 'ess-r-args-show-as "Use `eldoc-mode' instead." "2018-05-22")
 
-(defcustom ess-r-args-keep-silent ess-S-non-functions
+(defvar ess-r-args-keep-silent ess-S-non-functions
   "List of functions names which should *not* trigger \\[ess-r-args-show];
-Defaults to `ess-S-non-functions'."
-  :group 'ess-R
-  :type '(repeat string))
+Defaults to `ess-S-non-functions'.")
+(make-obsolete-variable 'ess-r-args-keep-silent "Use `eldoc-mode' instead." "2018-05-22")
 
-(defcustom ess-r-args-electric-paren nil
-  "Non-nil means re-assign \"(\" to \\[ess-r-args-auto-show]."
-  :group 'ess-R
-  :type 'boolean)
+(defvar ess-r-args-electric-paren nil
+  "Non-nil means re-assign \"(\" to \\[ess-r-args-auto-show].")
+(make-obsolete-variable 'ess-r-args-electric-paren "Use `eldoc-mode' instead." "2018-05-22")
 
 
  ; System variables

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -327,9 +327,6 @@ indentation style. At present, predefined style are `BSD', `GNU', `K&R', `C++',
   (unless is-derived
     (kill-all-local-variables)) ;; NOTICE THIS! *** NOTICE THIS! *** NOTICE THIS! ***
   (ess-setq-vars-local alist)
-  ;; fixme: This is dialect-specific
-  ;; must happen here, since the mode map is set up too early:
-  (if ess-r-args-electric-paren (define-key ess-mode-map "(" 'ess-r-args-auto-show))
   (ess-write-to-dribble-buffer
    (format "(ess-mode-1): ess-language=%s, ess-dialect=%s buf=%s \n"
            ess-language

--- a/lisp/obsolete/ess-r-args.el
+++ b/lisp/obsolete/ess-r-args.el
@@ -188,6 +188,7 @@ found."
       (let ((rfunname (buffer-substring-no-properties posend (point))))
         (if (posix-string-match "^[a-zA-Z0-9_\.]+$" rfunname)
             rfunname nil)))))
+(make-obsolete 'ess-r-args-current-function "See `eldoc-mode'" "2018-05-22")
 
 (defun ess-r-args-get (&optional function trim)
   "Returns string of arguments and their default values of R
@@ -206,6 +207,9 @@ buffer readjustments for multiline string)."
     (mapconcat (lambda (arg) (concat (car arg) "=" (cdr arg)))
                (cadr (ess-function-arguments function))
                ", ")))
+
+(make-obsolete 'ess-r-args-get "See `eldoc-mode'" "2018-05-22")
+
 ;;;###autoload
 (defun ess-r-args-show (&optional function)
   "Show arguments and their default values of R function. Calls
@@ -230,6 +234,7 @@ buffer readjustments for multiline string)."
           ;; lines of text
           (ess-tooltip-show-at-point args 0 30))
         ))))
+(make-obsolete 'ess-r-args-show "See `eldoc-mode'" "2018-05-22")
 
 ;;;###autoload
 (defun ess-r-args-auto-show ()
@@ -241,6 +246,7 @@ and their default values of an R function. Built on \\[ess-r-args-show]."
            ess-local-process-name ; has a process and it must still be running
            (ess-get-process ess-local-process-name))
       (ess-r-args-show)))
+(make-obsolete 'ess-r-args-auto-show "See `eldoc-mode'" "2018-05-22")
 
 ;; MM: I would strongly discourage use of the following:
 ;;     it leads to clueless newbie-users  who indeed
@@ -257,6 +263,7 @@ ess-r-args-current-function if no argument given."
             (pointpos (point)))
         (insert args)
         (goto-char pointpos))))
+(make-obsolete 'ess-r-args-insert "See `eldoc-mode'" "2018-05-22")
 
 
 ;; (defvar ess-r-object-tooltip-alist

--- a/lisp/obsolete/ess-r-args.el
+++ b/lisp/obsolete/ess-r-args.el
@@ -176,6 +176,29 @@
 
 (require 'ess)
 
+;; These defvars were previously defcustoms in ess-custom
+(defvar ess-r-args-noargsmsg "No args found."
+  "Message returned if \\[ess-r-args-get] cannot find a list of arguments.")
+(make-obsolete-variable 'ess-r-args-noargsmsg "Use `eldoc-mode' instead." "2018-05-22")
+
+(defvar ess-r-args-show-prefix "ARGS: "
+  "A prefix string that is shown before the arguments list.")
+(make-obsolete-variable 'ess-r-args-show-prefix "Use `eldoc-mode' instead." "2018-05-22")
+
+(defvar ess-r-args-show-as 'message
+  "How ess-r-args-show should show the argument list. Possible values
+are: 'message' (the default) or 'tooltip'.")
+(make-obsolete-variable 'ess-r-args-show-as "Use `eldoc-mode' instead." "2018-05-22")
+
+(defvar ess-r-args-keep-silent ess-S-non-functions
+  "List of functions names which should *not* trigger \\[ess-r-args-show];
+Defaults to `ess-S-non-functions'.")
+(make-obsolete-variable 'ess-r-args-keep-silent "Use `eldoc-mode' instead." "2018-05-22")
+
+(defvar ess-r-args-electric-paren nil
+  "Non-nil means re-assign \"(\" to \\[ess-r-args-auto-show].")
+(make-obsolete-variable 'ess-r-args-electric-paren "Use `eldoc-mode' instead." "2018-05-22")
+
 (defun ess-r-args-current-function ()
   "Returns the name of the R function assuming point is currently
 within the argument list or nil if no possible function name is


### PR DESCRIPTION
With the excellent eldoc support, I don't see any reason to keep `ess-r-args`. This PR moves it to `old/`, demotes a few `defcustom`s to `defvar`s and makes them obsolete. 

Closes #428 (by smashing the problem with a hammer, admittedly)