### PR TITLE
Improve finding binaries

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -60,6 +60,12 @@ number of characters as their non-pretty cousins.
 @item Variable @code{ess-s-versions-list} is obsolete and ignored.
 Use @code{ess-s-versions} instead.  You may pass arguments by starting the inferior process with the universal argument.
 
+@item All of the @code{*-program-name} variables have been renamed to @code{*-program}.
+Users who previously customized e.g. @code{inferior-ess-R-program-name}
+will need to update their customization to
+@code{inferior-ess-R-program}. These variables are treated as risky
+variables.
+
 
 @end itemize
 

--- a/lisp/ess-arc-d.el
+++ b/lisp/ess-arc-d.el
@@ -50,7 +50,7 @@
     (ess-help-sec-keys-alist       .  " ")
     (inferior-ess-primary-prompt   .  "> ?"               )
     (comint-use-prompt-regexp      . t)
-    (inferior-ess-program          .  inferior-ARC-program-name)
+    (inferior-ess-program          .  inferior-ARC-program)
     (inferior-ess-help-command     .  "(help '%s)\n"      )
     (inferior-ess-objects-command  .  "(variables)\n"     )
     (inferior-ess-exit-command     .  "(exit)\n"          )

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -376,7 +376,7 @@ for all projects."
   :type 'boolean)
 
 
-(defcustom ess-use-inferior-program-name-in-buffer-name nil
+(defcustom ess-use-inferior-program-in-buffer-name nil
   "For R, use e.g., 'R-2.1.0' or 'R-devel' (the program name) for buffer name.
 Avoids the plain dialect name."
   :group 'ess
@@ -1661,12 +1661,12 @@ non-nil."
   :type 'integer)
 
 
-(defcustom inferior-ess-r-program-name (or (executable-find "Rterm")
-                                           (executable-find "R"))
+(defcustom inferior-ess-r-program (or (executable-find "Rterm")
+                                      (executable-find "R"))
   "Program name for invoking an inferior ESS with \\[R]."
   :group 'ess-R
   :type '(choice (string) file))
-(defvaralias 'inferior-R-program-name 'inferior-ess-r-program-name)
+(defvaralias 'inferior-R-program 'inferior-ess-r-program)
 
 (defcustom inferior-R-args ""
   "String of arguments (see 'R --help') used when starting R,
@@ -1692,7 +1692,7 @@ for file name completion.  This can mess up ess evaluation completely."
   "String of switches used when starting stata.
 Don't use this to send initialization command to stata, use
 `inferior-STA-start-file' instead. Also see
-`inferior-STA-program-name'."
+`inferior-STA-program'."
   :group 'ess-Stata
   :type 'string)
 
@@ -1816,18 +1816,18 @@ menu."
   :group 'ess-SPLUS
   :type '(repeat string))
 
-(defcustom inferior-S3-program-name "/disk05/s/S"
+(defcustom inferior-S3-program "/disk05/s/S"
   "Program name for invoking an inferior ESS with S3()."
   :group 'ess-S
   :type 'string)
 
-(defcustom inferior-S+3-program-name (or (executable-find "Splus")
-                                         "Splus")
+(defcustom inferior-S+3-program (or (executable-find "Splus")
+                                    "Splus")
   "Program name for invoking an inferior ESS with S+3()."
   :group 'ess-SPLUS
   :type '(choice (string) file))
 
-(defcustom inferior-S+4-program-name
+(defcustom inferior-S+4-program
   (concat ess-program-files "/spls45se/cmd/Splus.exe")
   "Program name for invoking an external GUI S+4.
 The default value is correct for a default installation of
@@ -1850,7 +1850,7 @@ in S+4 Commands window and in Sqpe+4 buffer."
   :group 'ess-S
   :type 'string)
 
-(defcustom inferior-Sqpe+4-program-name
+(defcustom inferior-Sqpe+4-program
   (concat ess-program-files "/spls45se/cmd/Sqpe.exe")
   "Program name for invoking an inferior ESS with Sqpe+4()."
   :group 'ess-SPLUS
@@ -1882,25 +1882,25 @@ version of the pathname."
 ;;      (setq-default inferior-Sqpe+4-SHOME-name SHOME)))
 
 
-(defcustom inferior-S-elsewhere-program-name "sh"
+(defcustom inferior-S-elsewhere-program "sh"
   "Program name to invoke an inferior ESS with S on a different computer."
   :group 'ess-proc
   :type 'string)
 
-(defcustom inferior-ESS-elsewhere-program-name "sh"
+(defcustom inferior-ESS-elsewhere-program "sh"
   "Program name to invoke an inferior ESS with program on a
 different computer."
   :group 'ess-proc
   :type 'string)
 
-(defcustom inferior-S4-program-name (or (executable-find "S4")
-                                        "S4")
+(defcustom inferior-S4-program (or (executable-find "S4")
+                                   "S4")
   "Program name to invoke an inferior ESS with S4()."
   :group 'ess-S
   :type '(choice (string) (file)))
 
-(defcustom inferior-S+5-program-name (or (executable-find "Splus5")
-                                         "Splus5")
+(defcustom inferior-S+5-program (or (executable-find "Splus5")
+                                    "Splus5")
   "Program name to invoke an inferior ESS with S+5()."
   :group 'ess-SPLUS
   :type '(choice (string) (file)))
@@ -1912,9 +1912,9 @@ Easily changeable in a user's `.emacs'."
   :group 'ess-SPLUS
   :type 'string)
 
-(defvaralias 'inferior-S+6-program-name 'inferior-S+-program-name)
+(defvaralias 'inferior-S+6-program 'inferior-S+-program)
 
-(defcustom inferior-S+-program-name
+(defcustom inferior-S+-program
   (if ess-microsoft-p
       (concat ess-program-files "/TIBCO/splus82/cmd/Splus.exe")
     (or (executable-find "Splus")
@@ -1969,8 +1969,8 @@ for Windows Commands window and in Sqpe+6 for Windows buffer."
   :group 'ess-SPLUS
   :type 'string)
 
-(defvaralias 'inferior-Sqpe+6-program-name 'inferior-Sqpe+-program-name)
-(defcustom inferior-Sqpe+-program-name
+(defvaralias 'inferior-Sqpe+6-program 'inferior-Sqpe+-program)
+(defcustom inferior-Sqpe+-program
   (concat ess-program-files "/TIBCO/splus82/cmd/Sqpe.exe")
   "Program name for invoking an inferior ESS with Sqpe+6() for Windows."
   :group 'ess-S
@@ -2012,32 +2012,32 @@ ask - ask the user whether the S buffers should be killed."
   :group 'ess-S
   :type '(choice (const nil) (const t) (const ask)))
 
-(defcustom inferior-XLS-program-name (or (executable-find "xlispstat")
-                                         "xlispstat")
+(defcustom inferior-XLS-program (or (executable-find "xlispstat")
+                                    "xlispstat")
   "Program name for invoking an inferior ESS with \\[XLS]."
   :group 'ess-XLS
   :type '(choice (string) (file)))
 
-(defcustom inferior-VST-program-name (or (executable-find "vista")
-                                         "vista")
+(defcustom inferior-VST-program (or (executable-find "vista")
+                                    "vista")
   "Program name for invoking an inferior ESS with \\[ViSta]."
   :group 'ess-XLS
   :type '(choice (string) (file)))
 
-(defcustom inferior-ARC-program-name (or (executable-find "arc")
-                                         "arc")
+(defcustom inferior-ARC-program (or (executable-find "arc")
+                                    "arc")
   "Program name for invoking an inferior ESS with \\[ARC]."
   :group 'ess-XLS
   :type '(choice (string) (file)))
 
-(defcustom inferior-SAS-program-name (or (executable-find "sas")
-                                         "sas")
+(defcustom inferior-SAS-program (or (executable-find "sas")
+                                    "sas")
   "Program name for invoking an inferior ESS with SAS()."
   :group 'ess-sas
   :type '(choice (string) (file)))
 
-(defcustom inferior-STA-program-name (or (executable-find "stata")
-                                         "stata")
+(defcustom inferior-STA-program (or (executable-find "stata")
+                                    "stata")
   "Program name for invoking an inferior ESS with stata().
 This is NOT Stata, because we need to call stata with TERM=emacs in
 order for it to work right.  And Emacs is too smart for it."
@@ -2049,8 +2049,8 @@ order for it to work right.  And Emacs is too smart for it."
   :group 'ess-Stata
   :type 'boolean)
 
-(defcustom inferior-OMG-program-name (or (executable-find "omegahat")
-                                         "omegahat")
+(defcustom inferior-OMG-program (or (executable-find "omegahat")
+                                    "omegahat")
   "Program name for invoking an inferior ESS with omegahat()."
   :group 'ess-OMG
   :type '(choice (string) (file)))
@@ -2143,8 +2143,8 @@ for help files.  The default value is nil for other systems."
 
 
 ;;;;; user settable defaults
-(defvar inferior-S-program-name  inferior-S+3-program-name
-  "*Program name for invoking an inferior ESS with S().")
+(defvar inferior-S-program  inferior-S+3-program
+  "Program name for invoking an inferior ESS with S.")
 ;;- (setq inferior-S-program
 ;;-       (cond ((string= S-proc-prefix "S") "Splus")
 ;;-         ((string= S-proc-prefix "R") "R")
@@ -2152,18 +2152,14 @@ for help files.  The default value is nil for other systems."
 ;;-         ))
 ;;(make-local-variable 'inferior-S-program)
 
-(defvar inferior-ess-program nil ;inferior-S-program-name
-  "*Default program name for invoking inferior-ess().
-The other variables ...-program-name should be changed, for the
+(defvar inferior-ess-program nil ;inferior-S-program
+  "Default program name for invoking inferior-ess.
+The other variables ...-program should be changed, for the
 corresponding program.")
 
 (make-variable-buffer-local 'inferior-ess-program)
-;; (setq-default inferior-ess-program inferior-S-program-name)
+;; (setq-default inferior-ess-program inferior-S-program)
 
-
-(defvar inferior-R-version "R (default)"
-  "A (short) name of the current R version.  A global variable for
-ESS internal communication.")
 
 (defvar inferior-ess-start-args ""
   "String of arguments passed to the ESS process.
@@ -3082,9 +3078,9 @@ Defaults to `ess-S-non-functions'."
 
 
  ; julia-mode
-(defcustom inferior-julia-program-name (or (executable-find "julia-basic")
-                                           (executable-find "julia")
-                                           "julia")
+(defcustom inferior-julia-program (or (executable-find "julia-basic")
+                                      (executable-find "julia")
+                                      "julia")
   "Executable for Julia.
 Should be an absolute path to the julia executable."
   :group 'ess-Julia

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1634,12 +1634,6 @@ by `ess-function-template'."
  ; ess-inf: variables for inferior-ess.
 
 ;;*;; System dependent variables
-
-;; If you need to change the *-program-name variables, do so in
-;; ess-site.el.  Do NOT make the changes here!!
-;; Keep a copy of your revised ess-site.el to use as a starting point
-;; for upgrades of ESS.
-
 (defcustom inferior-ess-own-frame nil
   "Non-nil means that inferior ESS buffers should start in their own frame.
 The parameters of this frame are stored in `inferior-ess-frame-alist'."
@@ -1667,11 +1661,11 @@ non-nil."
   :type 'integer)
 
 
-(defcustom inferior-ess-r-program-name
-  (if ess-microsoft-p "Rterm"  "R")
+(defcustom inferior-ess-r-program-name (or (executable-find "Rterm")
+                                           (executable-find "R"))
   "Program name for invoking an inferior ESS with \\[R]."
   :group 'ess-R
-  :type 'string)
+  :type '(choice (string) file))
 (defvaralias 'inferior-R-program-name 'inferior-ess-r-program-name)
 
 (defcustom inferior-R-args ""
@@ -1827,10 +1821,11 @@ menu."
   :group 'ess-S
   :type 'string)
 
-(defcustom inferior-S+3-program-name "Splus"
+(defcustom inferior-S+3-program-name (or (executable-find "Splus")
+                                         "Splus")
   "Program name for invoking an inferior ESS with S+3()."
   :group 'ess-SPLUS
-  :type 'string)
+  :type '(choice (string) file))
 
 (defcustom inferior-S+4-program-name
   (concat ess-program-files "/spls45se/cmd/Splus.exe")
@@ -1898,15 +1893,17 @@ different computer."
   :group 'ess-proc
   :type 'string)
 
-(defcustom inferior-S4-program-name "S4"
+(defcustom inferior-S4-program-name (or (executable-find "S4")
+                                        "S4")
   "Program name to invoke an inferior ESS with S4()."
   :group 'ess-S
-  :type 'string)
+  :type '(choice (string) (file)))
 
-(defcustom inferior-S+5-program-name "Splus5"
+(defcustom inferior-S+5-program-name (or (executable-find "Splus5")
+                                         "Splus5")
   "Program name to invoke an inferior ESS with S+5()."
   :group 'ess-SPLUS
-  :type 'string)
+  :type '(choice (string) (file)))
 
 (defvaralias 'S+6-dialect-name 'S+-dialect-name)
 (defcustom S+-dialect-name "S+"
@@ -1916,21 +1913,21 @@ Easily changeable in a user's `.emacs'."
   :type 'string)
 
 (defvaralias 'inferior-S+6-program-name 'inferior-S+-program-name)
-(if ess-microsoft-p
-    (defcustom inferior-S+-program-name
+
+(defcustom inferior-S+-program-name
+  (if ess-microsoft-p
       (concat ess-program-files "/TIBCO/splus82/cmd/Splus.exe")
-      "Program name to invoke an external GUI S+ for Windows.
-The default value is correct for a default installation of
-S-Plus 8.1 and with bash as the shell.
-For any other version or location, change this value in ess-site.el or
-site-start.el.  Use the 8.3 version of the pathname.
-Use double backslashes if you use the msdos shell."
-      :group 'ess-SPLUS
-      :type 'string)
-  (defcustom inferior-S+-program-name "Splus"
-    "Program name to invoke an inferior ESS with S+ for Unix."
-    :group 'ess-SPLUS
-    :type 'string))
+    (or (executable-find "Splus")
+        "Splus"))
+  "Program name to invoke S+.
+On Unix/Linux, use the Splus executable.  On Windows, the default
+value is correct for a default installation of S-Plus 8.1 and
+with bash as the shell.  For any other version or location,
+change this value in ess-site.el or site-start.el.  Use the 8.3
+version of the pathname.  Use double backslashes if you use the
+msdos shell."
+  :group 'ess-SPLUS
+  :type '(choice (string) (file)))
 
 (defvaralias 'inferior-S+6-start-args 'inferior-S+-start-args)
 (defvaralias 'inferior-Splus-args 'inferior-S+-start-args)
@@ -2015,42 +2012,48 @@ ask - ask the user whether the S buffers should be killed."
   :group 'ess-S
   :type '(choice (const nil) (const t) (const ask)))
 
-(defcustom inferior-XLS-program-name "xlispstat"
+(defcustom inferior-XLS-program-name (or (executable-find "xlispstat")
+                                         "xlispstat")
   "Program name for invoking an inferior ESS with \\[XLS]."
   :group 'ess-XLS
-  :type 'string)
+  :type '(choice (string) (file)))
 
-(defcustom inferior-VST-program-name "vista"
+(defcustom inferior-VST-program-name (or (executable-find "vista")
+                                         "vista")
   "Program name for invoking an inferior ESS with \\[ViSta]."
   :group 'ess-XLS
-  :type 'string)
+  :type '(choice (string) (file)))
 
-(defcustom inferior-ARC-program-name "arc"
+(defcustom inferior-ARC-program-name (or (executable-find "arc")
+                                         "arc")
   "Program name for invoking an inferior ESS with \\[ARC]."
   :group 'ess-XLS
-  :type 'string)
+  :type '(choice (string) (file)))
 
-(defcustom inferior-SAS-program-name "sas"
+(defcustom inferior-SAS-program-name (or (executable-find "sas")
+                                         "sas")
   "Program name for invoking an inferior ESS with SAS()."
   :group 'ess-sas
-  :type 'string)
+  :type '(choice (string) (file)))
 
-(defcustom inferior-STA-program-name "stata"
+(defcustom inferior-STA-program-name (or (executable-find "stata")
+                                         "stata")
   "Program name for invoking an inferior ESS with stata().
 This is NOT Stata, because we need to call stata with TERM=emacs in
 order for it to work right.  And Emacs is too smart for it."
   :group 'ess-Stata
-  :type 'string)
+  :type '(choice (string) (file)))
 
 (defcustom ess-sta-delimiter-friendly nil
   "Non-nil means convert embedded semi-colons to newlines for Stata processing."
   :group 'ess-Stata
   :type 'boolean)
 
-(defcustom inferior-OMG-program-name "omegahat"
+(defcustom inferior-OMG-program-name (or (executable-find "omegahat")
+                                         "omegahat")
   "Program name for invoking an inferior ESS with omegahat()."
   :group 'ess-OMG
-  :type 'string)
+  :type '(choice (string) (file)))
 
 
 ;;;;; names for setting the pager and editor options of the
@@ -3006,17 +3009,17 @@ In `R-mode', for example, this includes \"while,\" \"if/else\",
 
 (defvar ess-help-web-search-command nil
   "Dialect specific command web help search.
-Passed to `ess-execute-dialect-specific' which see. ")
+Passed to `ess-execute-dialect-specific' which see.")
 (make-variable-buffer-local 'ess-help-web-search-command)
 
 (defvar ess-manual-lookup-command nil
   "Dialect specific command manual lookup.
-Passed to `ess-execute-dialect-specific' which see. ")
+Passed to `ess-execute-dialect-specific' which see.")
 (make-variable-buffer-local 'ess-manual-lookup-command)
 
 (defvar ess-reference-lookup-command nil
-  "Dialect specific command for reference lookup..
-Passed to `ess-execute-dialect-specific' which see. ")
+  "Dialect specific command for reference lookup.
+Passed to `ess-execute-dialect-specific' which see.")
 (make-variable-buffer-local 'ess-reference-lookup-command)
 
 (defvar ess-funargs-command  nil
@@ -3026,7 +3029,7 @@ S+ for details of the format that should be returned.")
 (make-variable-buffer-local 'ess-funargs-command)
 
 (defvar ess-eldoc-function nil
-  "Holds a dialect specific eldoc function,
+  "Holds a dialect specific eldoc function.
 See `ess-r-eldoc-function' and `ess-julia-eldoc-function' for examples.")
 
 (defcustom ess-r-args-noargsmsg "No args found."
@@ -3072,24 +3075,23 @@ Defaults to `ess-S-non-functions'."
   "Alist of (key . string) pairs for use in section searching.")
 
 (defvar ess-help-sec-regex nil
-  "Reg(ular) Ex(pression) of section headers in help file")
+  "Reg(ular) Ex(pression) of section headers in help file.")
 
 (make-variable-buffer-local 'ess-help-sec-keys-alist)
 (make-variable-buffer-local 'ess-help-sec-regex)
 
 
  ; julia-mode
-(defcustom inferior-julia-program-name (if (executable-find "julia-basic")
-                                           "julia-basic"
-                                         "julia")
-  "julia' executable.
-Need to be a full path if julia executable is not in the `exec-path'"
+(defcustom inferior-julia-program-name (or (executable-find "julia-basic")
+                                           (executable-find "julia")
+                                           "julia")
+  "Executable for Julia.
+Should be an absolute path to the julia executable."
   :group 'ess-Julia
-  :type 'string)
+  :type '(choice (string) (file)))
 
 (defvar julia-basic-offset 4
-  "Offset for julia code editing")
-
+  "Offset for julia code editing.")
 
 
  ; ess-mode: editing S source
@@ -3151,7 +3153,7 @@ Used to store the values for passing on to newly created buffers.")
 (make-variable-buffer-local 'ess-local-customize-alist)
 
 (defvar ess-mode-editing-alist nil
-  "Variable settings for ess-mode.")
+  "Variable settings for `ess-mode'.")
 
 (defvar ess-transcript-minor-mode nil
   "Non-nil if using `ess-transcript-mode' as a minor mode of some other mode.")
@@ -3159,12 +3161,12 @@ Used to store the values for passing on to newly created buffers.")
 (make-variable-buffer-local 'ess-transcript-minor-mode)
 
 (defvar ess-listing-minor-mode nil
-  "Non-nil if using ess-listing-minor-mode.")
+  "Non-nil if using `ess-listing-minor-mode'.")
 
 (make-variable-buffer-local 'ess-listing-minor-mode)
 
 (defvar ess--enable-experimental-projects nil
-  "Enable experimental project support in ESS")
+  "Enable experimental project support in ESS.")
 
 (provide 'ess-custom)
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -381,6 +381,9 @@ for all projects."
 Avoids the plain dialect name."
   :group 'ess
   :type 'boolean)
+(define-obsolete-variable-alias
+  'ess-use-inferior-program-name-in-buffer-name
+  'ess-use-inferior-program-in-buffer-name "2018-05-23")
 
 (defcustom  ess-use-ido t
   "If t ess will try to use ido completion whenever possible.
@@ -1667,6 +1670,10 @@ non-nil."
   :group 'ess-R
   :type '(choice (string) file))
 (defvaralias 'inferior-R-program 'inferior-ess-r-program)
+(define-obsolete-variable-alias 'inferior-R-program-name
+  'inferior-ess-r-program "2018-05-23")
+(define-obsolete-variable-alias 'inferior-ess-r-program-name
+  'inferior-ess-r-program "2018-05-23")
 
 (defcustom inferior-R-args ""
   "String of arguments (see 'R --help') used when starting R,
@@ -1820,12 +1827,16 @@ menu."
   "Program name for invoking an inferior ESS with S3()."
   :group 'ess-S
   :type 'string)
+(define-obsolete-variable-alias 'inferior-S3-program-name
+  'inferior-S3-program "2018-05-23")
 
 (defcustom inferior-S+3-program (or (executable-find "Splus")
                                     "Splus")
   "Program name for invoking an inferior ESS with S+3()."
   :group 'ess-SPLUS
   :type '(choice (string) file))
+(define-obsolete-variable-alias 'inferior-S+3-program-name
+  'inferior-S+3-program "2018-05-23")
 
 (defcustom inferior-S+4-program
   (concat ess-program-files "/spls45se/cmd/Splus.exe")
@@ -1837,6 +1848,8 @@ site-start.el.  Use the 8.3 version of the pathname.
 Use double backslashes if you use the msdos shell."
   :group 'ess-SPLUS
   :type 'string)
+(define-obsolete-variable-alias 'inferior-S+4-program-name
+  'inferior-S+4-program "2018-05-23")
 
 (defcustom inferior-S+4-print-command "S_PRINT_COMMAND=emacsclientw.exe"
   "Destination of print icon in S+4 Commands window."
@@ -1855,6 +1868,8 @@ in S+4 Commands window and in Sqpe+4 buffer."
   "Program name for invoking an inferior ESS with Sqpe+4()."
   :group 'ess-SPLUS
   :type '(choice (const nil) (string)))
+(define-obsolete-variable-alias 'inferior-Sqpe+4-program-name
+  'inferior-Sqpe+4-program "2018-05-23")
 
 (defcustom inferior-Sqpe+4-SHOME-name
   (if ess-microsoft-p (concat ess-program-files "/spls45se" ""))
@@ -1886,24 +1901,34 @@ version of the pathname."
   "Program name to invoke an inferior ESS with S on a different computer."
   :group 'ess-proc
   :type 'string)
+(define-obsolete-variable-alias
+  'inferior-S-elsewhere-program-name
+  'inferior-S-elsewhere-program "2018-05-23")
 
 (defcustom inferior-ESS-elsewhere-program "sh"
   "Program name to invoke an inferior ESS with program on a
 different computer."
   :group 'ess-proc
   :type 'string)
+(define-obsolete-variable-alias
+  'inferior-ESS-elsewhere-program-name
+  'inferior-ESS-elsewhere-program "2018-05-23")
 
 (defcustom inferior-S4-program (or (executable-find "S4")
                                    "S4")
   "Program name to invoke an inferior ESS with S4()."
   :group 'ess-S
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-S4-program-name
+  'inferior-S4-program "2018-05-23")
 
 (defcustom inferior-S+5-program (or (executable-find "Splus5")
                                     "Splus5")
   "Program name to invoke an inferior ESS with S+5()."
   :group 'ess-SPLUS
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-S+5-program-name
+  'inferior-S+5-program "2018-05-23")
 
 (defvaralias 'S+6-dialect-name 'S+-dialect-name)
 (defcustom S+-dialect-name "S+"
@@ -1913,6 +1938,8 @@ Easily changeable in a user's `.emacs'."
   :type 'string)
 
 (defvaralias 'inferior-S+6-program 'inferior-S+-program)
+(define-obsolete-variable-alias 'inferior-S+6-program-name
+  'inferior-S+-program "2018-05-23")
 
 (defcustom inferior-S+-program
   (if ess-microsoft-p
@@ -1928,6 +1955,8 @@ version of the pathname.  Use double backslashes if you use the
 msdos shell."
   :group 'ess-SPLUS
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-S+-program-name
+  'inferior-S+-program "2018-05-23")
 
 (defvaralias 'inferior-S+6-start-args 'inferior-S+-start-args)
 (defvaralias 'inferior-Splus-args 'inferior-S+-start-args)
@@ -1975,6 +2004,8 @@ for Windows Commands window and in Sqpe+6 for Windows buffer."
   "Program name for invoking an inferior ESS with Sqpe+6() for Windows."
   :group 'ess-S
   :type '(choice (const nil) (string)))
+(define-obsolete-variable-alias 'inferior-Sqpe+-program-name
+  'inferior-Sqpe+-program "2018-05-23")
 
 (defvaralias 'inferior-Sqpe+6-SHOME-name 'inferior-Sqpe+-SHOME-name)
 (defcustom inferior-Sqpe+-SHOME-name
@@ -2017,24 +2048,32 @@ ask - ask the user whether the S buffers should be killed."
   "Program name for invoking an inferior ESS with \\[XLS]."
   :group 'ess-XLS
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-XLS-program-name
+  'inferior-XLS-program "2018-05-23")
 
 (defcustom inferior-VST-program (or (executable-find "vista")
                                     "vista")
   "Program name for invoking an inferior ESS with \\[ViSta]."
   :group 'ess-XLS
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-VST-program-name
+  'inferior-VST-program "2018-05-23")
 
 (defcustom inferior-ARC-program (or (executable-find "arc")
                                     "arc")
   "Program name for invoking an inferior ESS with \\[ARC]."
   :group 'ess-XLS
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-ARC-program-name
+  'inferior-ARC-program "2018-05-23")
 
 (defcustom inferior-SAS-program (or (executable-find "sas")
                                     "sas")
   "Program name for invoking an inferior ESS with SAS()."
   :group 'ess-sas
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-SAS-program-name
+  'inferior-SAS-program "2018-05-23")
 
 (defcustom inferior-STA-program (or (executable-find "stata")
                                     "stata")
@@ -2043,6 +2082,8 @@ This is NOT Stata, because we need to call stata with TERM=emacs in
 order for it to work right.  And Emacs is too smart for it."
   :group 'ess-Stata
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-STA-program-name
+  'inferior-STA-program "2018-05-23")
 
 (defcustom ess-sta-delimiter-friendly nil
   "Non-nil means convert embedded semi-colons to newlines for Stata processing."
@@ -2054,6 +2095,8 @@ order for it to work right.  And Emacs is too smart for it."
   "Program name for invoking an inferior ESS with omegahat()."
   :group 'ess-OMG
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-OMG-program-name
+  'inferior-OMG-program "2018-05-23")
 
 
 ;;;;; names for setting the pager and editor options of the
@@ -2151,11 +2194,15 @@ for help files.  The default value is nil for other systems."
 ;;-         (t "S")
 ;;-         ))
 ;;(make-local-variable 'inferior-S-program)
+(define-obsolete-variable-alias 'inferior-S-program-name
+  'inferior-S+3-program "2018-05-23")
 
 (defvar inferior-ess-program nil ;inferior-S-program
   "Default program name for invoking inferior-ess.
 The other variables ...-program should be changed, for the
 corresponding program.")
+(define-obsolete-variable-alias 'inferior-ess-program-name
+  'inferior-ess-program "2018-05-23")
 
 (make-variable-buffer-local 'inferior-ess-program)
 ;; (setq-default inferior-ess-program inferior-S-program)
@@ -3085,6 +3132,8 @@ Defaults to `ess-S-non-functions'."
 Should be an absolute path to the julia executable."
   :group 'ess-Julia
   :type '(choice (string) (file)))
+(define-obsolete-variable-alias 'inferior-julia-program-name
+  'inferior-julia-program "2018-05-23")
 
 (defvar julia-basic-offset 4
   "Offset for julia code editing.")

--- a/lisp/ess-gretl.el
+++ b/lisp/ess-gretl.el
@@ -531,7 +531,7 @@ end keywords as associated values.")
     )
   "Variables to customize for Gretl -- set up later than emacs initialization.")
 
-;; (defcustom inferior-gretl-program-name "gretlcli"
+;; (defcustom inferior-gretl-program "gretlcli"
 ;;   "*The program to use for running gretl scripts."
 ;;   :type 'string
 ;;   :group 'ess-gretl)
@@ -584,33 +584,33 @@ Optional prefix (C-u) allows to set command line arguments, such as
 If you have certain command line arguments that should always be passed
 to gretl, put them in the variable `inferior-gretl-args'."
   (interactive "P")
-  ;; get settings, notably inferior-ess-r-program-name :
-  ;; (if (null inferior-gretl-program-name)
-  ;;     (error "'inferior-gretl-program-name' does not point to 'gretl-release-basic' executable")
-    (setq ess-customize-alist gretl-customize-alist)
-    (ess-write-to-dribble-buffer   ;; for debugging only
-     (format
-      "\n(Gretl): ess-dialect=%s, buf=%s"
-      ess-dialect (current-buffer)))
-    (let* ((r-start-args
-	    (concat inferior-gretl-args " " ; add space just in case
-		    (if start-args
-			(read-string
-			 (concat "Starting Args [other than `"
-				 inferior-gretl-args
-				 "'] ? "))
-		      nil))))
-      (inferior-ess r-start-args)
-      (set (make-local-variable 'indent-line-function) 'gretl-indent-line)
-      (set (make-local-variable 'gretl-basic-offset) 4)
-      (setq indent-tabs-mode nil)
-      (goto-char (point-max))
-      ;; (if inferior-ess-language-start
-      ;; 	(ess-eval-linewise inferior-ess-language-start
-      ;; 			   nil nil nil 'wait-prompt)))
-      (with-ess-process-buffer nil
-        (run-mode-hooks 'ess-gretl-post-run-hook))
-      ))
+  ;; get settings, notably inferior-ess-r-program :
+  ;; (if (null inferior-gretl-program)
+  ;;     (error "'inferior-gretl-program' does not point to 'gretl-release-basic' executable")
+  (setq ess-customize-alist gretl-customize-alist)
+  (ess-write-to-dribble-buffer   ;; for debugging only
+   (format
+    "\n(Gretl): ess-dialect=%s, buf=%s"
+    ess-dialect (current-buffer)))
+  (let* ((r-start-args
+	  (concat inferior-gretl-args " " ; add space just in case
+		  (if start-args
+		      (read-string
+		       (concat "Starting Args [other than `"
+			       inferior-gretl-args
+			       "'] ? "))
+		    nil))))
+    (inferior-ess r-start-args)
+    (set (make-local-variable 'indent-line-function) 'gretl-indent-line)
+    (set (make-local-variable 'gretl-basic-offset) 4)
+    (setq indent-tabs-mode nil)
+    (goto-char (point-max))
+    ;; (if inferior-ess-language-start
+    ;; 	(ess-eval-linewise inferior-ess-language-start
+    ;; 			   nil nil nil 'wait-prompt)))
+    (with-ess-process-buffer nil
+      (run-mode-hooks 'ess-gretl-post-run-hook))
+    ))
 
 
 ;;;; IMENU

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -125,9 +125,9 @@ Alternatively, it can appear in its own frame if
              ess-language ess-dialect temp-ess-dialect (current-buffer)))
     (let* ((process-environment process-environment)
            ;; Use temp-ess-dialect if not R, R program name otherwise
-           (temp-dialect (if ess-use-inferior-program-name-in-buffer-name ;VS[23-02-2013]: fixme: this should not be here
+           (temp-dialect (if ess-use-inferior-program-in-buffer-name ;VS[23-02-2013]: fixme: this should not be here
                              (if (string-equal temp-ess-dialect "R")
-                                 inferior-ess-r-program-name
+                                 inferior-ess-r-program
                                temp-ess-dialect)
                            temp-ess-dialect))
            (temp-lang temp-ess-lang)
@@ -705,16 +705,16 @@ process happens interactively (when possible)."
   (ess-get-process-variable 'default-directory))
 
 ;;--- Unfinished idea (ESS-help / R-help ) -- probably not worth it...
-;;- (defun ess-set-inferior-program-name (filename)
+;;- (defun ess-set-inferior-program (filename)
 ;;-   "Allows to set or change `inferior-ess-program', the program (file)name."
 ;;-   (interactive "fR executable (script) file: ")
 ;;-   ;; "f" : existing file {file name completion} !
 ;;-   (setq inferior-ess-program filename))
 ;; the inferior-ess-program is initialized in the customize..alist,
-;; e.g. from  inferior-ess-r-program-name ... --> should change rather these.
+;; e.g. from  inferior-ess-r-program ... --> should change rather these.
 ;; However these really depend on the current ess-language!
 ;; Plan: 1) must know and use ess-language
-;;       2) change the appropriate  inferior-<ESSlang>-program-name
+;;       2) change the appropriate  inferior-<ESSlang>-program
 ;; (how?) in R/S : assign(paste("inferior-",ESSlang,"-p...."),  filename))
 
 

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -31,7 +31,7 @@
 ;;
 ;;; Commentary:
 ;;
-;;  Customise inferior-julia-program-name to point to your julia binary
+;;  Customise inferior-julia-program to point to your julia binary
 ;;  and start the inferior with M-x julia.
 ;;
 ;;  As of Sept 2015, this file depends heavily on julia-mode.el from the Julia
@@ -310,7 +310,7 @@ to look up any doc strings."
     (inferior-ess-secondary-prompt . nil)
     (inferior-ess-prompt           . "\\w*> ")
     (ess-local-customize-alist     . 'ess-julia-customize-alist)
-    (inferior-ess-program          . inferior-julia-program-name)
+    (inferior-ess-program          . inferior-julia-program)
     (ess-get-help-topics-function  . 'ess-julia-get-help-topics)
     (ess-help-web-search-command   . "http://docs.julialang.org/en/latest/search/?q=%s")
     (ess-manual-lookup-command     . 'ess-julia-manual-lookup-function)
@@ -400,23 +400,23 @@ Optional prefix (C-u) allows to set command line arguments, such as
 If you have certain command line arguments that should always be passed
 to julia, put them in the variable `inferior-julia-args'."
   (interactive "P")
-  ;; get settings, notably inferior-julia-program-name :
-  (if (null inferior-julia-program-name)
-      (error "'inferior-julia-program-name' does not point to 'julia' or 'julia-basic' executable")
+  ;; get settings, notably inferior-julia-program :
+  (if (null inferior-julia-program)
+      (error "'inferior-julia-program' does not point to 'julia' or 'julia-basic' executable")
     (setq ess-customize-alist ess-julia-customize-alist)
     (ess-write-to-dribble-buffer   ;; for debugging only
      (format
       "\n(julia): ess-dialect=%s, buf=%s, start-arg=%s\n current-prefix-arg=%s\n"
       ess-dialect (current-buffer) start-args current-prefix-arg))
     (let* ((jl-start-args
-	        (concat inferior-julia-args " " ; add space just in case
-		            (if start-args
-			            (read-string
+	    (concat inferior-julia-args " " ; add space just in case
+		    (if start-args
+			(read-string
                          (concat "Starting Args"
                                  (if inferior-julia-args
                                      (concat " [other than '" inferior-julia-args "']"))
                                  " ? "))
-		              nil))))
+		      nil))))
       (inferior-ess jl-start-args)
 
       (remove-hook 'completion-at-point-functions 'ess-filename-completion 'local) ;; should be first

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -1002,15 +1002,13 @@ version.  DIALECT can be \"R,\" \"S,\", \"SAS.\""
 Function defined using `ess-define-runner'."
             (interactive "P")
             (cond ((string= dialect "R")
-                   (let ((inferior-R-version name)
-                         (inferior-ess-r-program-name (if ess-microsoft-p
-                                                          "Rterm" "R")))
+                   (let ((inferior-ess-r-program name))
                      (R start-args)))
                   ((string= dialect "S")
-                   (let ((inferior-S+-program-name name))
+                   (let ((inferior-S+-program name))
                      (S+)))
                   ((string= dialect "SAS")
-                   (let ((inferior-SAS-program-name name))
+                   (let ((inferior-SAS-program name))
                      (SAS))))))))
 
 (defun ess-version ()

--- a/lisp/ess-omg-d.el
+++ b/lisp/ess-omg-d.el
@@ -56,7 +56,7 @@
     (ess-help-sec-regex            . ess-help-S+-sec-regex)
     (ess-help-sec-keys-alist       . ess-help-S+sec-keys-alist)
     (ess-object-name-db-file       . "ess-omg-namedb.el" )
-    (inferior-ess-program          . inferior-OMG-program-name)
+    (inferior-ess-program          . inferior-OMG-program)
     (inferior-ess-objects-command  . "objects(%d)\n")
     (inferior-ess-help-command     . "help(\"%s\",pager=\"cat\",window=F)\n")
     (inferior-ess-exit-command     . "q()\n")

--- a/lisp/ess-r-flymake.el
+++ b/lisp/ess-r-flymake.el
@@ -144,8 +144,8 @@ into a list and call REPORT-FN on it."
 (defun ess-r-flymake (report-fn &rest _args)
   "A Flymake backend for ESS-R modes.  Relies on the lintr package.
 REPORT-FN is flymake's callback function."
-  (unless (executable-find inferior-ess-r-program-name)
-    (error "Cannot find program '%s'" inferior-ess-r-program-name))
+  (unless (executable-find inferior-ess-r-program)
+    (error "Cannot find program '%s'" inferior-ess-r-program))
   ;; Kill the process if earlier check was found. The sentinel of the earlier
   ;; check will detect this.
   (when (process-live-p ess-r--flymake-proc)
@@ -155,7 +155,7 @@ REPORT-FN is flymake's callback function."
           (make-process
            :name "ess-r-flymake" :noquery t :connection-type 'pipe
            :buffer (generate-new-buffer "*ess-r-flymake*")
-           :command (list inferior-R-program-name
+           :command (list inferior-R-program
                           "--no-save" "--no-restore" "--no-site-file" "--no-init-file" "--slave"
                           "-e" (concat
                                 ess-r--flymake-def-linter

--- a/lisp/ess-r-gui.el
+++ b/lisp/ess-r-gui.el
@@ -68,7 +68,7 @@ nil on Unix machines."
 
 (if (not (getenv "R_HOME")) (setenv "R_HOME" "c:/progra~1/R/R-2.6.1"))
 ;;                                                         ^^^^^^^^^ FIXME! do something better
-(defvar inferior-Rgui-program-name "cmd" "Rgui program name")
+(defvar inferior-Rgui-program "cmd" "Rgui program name")
 (defvar Rgui-pager "emacsclientw.exe" "Rgui pager program")
 (defvar inferior-ess-language-start-rgui
   "options(chmhelp=FALSE, htmlhelp=FALSE, help_type='text'); require(tcltk2)"
@@ -131,7 +131,7 @@ PROC, VISIBLY and MESSAGE are ignored."
      (ess-read-object-name-function    . #'ess-dde-read-object-name)
      (ess-find-help-file-function      . #'ess-dde-find-help-file)
      (ess-display-help-on-object-function . #'ess-dde-display-help-on-object)
-     (inferior-ess-program             . inferior-Rgui-program-name)
+     (inferior-ess-program             . inferior-Rgui-program)
      (inferior-ess-objects-command     . inferior-ess-r-objects-command)
      (inferior-ess-font-lock-keywords  . 'inferior-ess-r-font-lock-keywords)
      (inferior-ess-search-list-command . "search()\n")

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -314,7 +314,7 @@ It makes underscores and dots word constituent chars.")
      (ess-function-pattern                  . ess-r-function-pattern)
      (ess-object-name-db-file               . "ess-r-namedb.el")
      (ess-smart-operators                   . ess-r-smart-operators)
-     (inferior-ess-program                  . inferior-ess-r-program-name)
+     (inferior-ess-program                  . inferior-ess-r-program)
      (inferior-ess-objects-command          . inferior-ess-r-objects-command)
      (inferior-ess-font-lock-keywords       . 'inferior-ess-r-font-lock-keywords)
      (inferior-ess-search-list-command      . "search()\n")
@@ -336,13 +336,13 @@ It makes underscores and dots word constituent chars.")
      ;; <<- to ensure indentation does not change when
      ;; prettify-symbols-mode is turned on/off.
      (prettify-symbols-alist                . '(("<-" . (?\s (Br . Bl) ?\s (Bc . Bc) ?←))
-                                                      ("->" . (?\s (Br . Bl) ?\s (Bc . Bc) ?→))
-                                                      ("->>" .  (?\s (Br . Bl) ?\s (Br . Bl) ?\s
-                                                                     (Bl . Bl) ?- (Bc . Br) ?- (Bc . Bc) ?>
-                                                                     (Bc . Bl) ?- (Br . Br) ?>))
-                                                      ("<<-" .  (?\s (Br . Bl) ?\s (Br . Bl) ?\s
-                                                                     (Bl . Bl) ?< (Bc . Br) ?- (Bc . Bc) ?-
-                                                                     (Bc . Bl) ?< (Br . Br) ?-)))))
+                                                ("->" . (?\s (Br . Bl) ?\s (Bc . Bc) ?→))
+                                                ("->>" .  (?\s (Br . Bl) ?\s (Br . Bl) ?\s
+                                                               (Bl . Bl) ?- (Bc . Br) ?- (Bc . Bc) ?>
+                                                               (Bc . Bl) ?- (Br . Br) ?>))
+                                                ("<<-" .  (?\s (Br . Bl) ?\s (Br . Bl) ?\s
+                                                               (Bl . Bl) ?< (Bc . Br) ?- (Bc . Bc) ?-
+                                                               (Bc . Bl) ?< (Br . Br) ?-)))))
    S-common-cust-alist)
   "Variables to customize for R -- set up later than Emacs initialization.")
 
@@ -791,17 +791,17 @@ newest version of R can be potentially time-consuming."
              (if ess-microsoft-p
                  (ess-rterm-prefer-higher-bit)
                (add-to-list 'ess-r-created-runners
-                            inferior-ess-r-program-name))))))
+                            inferior-ess-r-program))))))
 
-(defun ess-check-R-program-name ()
-  "Check if `inferior-ess-r-program-name' points to an executable version of R.
+(defun ess-check-R-program ()
+  "Check if `inferior-ess-r-program' points to an executable version of R.
 If not, try to find the newest version of R elsewhere on the system, and
-update `inferior-ess-r-program-name' accordingly."
-  (unless (executable-find inferior-ess-r-program-name)
+update `inferior-ess-r-program' accordingly."
+  (unless (executable-find inferior-ess-r-program)
     ;; need to check if we can find another name.
     (let ((newest (ess-find-newest-R)))
       (if newest
-          (setq inferior-ess-r-program-name newest)
+          (setq inferior-ess-r-program newest)
         (message "Sorry, no version of R could be found on your system.")))))
 
 (defun R-newest (&optional start-args)

--- a/lisp/ess-s3-d.el
+++ b/lisp/ess-s3-d.el
@@ -43,7 +43,7 @@
      (ess-change-sp-regexp              . ess-S-change-sp-regexp)
      (ess-help-sec-keys-alist           . ess-help-S3-sec-keys-alist)
      (ess-object-name-db-file           . "ess-s3-namedb.el" )
-     (inferior-ess-program              . inferior-S3-program-name) ;        "S")
+     (inferior-ess-program              . inferior-S3-program) ;        "S")
      (inferior-ess-help-command         . "help(\"%s\")\n")
      (inferior-ess-help-filetype . nil)
      (inferior-ess-search-list-command  . "search()\n")

--- a/lisp/ess-s4-d.el
+++ b/lisp/ess-s4-d.el
@@ -49,7 +49,7 @@
      (ess-change-sp-regexp              . ess-S-change-sp-regexp)
      (ess-help-sec-keys-alist           . ess-help-S3-sec-keys-alist)
      (ess-object-name-db-file           . "ess-s4-namedb.el")
-     (inferior-ess-program              . inferior-S4-program-name)
+     (inferior-ess-program              . inferior-S4-program)
      (inferior-ess-objects-command      . ".SmodeObs(%d, pattern=\"%s\")\n")
      ;;(inferior-ess-objects-pattern    . ".*") ; for new s4 stuff
      (inferior-ess-help-command         . "help(\"%s\")\n")

--- a/lisp/ess-sas-d.el
+++ b/lisp/ess-sas-d.el
@@ -138,10 +138,10 @@ Better logic needed!  (see 2 uses, in this file).")
     (other-window 2)
 
     ;;workaround
-    (setq inferior-SAS-program-name
+    (setq inferior-SAS-program
           (concat (file-name-as-directory ess-etc-directory)
                   "ess-sas-sh-command"))
-    (setq inferior-ess-program inferior-SAS-program-name)))
+    (setq inferior-ess-program inferior-SAS-program)))
 
 (defun ess-insert-accept (command)
   "Submit command to process, get next line."
@@ -163,7 +163,7 @@ Better logic needed!  (see 2 uses, in this file).")
     (ess-dialect                   . "SAS")
     (ess-mode-editing-alist        . SAS-editing-alist) ; from ess-sas-l.el
     (ess-mode-syntax-table         . SAS-syntax-table)
-    (inferior-ess-program          . inferior-SAS-program-name)
+    (inferior-ess-program          . inferior-SAS-program)
     (ess-help-sec-regex            . "^[A-Z. ---]+:$")
     (ess-help-sec-keys-alist       . " ")
     (ess-object-name-db-file       . "ess-sas-namedb.el")

--- a/lisp/ess-site.el
+++ b/lisp/ess-site.el
@@ -223,9 +223,9 @@ for ESS, such as icons.")
      (ess-r-s-define-runners+menu)
      (ess-write-to-dribble-buffer "[ess-site:] after ess-versions-created ...")))
 
-;; Check to see that inferior-ess-r-program-name points to a working version
+;; Check to see that inferior-ess-r-program points to a working version
 ;; of R; if not, try to find the newest version:
-(ess-check-R-program-name) ;; -> (ess-find-newest-R) if needed, in ./ess-r-d.el
+(ess-check-R-program) ;; -> (ess-find-newest-R) if needed, in ./ess-r-d.el
 (ess-write-to-dribble-buffer "[ess-site:] *very* end ...")
 
 

--- a/lisp/ess-sp3-d.el
+++ b/lisp/ess-sp3-d.el
@@ -44,7 +44,7 @@
      (ess-dialect                       . S+3-dialect-name)
      (ess-loop-timeout                  . ess-S-loop-timeout);fixme: dialect spec.
      (ess-object-name-db-file           . "ess-s+3-namedb.el" )
-     (inferior-ess-program              . inferior-S+3-program-name)
+     (inferior-ess-program              . inferior-S+3-program)
      (inferior-ess-help-command         . "help(\"%s\", pager=\"cat\", window=FALSE)\n")
      (inferior-ess-help-filetype . nil)
      (inferior-ess-search-list-command  . "search()\n")

--- a/lisp/ess-sp4-d.el
+++ b/lisp/ess-sp4-d.el
@@ -56,7 +56,7 @@ connects it to the '(ddeESS [S+4])' window.")
      (ess-dialect                       . S+4-dialect-name)
      (ess-loop-timeout                  . ess-S-loop-timeout) ;fixme: dialect spec.
      (ess-object-name-db-file           . "ess-sp4-namedb.el" )
-     (inferior-ess-program              . inferior-S+4-program-name)
+     (inferior-ess-program              . inferior-S+4-program)
      (inferior-ess-help-command         . "help(\"%s\")\n")
      (inferior-ess-help-filetype        . "chm")
 
@@ -91,7 +91,7 @@ connects it to the '(ddeESS [S+4])' window.")
      (ess-loop-timeout                  . 500000 );fixme: dialect specific custom.v
      (ess-object-name-db-file           . "ess-sp4-namedb.el" )
      (ess-display-help-on-object-function . #'ess-chm-display-help-on-object)
-     (inferior-ess-program              . inferior-Sqpe+4-program-name)
+     (inferior-ess-program              . inferior-Sqpe+4-program)
      (inferior-ess-help-command         . "help(\"%s\")\n")
      (inferior-ess-help-filetype        . "chm")
      (inferior-ess-search-list-command  . "searchPaths()\n")
@@ -186,7 +186,7 @@ is here to allow slow disks to start the Splus program."
     (setq comint-process-echoes nil)
     (setq comint-input-sender 'comint-simple-send)
     (goto-char (point-max))
-    (insert (concat inferior-S+4-program-name " "
+    (insert (concat inferior-S+4-program " "
                     inferior-ess-start-args)) ; Note: there is no final "&".
     ;; Without the "&", the results of  !system.command  come to '(ddeESS [S+4])'
     ;; With the "&", the results of  !system.command  in S get lost.
@@ -350,7 +350,7 @@ is here to allow slow disks to start the Splus program."
     (setq comint-process-echoes nil)
     (set-buffer-process-coding-system 'raw-text-dos 'raw-text-dos)
     (goto-char (point-max))
-    (insert (concat inferior-S+4-program-name " "
+    (insert (concat inferior-S+4-program " "
                     inferior-ess-start-args)) ; Note: there is no final "&".
                                         ; Without the "&", the results of  !system.command  come to '(ddeESS [S+4])'
                                         ; With the "&", the results of  !system.command  in S get lost.

--- a/lisp/ess-sp5-d.el
+++ b/lisp/ess-sp5-d.el
@@ -53,7 +53,7 @@
      (ess-dialect                       . S+5-dialect-name)
      (ess-loop-timeout                  . ess-S-loop-timeout);fixme: dialect spec.
      (ess-object-name-db-file           . "ess-sp5-namedb.el")
-     (inferior-ess-program              . inferior-S+5-program-name)
+     (inferior-ess-program              . inferior-S+5-program)
      ;;(inferior-ess-objects-pattern    . ".*") ; for new s4 stuff
      (inferior-ess-help-command   . "help(\"%s\", pager=\"slynx -dump\", window=FALSE)\n")
      (inferior-ess-help-filetype . nil)

--- a/lisp/ess-sp6-d.el
+++ b/lisp/ess-sp6-d.el
@@ -73,7 +73,7 @@
      (ess-function-pattern             . ess-r-function-pattern)
 
      (ess-object-name-db-file          . "ess-sp6-namedb.el")
-     (inferior-ess-program             . inferior-S+-program-name)
+     (inferior-ess-program             . inferior-S+-program)
      (inferior-ess-help-command        . "help(\"%s\", pager=\"slynx -dump\", window=FALSE)\n")
      (inferior-ess-help-filetype       . nil)
      (inferior-ess-search-list-command . "searchPaths()\n")

--- a/lisp/ess-sp6w-d.el
+++ b/lisp/ess-sp6w-d.el
@@ -60,7 +60,7 @@ connects it to the '(ddeESS [S+])' window.")
      (ess-loop-timeout          . ess-S-loop-timeout);fixme: dialect spec.
      (ess-object-name-db-file    . "ess-sp6-namedb.el" )
      (ess-display-help-on-object-function . #'ess-chm-display-help-on-object)
-     (inferior-ess-program       . inferior-S+-program-name)
+     (inferior-ess-program       . inferior-S+-program)
      (inferior-ess-help-command  . "help(\"%s\")\n")
      (inferior-ess-help-filetype . "chm")
      (inferior-ess-search-list-command . "searchPaths()\n")
@@ -92,7 +92,7 @@ connects it to the '(ddeESS [S+])' window.")
      (ess-loop-timeout           . 500000 );fixme: dialect specific custom.var
      (ess-object-name-db-file    . "ess-sp6-namedb.el" )
      (ess-display-help-on-object-function . #'ess-chm-display-help-on-object)
-     (inferior-ess-program       . inferior-Sqpe+-program-name)
+     (inferior-ess-program       . inferior-Sqpe+-program)
      (inferior-ess-help-command  . "help(\"%s\")\n")
      (inferior-ess-help-filetype . "chm")
      (inferior-ess-search-list-command . "searchPaths()\n")
@@ -139,23 +139,23 @@ connects it to the '(ddeESS [S+])' window.")
 ;;;
 (defalias 'S+6 'S+)
 (defun S+ (&optional proc-name)
-  "Verify that `inferior-S+-program-name' points to S-Plus 6 or
+  "Verify that `inferior-S+-program' points to S-Plus 6 or
 S-Plus 7 or S-Plus 8.  Start normally for S-Plus 6.1 and later.
 Inform the user to start S-Plus 6.0 from the icon and then
 connect to it with `S+-existing'.  Give an error message if
-`inferior-S+-program-name' doesn't point to S-Plus 6 or S-Plus 7
+`inferior-S+-program' doesn't point to S-Plus 6 or S-Plus 7
 or S-Plus 8."
   (interactive)
   (with-current-buffer (find-file-noselect
-                        (concat (executable-find inferior-S+-program-name)
+                        (concat (executable-find inferior-S+-program)
                                 "/../../versions") t)
     (setq buffer-read-only 1)
     (forward-line)
     (if (not (search-backward-regexp "splus\t[678].[0-9]" (point-min) t))
-        (error "The emacs variable `inferior-S+-program-name' does
+        (error "The emacs variable `inferior-S+-program' does
 not point to S-Plus 6 or 7 or 8.  Please add `splus[678]?/cmd' (expand the
 `[678]?' to match your setup) to your `exec-path' or specify the complete
-path to `Splus.exe' in the variable `inferior-S+-program-name' in your
+path to `Splus.exe' in the variable `inferior-S+-program' in your
 `.emacs' file.")
       (forward-line)
       (if (search-backward "splus\t6.0" (point-min) t)
@@ -215,7 +215,7 @@ to start the Splus program."
     (setq comint-process-echoes nil)
     (setq comint-input-sender 'comint-simple-send)
     (goto-char (point-max))
-    (insert (concat inferior-S+-program-name " "
+    (insert (concat inferior-S+-program " "
                     inferior-ess-start-args)) ; Note: there is no final "&".
     ;; Without the "&", the results of  !system.command  come to '(ddeESS [S+])'
     ;; With the "&", the results of  !system.command  in S get lost.
@@ -341,24 +341,24 @@ Splus Commands window blink a DOS window and you won't see them.\n\n")
   (ess-transcript-mode S+-customize-alist))
 
 (defun S+-msdos (&optional proc-name)
-  "Verify that `inferior-S+-program-name' points to S-Plus 6 or
+  "Verify that `inferior-S+-program' points to S-Plus 6 or
 S-Plus 7 or S-Plus 8.  Start normally for S-Plus 6.1 and later.
 Inform the user to start S-Plus 6.0 from the icon and then
 connect to it with `S+-msdos-existing'.  Give an error message
-if `inferior-S+-program-name' doesn't point to S-Plus 6 or
+if `inferior-S+-program' doesn't point to S-Plus 6 or
 S-Plus 7 or S-Plus 8."
   (interactive)
   (with-current-buffer  (find-file-noselect
-                         (concat (executable-find inferior-S+-program-name)
+                         (concat (executable-find inferior-S+-program)
                                  "/../../versions") t)
     (setq buffer-read-only 1)
     (forward-line)
     (if (not (search-backward-regexp "splus\t[678].[0-9]" (point-min) t))
-        (error "The emacs variable `inferior-S+-program-name' does
+        (error "The emacs variable `inferior-S+-program' does
  not point to S-Plus 6 or 7 or 8.  Please add `splus[678]?/cmd'
  (expand the `[678]?' to match your setup) to your `exec-path' or
  specify the complete path to `Splus.exe' in the variable
-`inferior-S+-program-name' in your `.emacs' file.")  ;;; " This comment keeps emacs font-lock from getting out of phase.
+`inferior-S+-program' in your `.emacs' file.")  ;;; " This comment keeps emacs font-lock from getting out of phase.
 
       (progn
         (forward-line)
@@ -422,7 +422,7 @@ to start the Splus program."
     (setq comint-process-echoes nil)
     (set-buffer-process-coding-system 'raw-text-dos 'raw-text-dos)
     (goto-char (point-max))
-    (insert (concat inferior-S+-program-name " "
+    (insert (concat inferior-S+-program " "
                     inferior-ess-start-args)) ; Note: there is no final "&".
     ;; Without the "&", the results of  !system.command  come to '(ddeESS [S+])'
     ;; With the "&", the results of  !system.command  in S get lost.
@@ -558,7 +558,7 @@ This function was generated by `ess-sqpe-versions-create'."
   (let* ((use-dialog-box) ;; MS dialog box won't return a directory
          (shome-old (getenv "SHOME"))
          (inferior-Sqpe+-SHOME-name "ess-SHOME")
-         (inferior-Sqpe+-program-name (concat "ess-SHOME" "/cmd/sqpe.exe")))
+         (inferior-Sqpe+-program (concat "ess-SHOME" "/cmd/sqpe.exe")))
     (setenv "SHOME" "ess-SHOME")
     (ess-write-to-dribble-buffer
      (format "\n(Sqpe+template): ess-dialect=%s, buf=%s\n" ess-dialect

--- a/lisp/ess-stata-mode.el
+++ b/lisp/ess-stata-mode.el
@@ -56,7 +56,7 @@
     (ess-help-web-search-command   . "http://www.stata.com/search/?q=%s&restrict=&btnG=Search&client=stata&num=&output=xml_no_dtd&site=stata&ie=&oe=UTF-8&sort=&proxystylesheet=stata")
     (ess-eval-linewise-function    . #'stata-eval-linewise)
     (inferior-ess-font-lock-defaults . ess-STA-mode-font-lock-defaults)
-    (inferior-ess-program          . inferior-STA-program-name)
+    (inferior-ess-program          . inferior-STA-program)
     (inferior-ess-objects-command  . "describe\n")
     (inferior-ess-help-command     . "help %s\n") ;; assumes set more off 
     (inferior-ess-exit-command     . "exit\n")

--- a/lisp/ess-vst-d.el
+++ b/lisp/ess-vst-d.el
@@ -47,7 +47,7 @@
     (ess-help-sec-keys-alist       .  " ")
     (inferior-ess-primary-prompt   .  "> ?"               )
     (comint-use-prompt-regexp      . t)
-    (inferior-ess-program          .  inferior-VST-program-name)
+    (inferior-ess-program          .  inferior-VST-program)
     (inferior-ess-help-command     .  "(help '%s)\n"      )
     (inferior-ess-objects-command  .  "(variables)\n"     )
     (inferior-ess-exit-command     .  "(exit)\n"          )

--- a/lisp/ess-xls-d.el
+++ b/lisp/ess-xls-d.el
@@ -56,7 +56,7 @@
     (inferior-ess-primary-prompt   . "> ?"               )
     (inferior-ess-secondary-prompt . "^"                 )
     (comint-use-prompt-regexp      . t)
-    (inferior-ess-program          . inferior-XLS-program-name)
+    (inferior-ess-program          . inferior-XLS-program)
     (inferior-ess-help-command     . "(help '%s)\n"      )
     (inferior-ess-objects-command  . "(variables)\n"     )
     (inferior-ess-exit-command     . "(exit)\n"          )

--- a/lisp/essd-els.el
+++ b/lisp/essd-els.el
@@ -61,7 +61,7 @@
      (ess-dialect                       . S+elsewhere-dialect-name)
      (ess-loop-timeout                  . ess-S-loop-timeout);fixme: dialect spec.
      (ess-object-name-db-file           . "ess-spelsewhere-namedb.el" )
-     (inferior-ess-program              . inferior-S-elsewhere-program-name)
+     (inferior-ess-program              . inferior-S-elsewhere-program)
      (inferior-ess-help-command         . "help(\"%s\", pager=\"cat\", window=F)\n")
 
      (inferior-ess-start-file           . nil) ;"~/.ess-S+3")
@@ -149,7 +149,7 @@ return new alist whose car is the new pair and cdr is ALIST.
 ;;   ;; Need to select a elsewhere-customize-alist
 ;;   (let ((elsewhere-customize-alist (ess-select-alist-dialect)))
 ;;     (ess-change-alist 'inferior-ess-program
-;;                       inferior-ESS-elsewhere-program-name
+;;                       inferior-ESS-elsewhere-program
 ;;                       elsewhere-customize-alist)
 ;;     (setq ess-customize-alist elsewhere-customize-alist)
 ;;     (ess-write-to-dribble-buffer

--- a/lisp/old/ess-old-site.el
+++ b/lisp/old/ess-old-site.el
@@ -77,32 +77,32 @@
 ;;; provided for cases where the program is not on the standard default path.
 ;;; If the program doesn't get located correctly by the default use of
 ;;; M-x S+3 (for example), then put the path name for your system into the
-;;; the variable inferior-S+3-program-name.  If for any reason you want the
+;;; the variable inferior-S+3-program.  If for any reason you want the
 ;;; default use of M-x S to refer to a different program than S+3, then
-;;; redefine inferior-S-program-name.
+;;; redefine inferior-S-program.
 
-;;(setq-default inferior-S3-program-name "/disk05/s/S")
-;;(setq-default inferior-S+3-program-name "Splus34")
-;;(setq-default inferior-S4-program-name "/disk05/s4/S")
-;;(setq-default inferior-S+4-program-name "Splus")
-;;(setq-default inferior-S+5-program-name "Splus5")
-;;(setq-default inferior-S+-program-name "Splus7") ; unix systems ; or
-;;(setq-default inferior-S+-program-name "Splus") ; unix systems
+;;(setq-default inferior-S3-program "/disk05/s/S")
+;;(setq-default inferior-S+3-program "Splus34")
+;;(setq-default inferior-S4-program "/disk05/s4/S")
+;;(setq-default inferior-S+4-program "Splus")
+;;(setq-default inferior-S+5-program "Splus5")
+;;(setq-default inferior-S+-program "Splus7") ; unix systems ; or
+;;(setq-default inferior-S+-program "Splus") ; unix systems
 ;;
 ;; If you wish to call other versions of R on a Unix system, ESS
 ;; should auto-detect other versions of R, according to matches to the
 ;; variable `ess-r-versions' as described in its docstring.  Consider
-;; changing that variable rather than changing inferior-ess-r-program-name
+;; changing that variable rather than changing inferior-ess-r-program
 ;; if your version of R is not already auto-detected.
-;;(setq-default inferior-R-program-name "R")        ; unix systems
-;;(setq-default inferior-R-program-name "Rterm")    ; MS Windows, see below for path as well
-;;(setq-default inferior-R-program-name "C:\\Program Files\\R\\R-2.5.0\\bin\\Rterm.exe")
-;;(setq-default inferior-XLS-program-name "xlispstat")
-;;(setq-default inferior-ARC-program-name "arc")
-;;(setq-default inferior-VST-program-name "vista")
-;;(setq-default inferior-SAS-program-name "sas")
-;;(setq-default inferior-OMG-program-name "/home/rossini/src/anoncvs/Omegahat/org/omegahat/bin/omegahat")
-;;(setq-default inferior-OMG-program-name "omegahat")
+;;(setq-default inferior-R-program "R")        ; unix systems
+;;(setq-default inferior-R-program "Rterm")    ; MS Windows, see below for path as well
+;;(setq-default inferior-R-program "C:\\Program Files\\R\\R-2.5.0\\bin\\Rterm.exe")
+;;(setq-default inferior-XLS-program "xlispstat")
+;;(setq-default inferior-ARC-program "arc")
+;;(setq-default inferior-VST-program "vista")
+;;(setq-default inferior-SAS-program "sas")
+;;(setq-default inferior-OMG-program "/home/rossini/src/anoncvs/Omegahat/org/omegahat/bin/omegahat")
+;;(setq-default inferior-OMG-program "omegahat")
 
 
 ;;; The line below is the ESS default and sends the commands window
@@ -128,19 +128,19 @@
 ;;; See ess-sp4-d.el or ess-sp6w-d.el
 
 ;;; -----> configuration now via custom, see ./ess-custom.el and look for
-;;;        inferior-Sqpe+... e.g. inferior-Sqpe+6-program-name
+;;;        inferior-Sqpe+... e.g. inferior-Sqpe+6-program
 
 
 ;;; see essd-els.el
 
-;;(setq-default inferior-S-elsewhere-program-name "sh")
-;;(setq-default inferior-S-elsewhere-program-name "ssh")
+;;(setq-default inferior-S-elsewhere-program "sh")
+;;(setq-default inferior-S-elsewhere-program "ssh")
 ;;; You might consider using ssh, if you can!  (and if you really do
 ;;; this, use ssh-agent, etc, for securing your sessions).
 
 
 ;;;; Choice for S().
-;;(setq-default inferior-S-program-name inferior-S+3-program-name)
+;;(setq-default inferior-S-program inferior-S+3-program)
 
 ;; (ess-message "[ess-site:] require 'ess-s4-d ...")
 ;; (require 'ess-s4-d) ; has become VERY RARE ..
@@ -189,7 +189,7 @@
 
 ;;; (3.02) Some people have requested using the program name as part
 ;;; of the buffer.  Turned on for R.
-;;(setq ess-use-inferior-program-name-in-buffer-name t)
+;;(setq ess-use-inferior-program-in-buffer-name t)
 
 
 ;;; (3.2) Framepop.  Windows produced by ess-execute-objects etc. are


### PR DESCRIPTION
An attacker could currently get ESS users to unwittingly run a malicious program by setting the `-program-name` variable in a file. This renames all of them to `-program`, which makes them risky variables automatically. 

A few other improvements:
- Remove `inferior-R-version`, since it's not used anywhere
- Fix defining R runners (mentioned in #536)
- Use absolute paths for executables when possible (closes #113, I think, since I don't think we can do any better to correctly detect the executable). 