### PR TITLE
Test on 26.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: emacs-lisp
 env:
   - EVM_EMACS=emacs-24.3-travis
   - EVM_EMACS=emacs-25.3-travis
+  - EVM_EMACS=emacs-26.1-travis
   - EVM_EMACS=emacs-git-snapshot-travis
 
 before_install:
@@ -19,5 +20,6 @@ before_install:
   - evm install $EVM_EMACS --use --skip
 
 script:
+- emacs --version
 - make all
 - make test


### PR DESCRIPTION
Add 26.1 to travis test.

What's the plan to drop support for older Emacs versions? We currently say that 24.3 and older are supported. 24.3 was released in March 2013, over 5 years ago. Even Debian stretch is shipping 24.5 (from 2015) now as their oldest Emacs. They also ship Emacs 25.

I vote we add a note to `newfeat` that says that the upcoming release (whenever that is) will be the last to support Emacs < 25.1. 