### PR TITLE
Rethink control flow keywords

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -14,15 +14,17 @@ opening parenthesis. The same holds for search path modifiers like
 Emacs >= 25.
 
 @item @ESS{[R]}: We have improved fontification of keywords so they
-better reflect the semantics of the R language. The following variables
-have been added to @code{ess-R-keywords}: @code{on.exit()},
-@code{tryCatch()}, @code{withRestarts()}, @code{invokeRestart()},
-@code{recover()} and @code{browser()}. This variable now refers to
-functions that either cause a jump in control flow or represent a jump
-target.
+better reflect the semantics of the R language. @code{ess-R-keywords}
+now only contains words reserved by the R parser.
+@code{ess-R-control-flow-keywords} contains words of base functions that
+cause non-contiguous control flow, such as @code{return()} and
+@code{stop()}. It includes the following variables that were previously
+not fontified: @code{on.exit()}, @code{tryCatch()},
+@code{withRestarts()}, @code{invokeRestart()}, @code{recover()} and
+@code{browser()}
 
-In addition, the new @code{ess-R-weak-keywords} variable holds functions
-that might cause a jump but not necessarily. It includes
+Finally, @code{ess-R-signal-keywords} contains functions part of the
+condition system that only potentially impact control flow:
 @code{message()}, @code{warning()} (moved from @code{ess-R-keywords}),
 @code{signalCondition()} and @code{withCallingHandlers()}. These
 keywords inherit from @code{ess-modifiers-face} (the face used for

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -21,6 +21,13 @@ have been added to @code{ess-R-keywords}: @code{on.exit()},
 functions that either cause a jump in control flow or represent a jump
 target.
 
+In addition, the new @code{ess-R-weak-keywords} variable holds functions
+that might cause a jump but not necessarily. It includes
+@code{message()}, @code{warning()} (moved from @code{ess-R-keywords}),
+@code{signalCondition()} and @code{withCallingHandlers()}. These
+keywords inherit from @code{ess-modifiers-face} (the face used for
+@code{library()} etc).
+
 @item ESS modes now inherit from @code{prog-mode}.
 
 @item @ESS{[R]}: The package development minor mode now only activates

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -13,6 +13,14 @@ opening parenthesis. The same holds for search path modifiers like
 @code{library()} or @code{require()}. This feature is only available in
 Emacs >= 25.
 
+@item @ESS{[R]}: We have improved fontification of keywords so they
+better reflect the semantics of the R language. The following variables
+have been added to @code{ess-R-keywords}: @code{on.exit()},
+@code{tryCatch()}, @code{withRestarts()}, @code{invokeRestart()},
+@code{recover()} and @code{browser()}. This variable now refers to
+functions that either cause a jump in control flow or represent a jump
+target.
+
 @item ESS modes now inherit from @code{prog-mode}.
 
 @item @ESS{[R]}: The package development minor mode now only activates

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2647,7 +2647,13 @@ This variable has no effect. Customize
 
 (defvar ess-R-keywords
   '("in" "else" "break" "next" "while" "for" "if" "switch"
-    "function" "return" "message" "warning" "stop"))
+    "function" "return" "on.exit" "stop"
+    "tryCatch" "withRestarts" "invokeRestart"
+    "recover" "browser")
+  "Keywords that impact control flow.
+These keywords either cause a control flow jump or establish a
+jump target.")
+
 
 (defvar ess-S-keywords
   (append ess-R-keywords '("terminate")))

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2646,17 +2646,20 @@ This variable has no effect. Customize
           '("T" "F")))
 
 (defvar ess-R-keywords
-  '("in" "else" "break" "next" "repeat" "while" "for" "if"
-    "switch" "function" "return" "on.exit" "stop"
+  '("if" "else" "repeat" "while" "function" "for" "in" "next" "break")
+  "Reserved words in the R language.")
+
+(defvar ess-R-control-flow-keywords
+  '("switch" "function" "return" "on.exit" "stop"
     "tryCatch" "withRestarts" "invokeRestart"
     "recover" "browser")
   "Keywords that impact control flow.
 These keywords either cause a control flow jump or establish a
 jump target.")
 
-(defvar ess-R-weak-keywords
+(defvar ess-R-signal-keywords
   '("message" "warning" "signalCondition" "withCallingHandlers")
-  "Keywords that possibly impact control flow.
+  "Keywords for condition signalling.
 These keywords might cause a control flow jump but do not necessarily.")
 
 (defvar ess-S-keywords
@@ -2812,9 +2815,13 @@ default or not."
             '(1 ess-keyword-face))
       "Font-lock keywords that precede an opening parenthesis.")))
 
-(defvar ess-R-fl-keyword:weak-keywords
-  (cons (concat "\\(" (regexp-opt ess-R-weak-keywords 'words) "\\)\\s-*(")
-        '(1 ess-weak-keyword-face)))
+(defvar ess-R-fl-keyword:control-flow-keywords
+  (cons (concat "\\(" (regexp-opt ess-R-control-flow-keywords 'words) "\\)\\s-*(")
+        '(1 ess-r-control-flow-keyword-face)))
+
+(defvar ess-R-fl-keyword:signal-keywords
+  (cons (concat "\\(" (regexp-opt ess-R-signal-keywords 'words) "\\)\\s-*(")
+        '(1 ess-r-signal-keyword-face)))
 
 (defvar ess-R-fl-keyword:assign-ops
   (cons (regexp-opt ess-R-assign-ops) 'ess-assignment-face)
@@ -2837,7 +2844,8 @@ default or not."
     (ess-R-fl-keyword:fun-defs   . t)
     (ess-R-fl-keyword:keywords . t)
     (ess-R-fl-keyword:bare-keywords . t)
-    (ess-R-fl-keyword:weak-keywords . t)
+    (ess-R-fl-keyword:control-flow-keywords . t)
+    (ess-R-fl-keyword:signal-keywords . t)
     (ess-R-fl-keyword:assign-ops . t)
     (ess-R-fl-keyword:constants  . t)
     (ess-fl-keyword:fun-calls)
@@ -3081,17 +3089,28 @@ others. See `ess-R-constants'."
 (defconst ess-keyword-face 'ess-keyword-face)
 (defface ess-keyword-face
   '((default (:inherit font-lock-keyword-face)))
-  "Font lock face used to highlight keywords.
+  "Font lock face used to highlight reserved keywords.
 In `R-mode', for example, this includes \"while,\" \"if/else\",
 \"function,\" and others. See `ess-R-keywords'."
   :group 'ess-faces)
 
-(defconst ess-weak-keyword-face 'ess-weak-keyword-face)
-(defface ess-weak-keyword-face
+(defconst ess-r-control-flow-keyword-face 'ess-r-control-flow-keyword-face)
+(defface ess-r-control-flow-keyword-face
+  '((default (:inherit ess-keyword-face)))
+  "Font lock face used to highlight control flow keywords.
+In `R-mode', for example, this includes \"switch(),\" \"tryCatch()\",
+and \"stop(),\". See `ess-R-control-flow-keywords'.
+
+By default, these keywords are highlighted with the same face as
+`ess-R-keywords'"
+  :group 'ess-faces)
+
+(defconst ess-r-signal-keyword-face 'ess-r-signal-keyword-face)
+(defface ess-r-signal-keyword-face
   '((default (:inherit ess-modifiers-face)))
   "Font lock face used to highlight weak keywords.
 In `R-mode', for example, this includes \"message(),\" \"warning()\",
-and \"withCallingHandlers(),\". See `ess-R-weak-keywords'.
+and \"withCallingHandlers(),\". See `ess-R-signal-keywords'.
 
 By default, these keywords are highlighted with the same face as
 `ess-R-modifyiers'"

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2654,6 +2654,10 @@ This variable has no effect. Customize
 These keywords either cause a control flow jump or establish a
 jump target.")
 
+(defvar ess-R-weak-keywords
+  '("message" "warning" "signalCondition" "withCallingHandlers")
+  "Keywords that possibly impact control flow.
+These keywords might cause a control flow jump but do not necessarily.")
 
 (defvar ess-S-keywords
   (append ess-R-keywords '("terminate")))
@@ -2805,6 +2809,10 @@ default or not."
             '(1 ess-keyword-face))
       "Font-lock keywords that precede an opening parenthesis.")))
 
+(defvar ess-R-fl-keyword:weak-keywords
+  (cons (concat "\\(" (regexp-opt ess-R-weak-keywords 'words) "\\)\\s-*(")
+        '(1 ess-weak-keyword-face)))
+
 (defvar ess-R-fl-keyword:assign-ops
   (cons (regexp-opt ess-R-assign-ops) 'ess-assignment-face)
   "Font-lock assign operators.")
@@ -2824,8 +2832,9 @@ default or not."
 (defcustom ess-R-font-lock-keywords
   '((ess-R-fl-keyword:modifiers  . t)
     (ess-R-fl-keyword:fun-defs   . t)
-    (ess-R-fl-keyword:bare-keywords . t)
     (ess-R-fl-keyword:keywords . t)
+    (ess-R-fl-keyword:bare-keywords . t)
+    (ess-R-fl-keyword:weak-keywords . t)
     (ess-R-fl-keyword:assign-ops . t)
     (ess-R-fl-keyword:constants  . t)
     (ess-fl-keyword:fun-calls)
@@ -3074,7 +3083,16 @@ In `R-mode', for example, this includes \"while,\" \"if/else\",
 \"function,\" and others. See `ess-R-keywords'."
   :group 'ess-faces)
 
+(defconst ess-weak-keyword-face 'ess-weak-keyword-face)
+(defface ess-weak-keyword-face
+  '((default (:inherit ess-modifiers-face)))
+  "Font lock face used to highlight weak keywords.
+In `R-mode', for example, this includes \"message(),\" \"warning()\",
+and \"withCallingHandlers(),\". See `ess-R-weak-keywords'.
 
+By default, these keywords are highlighted with the same face as
+`ess-R-modifyiers'"
+  :group 'ess-faces)
 
 (defcustom ess-help-kill-bogus-buffers t
   "Non-nil means kill ESS help buffers immediately if they are \"bogus\"."

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2646,8 +2646,8 @@ This variable has no effect. Customize
           '("T" "F")))
 
 (defvar ess-R-keywords
-  '("in" "else" "break" "next" "while" "for" "if" "switch"
-    "function" "return" "on.exit" "stop"
+  '("in" "else" "break" "next" "repeat" "while" "for" "if"
+    "switch" "function" "return" "on.exit" "stop"
     "tryCatch" "withRestarts" "invokeRestart"
     "recover" "browser")
   "Keywords that impact control flow.
@@ -2789,12 +2789,15 @@ default or not."
         '(1 font-lock-function-name-face nil))
   "Font-lock keyword - function defintions for R.")
 
+(defvar ess-r--bare-keywords
+  '("in" "else" "break" "next" "repeat"))
+
 ;; FIXME Emacs 25: Remove guard
 (eval-and-compile
   (let* ((keywords (if (< emacs-major-version 25)
                        (list (append (list 'bare) ess-R-keywords) (list 'normal))
                      (require 'seq)
-                     (seq-group-by (lambda (x) (if (member x '("in" "else" "break" "next"))
+                     (seq-group-by (lambda (x) (if (member x ess-r--bare-keywords)
                                               'bare
                                             'normal))
                                    ess-R-keywords)))

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -3,28 +3,32 @@
 
 ### 1 Bare function-like keywords are not fontified ------------------
 
-¶while for if switch function return message warning stop
+¶while for if switch function return on.exit stop
+tryCatch withRestarts invokeRestart recover browser
 
 ##! (while (not (eolp))
 ##>   (when (>= emacs-major-version 25)
 ##>     (should (not (face-at-point))))
-##>   (forward-word)
+##>   (forward-sexp)
 ##>   (ignore-errors (forward-char)))
 
-while for if switch function return message warning stop¶
+while for if switch function return on.exit stop
+tryCatch withRestarts invokeRestart recover browser¶
 
 
 ### 2 Function-like keywords are fontified ---------------------------
 
-¶while() for() if() switch() function() return() message() warning() stop()
+¶while() for() if() switch() function() return() on.exit() stop()
+tryCatch() withRestarts() invokeRestart() recover() browser()
 
 ##! (while (not (eolp))
 ##>   (should (eq (face-at-point) 'ess-keyword-face))
-##>   (forward-word)
+##>   (ess-forward-sexp)
 ##>   (should (not (face-at-point)))
 ##>   (ignore-errors (forward-char 3)))
 
-while() for() if() switch() function() return() message() warning() stop()¶
+while() for() if() switch() function() return() on.exit() stop()
+tryCatch() withRestarts() invokeRestart() recover() browser()¶
 
 
 ### 3 Simple keywords are always fontified ---------------------------

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -16,6 +16,18 @@ while for if switch function return on.exit stop
 tryCatch withRestarts invokeRestart recover browser¶
 
 
+### 1b Bare function-like weak keywords are not fontified ------------
+
+¶message warning signalCondition withCallingHandlers
+
+##! (while (not (eolp))
+##>   (should (not (face-at-point)))
+##>   (forward-sexp)
+##>   (ignore-errors (forward-char)))
+
+message warning signalCondition withCallingHandlers¶
+
+
 ### 2 Function-like keywords are fontified ---------------------------
 
 ¶while() for() if() switch() function() return() on.exit() stop()
@@ -29,6 +41,19 @@ tryCatch() withRestarts() invokeRestart() recover() browser()
 
 while() for() if() switch() function() return() on.exit() stop()
 tryCatch() withRestarts() invokeRestart() recover() browser()¶
+
+
+### 2b Function-like weak keywords are fontified ---------------------
+
+¶message() warning() signalCondition() withCallingHandlers()
+
+##! (while (not (eolp))
+##>   (should (eq (face-at-point) 'ess-weak-keyword-face))
+##>   (ess-forward-sexp)
+##>   (should (not (face-at-point)))
+##>   (ignore-errors (forward-char 3)))
+
+message() warning() signalCondition() withCallingHandlers()¶
 
 
 ### 3 Simple keywords are always fontified ---------------------------

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -58,14 +58,14 @@ message() warning() signalCondition() withCallingHandlers()¶
 
 ### 3 Simple keywords are always fontified ---------------------------
 
-¶in else break next
+¶in else break next repeat
 
 ##! (while (not (eolp))
 ##>   (should (eq (face-at-point) 'ess-keyword-face))
 ##>   (forward-word)
 ##>   (ignore-errors (forward-char)))
 
-in else break next¶
+in else break next repeat¶
 
 
 ### 4 Search list modifiers are not fontified if not in function position

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -30,8 +30,7 @@ message warning signalCondition withCallingHandlers¶
 
 ### 2 Function-like keywords are fontified ---------------------------
 
-¶while() for() if() switch() function() return() on.exit() stop()
-tryCatch() withRestarts() invokeRestart() recover() browser()
+¶while() for() if() function()
 
 ##! (while (not (eolp))
 ##>   (should (eq (face-at-point) 'ess-keyword-face))
@@ -39,16 +38,30 @@ tryCatch() withRestarts() invokeRestart() recover() browser()
 ##>   (should (not (face-at-point)))
 ##>   (ignore-errors (forward-char 3)))
 
-while() for() if() switch() function() return() on.exit() stop()
-tryCatch() withRestarts() invokeRestart() recover() browser()¶
+while() for() if() function()¶
 
 
-### 2b Function-like weak keywords are fontified ---------------------
+### 2b Function-like control flow keywords are fontified -------------
+
+¶switch() return() on.exit() stop() tryCatch()
+withRestarts() invokeRestart() recover() browser()
+
+##! (while (not (eolp))
+##>   (should (eq (face-at-point) 'ess-r-control-flow-keyword-face))
+##>   (ess-forward-sexp)
+##>   (should (not (face-at-point)))
+##>   (ignore-errors (forward-char 3)))
+
+switch() return() on.exit() stop() tryCatch()
+withRestarts() invokeRestart() recover() browser()¶
+
+
+### 2c Function-like signal keywords are fontified ---------------------
 
 ¶message() warning() signalCondition() withCallingHandlers()
 
 ##! (while (not (eolp))
-##>   (should (eq (face-at-point) 'ess-weak-keyword-face))
+##>   (should (eq (face-at-point) 'ess-r-signal-keyword-face))
 ##>   (ess-forward-sexp)
 ##>   (should (not (face-at-point)))
 ##>   (ignore-errors (forward-char 3)))


### PR DESCRIPTION
* `ess-R-keywords` now includes `on.exit()`, `tryCatch()`, `withRestarts()`, `invokeRestart()`, `recover()`, `browser()`.

* Add new `ess-R-weak-keywords` with a new face inheriting from `ess-modifiers-face`. It includes: `message()`, `warning()`, `signalCondition()`, `withCallingHandlers()`.

The goal is to fontify differently keywords that (a) cause a control flow jump or represent a jump target and (b) might cause a control flow jump.