### PR TITLE
New defcustom ess-r-prettify-symbols

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -64,7 +64,9 @@ removed. This affects @code{C-c h}, which was bound to
 
 @item prettify-symbols-mode no longer breaks indentation
 This is accomplished by having the pretty symbols occupy the same
-number of characters as their non-pretty cousins.
+number of characters as their non-pretty cousins.  You may customize
+the new variable @code{ess-r-prettify-symbols} to control this
+behavior.
 
 @item Variable @code{ess-s-versions-list} is obsolete and ignored.
 Use @code{ess-s-versions} instead.  You may pass arguments by starting the inferior process with the universal argument.

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -565,6 +565,25 @@ to another string, it must be set before ESS is loaded."
   :group 'ess-S
   :type '(choice (const :tag "Nothing" :value nil) string))
 
+(defcustom ess-r-prettify-symbols
+  '(("<-" . (?\s (Br . Bl) ?\s (Bc . Bc) ?←))
+    ("->" . (?\s (Br . Bl) ?\s (Bc . Bc) ?→))
+    ("->>" .  (?\s (Br . Bl) ?\s (Br . Bl) ?\s
+                   (Bl . Bl) ?- (Bc . Br) ?- (Bc . Bc) ?>
+                   (Bc . Bl) ?- (Br . Br) ?>))
+    ("<<-" .  (?\s (Br . Bl) ?\s (Br . Bl) ?\s
+                   (Bl . Bl) ?< (Bc . Br) ?- (Bc . Bc) ?-
+                   (Bc . Bl) ?< (Br . Br) ?-)))
+  ;; Setup prettify-symbols-alist to show "pretty" arrows, but make
+  ;; sure that they arrows use the same amount of spacing as <- and
+  ;; <<- to ensure indentation does not change when
+  ;; prettify-symbols-mode is turned on/off.
+  "Alist of symbols prettifications, see `prettify-symbols-alist'.
+This gets appended to `prettify-symbols-alist', so set it to nil
+if you want to disable R specific prettification."
+  :group 'ess-R
+  :type '(alist :key-type string :value-type symbol))
+
 ;;*;; Variables concerning editing behaviour
 
 (defcustom ess-filenames-map t

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -331,18 +331,7 @@ It makes underscores and dots word constituent chars.")
      (ess-pager                             . ess-r-pager)
      (ess-mode-syntax-table                 . ess-r-syntax-table)
      (font-lock-syntactic-face-function     . #'ess-r-font-lock-syntactic-face-function)
-     ;; Setup prettify-symbols-alist to show "pretty" arrows, but make
-     ;; sure that they arrows use the same amount of spacing as <- and
-     ;; <<- to ensure indentation does not change when
-     ;; prettify-symbols-mode is turned on/off.
-     (prettify-symbols-alist                . '(("<-" . (?\s (Br . Bl) ?\s (Bc . Bc) ?←))
-                                                ("->" . (?\s (Br . Bl) ?\s (Bc . Bc) ?→))
-                                                ("->>" .  (?\s (Br . Bl) ?\s (Br . Bl) ?\s
-                                                               (Bl . Bl) ?- (Bc . Br) ?- (Bc . Bc) ?>
-                                                               (Bc . Bl) ?- (Br . Br) ?>))
-                                                ("<<-" .  (?\s (Br . Bl) ?\s (Br . Bl) ?\s
-                                                               (Bl . Bl) ?< (Bc . Br) ?- (Bc . Bc) ?-
-                                                               (Bc . Bl) ?< (Br . Br) ?-)))))
+     (prettify-symbols-alist                . ess-r-prettify-symbols))
    S-common-cust-alist)
   "Variables to customize for R -- set up later than Emacs initialization.")
 


### PR DESCRIPTION
Allows users to change (and, if set to nil, stop) which symbols get
prettified in R buffers.

Closes #132