### PR TITLE
Simplify setting the working directory

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -3078,12 +3078,15 @@ NO-ERROR prevents errors when this has not been implemented for
   'ess-use-dir 'ess-set-working-directory "2018-06-11")
 
 (defun ess-use-this-dir (&optional no-force-current)
-  "Set the current process directory to `default-directory'.
-If that buffer has no associated *R* process, use
-\\[ess-force-buffer-current], unless prefix argument
-NO-FORCE-CURRENT is non-nil."
+  "Set the current process directory to the directory of this file.
+`default-directory' is used as a fallback.  If that buffer has no
+associated *R* process, use \\[ess-force-buffer-current], unless
+prefix argument NO-FORCE-CURRENT is non-nil."
   (interactive "P")
-  (ess-set-working-directory default-directory))
+  (let ((dir (if buffer-file-name
+                 (file-name-directory buffer-file-name)
+               default-directory)))
+    (ess-set-working-directory dir)))
 
 (defun ess-get-working-directory (&optional no-error)
   "Retrive the current working directory from the current ess process."

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -3053,8 +3053,9 @@ list."
 
  ; directories
 (defun ess-set-working-directory (path &optional no-error)
-  "Set the current working directory to PATH for both ESS
-subprocess and Emacs buffer `default-directory'."
+  "Set the current working to PATH for the ESS buffer and iESS process.
+NO-ERROR prevents errors when this has not been implemented for
+`ess-dialect'."
   (interactive "DChange working directory to: ")
   (if ess-setwd-command
       (let* ((remote (file-remote-p path))
@@ -3073,6 +3074,16 @@ subprocess and Emacs buffer `default-directory'."
       (error "Not implemented for dialect %s" ess-dialect))))
 
 (defalias 'ess-change-directory 'ess-set-working-directory)
+(define-obsolete-function-alias
+  'ess-use-dir 'ess-set-working-directory "2018-06-11")
+
+(defun ess-use-this-dir (&optional no-force-current)
+  "Set the current process directory to `default-directory'.
+If that buffer has no associated *R* process, use
+\\[ess-force-buffer-current], unless prefix argument
+NO-FORCE-CURRENT is non-nil."
+  (interactive "P")
+  (ess-set-working-directory default-directory))
 
 (defun ess-get-working-directory (&optional no-error)
   "Retrive the current working directory from the current ess process."

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -189,7 +189,7 @@ Root is determined by locating `ess-r-package-root-file'."
   "Set process directory to current package directory."
   (interactive)
   (let ((dir (cdr (ess-r-package-project))))
-    (ess-use-dir dir)))
+    (ess-set-working-directory dir)))
 
 (defun ess-r-package-set-package ()
   "Set a package for ESS r-package commands."

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -408,32 +408,6 @@
 ;;                    ;; Get initial indentation of the line we are on.
 ;;                    (current-indentation))))))))))
 
-
-(defun ess-use-this-dir (&optional no-force-current)
-  "Set the current process directory to `default-directory'.
-If that buffer has no associated *R* process, use
-\\[ess-force-buffer-current], unless prefix argument
-NO-FORCE-CURRENT is non-nil."
-  (interactive "P")
-  (ess-use-dir default-directory))
-
-(defun ess-use-dir (dir &optional no-force-current)
-  (interactive "P")
-  (unless (string= ess-language "S")
-    ;; FIXME: generalize this for Stata, SAS, Xlispstat... -- then move to ess-mode.el
-    (error "ESS setting working directory in *%s* not yet implemented for language %s"
-           ess-local-process-name
-           ess-language))
-  (unless no-force-current
-    (ess-force-buffer-current "R process to use: "))
-  (if ess-local-process-name
-      (let ((cmd (format "setwd('%s')\n" dir)))
-        (ess-command cmd)
-        (message "Directory of *%s* process set to %s"
-                 ess-local-process-name dir))
-    (message "No *%s* process associated with this buffer." ess-dialect)))
-
-
 ;;*;; S/R  Pretty-Editing
 
 (defun ess-fix-comments (&optional dont-query verbose)

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -59,6 +59,14 @@
       (should (output= (ess-eval-buffer nil)
                        "[1] \"hop\"")))))
 
+(ert-deftest ess-set-working-directory ()
+  (with-r-running nil
+    (ess-set-working-directory "/")
+    (ess-eval-linewise "getwd()" 'invisible)
+    (should (output= (ess-eval-buffer nil)
+              "setwd('/')\n> [1] \"/\""))
+    (should (string= default-directory "/"))))
+
 
 ;;; ess-r-package-mode
 


### PR DESCRIPTION
alias ess-use-dir to ess-set-working-directory since they do
essentially the same thing. Move ess-use-this-dir to ess-inf since it
can be used by non-S/R languages now.

Closes #550