### PR TITLE
Strip the path from the executable in inferior buffers

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -127,7 +127,7 @@ Alternatively, it can appear in its own frame if
            ;; Use temp-ess-dialect if not R, R program name otherwise
            (temp-dialect (if ess-use-inferior-program-in-buffer-name ;VS[23-02-2013]: fixme: this should not be here
                              (if (string-equal temp-ess-dialect "R")
-                                 inferior-ess-r-program
+                                 (file-name-nondirectory inferior-ess-r-program)
                                temp-ess-dialect)
                            temp-ess-dialect))
            (temp-lang temp-ess-lang)


### PR DESCRIPTION
When ess-use-inferior-program-in-buffer-name is non-nil, we should
show R-devel or whatever, not /path/to/R-devel

Closes #570