### PR TITLE
Strip extra + signs from output depending on ess-eval-visibly

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2237,38 +2237,24 @@ If you wish to pass arguments to a process, see e.g. `inferior-R-args'.")
   :group 'ess-proc
   :type 'string)
 
-;; does it make sense to customize here, as we currently set this *directly*
-;; in the FOO-BAR-cust-alist's ???
-;; VS: Right. It only confuses users. It should be set in post-run-hook if
-;; desired;  inferior-S-prompt should be customized instead.
 (defvar inferior-ess-primary-prompt "> "
   "Regular expression used by `ess-mode' to detect the primary prompt.")
-
 (make-variable-buffer-local 'inferior-ess-primary-prompt)
-;; (setq-default inferior-ess-primary-prompt "> ")
 
 (defvar inferior-ess-secondary-prompt nil
   "Regular expression used by ess-mode to detect the secondary prompt.
 This is issued by S to continue an incomplete expression.
 Set to nil if language doesn't support secondary prompt.")
-;; :group 'ess-proc
-;; :type 'string)
-
 (make-variable-buffer-local 'inferior-ess-secondary-prompt)
-;; (setq-default inferior-ess-secondary-prompt "+ ")
 
 (defvar ess-traceback-command nil
   "Command to generate error traceback.")
 
-;; need to recognise  + + + > > >
+;; need this to recognise  + + + > > >
 ;; and "+ . + " in tracebug prompt
-(defcustom inferior-S-prompt "[]a-zA-Z0-9.[]*\\(?:[>+.] \\)*> "
+(defvar inferior-S-prompt "^[]a-zA-Z0-9.[]*\\(?:[>+.] \\)+"
   "Regexp used in S and R inferior and transcript buffers for prompt navigation.
-Customise it to make `comint-previous-prompt' quiqly navigate to
-interesting portions of the buffer.
- "
-  :group 'ess-proc
-  :type 'string)
+Must be anchored to BOL.")
 
 (defvaralias 'inferior-ess-S-prompt 'inferior-S-prompt)
 ;;*;; Variables controlling interaction with the ESS process
@@ -2628,14 +2614,6 @@ If you change the value of this variable, restart Emacs for it to take effect."
   :group 'ess
   :type 'boolean)
 
-(defvar inferior-ess-font-lock-input t
-  "
-
-This variable has no effect. Customize
-`inferior-ess-font-lock-keywords' directly.
-")
-(make-obsolete-variable 'inferior-ess-font-lock-input nil "ESS[12.09]")
-
 ;; "Reserved Words" -- part 1 --
 (defvar ess-RS-constants
   '("TRUE" "FALSE" "NA" "NULL" "Inf" "NaN"))
@@ -2905,13 +2883,7 @@ system described in `inferior-ess-font-lock-keywords'.")
     (ess-fl-keyword:operators)
     (ess-fl-keyword:delimiters)
     (ess-fl-keyword:=)
-    (ess-R-fl-keyword:F&T)
-    ;;VS[17-09-2012]: what is this matching?
-    ;; (cons "^\\*\\*\\*.*\\*\\*\\*\\s *$" 'font-lock-comment-face); ess-mode msg
-
-    ;; (cons "#" 'font-lock-comment-face) ; comment
-    ;; (cons "^[^#]*#\\(.*$\\)" '(1 font-lock-comment-face keep t)) ; comments
-    )
+    (ess-R-fl-keyword:F&T))
   "Font-lock patterns used in inferior-R-mode buffers.
 The key of each cons cell is a name of the keyword.  The value
 should be t or nil to indicate if the keyword is active or not."

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2738,7 +2738,6 @@ system described in `ess-font-lock-keywords'.")
   (cons (regexp-opt ess-S-constants 'words) 'ess-constant-face)
   "Font-lock constants keyword.")
 
-
 (defcustom ess-S-font-lock-keywords
   '((ess-S-fl-keyword:modifiers . t)
     (ess-S-fl-keyword:fun-defs  . t)
@@ -2854,9 +2853,6 @@ system described in `inferior-ess-font-lock-keywords'.")
   (cons (concat "^" inferior-S-prompt) 'comint-highlight-prompt)
   "Highlight prompts missed by comint.")
 
-;; (defvar ess-S-fl-keyword:input-line
-;;   (cons "^[a-zA-Z0-9 ]*[>+]\\(.*$\\)" '(1 font-lock-variable-name-face keep t)))
-
 (defvar ess-fl-keyword:matrix-labels
   ;; also matches subsetting
   (cons "\\[,?[1-9][0-9]*,?\\]" 'ess-matrix-face)
@@ -2868,8 +2864,7 @@ system described in `inferior-ess-font-lock-keywords'.")
   "Inferior-ess problems or errors.")
 
 (defcustom inferior-ess-r-font-lock-keywords
-  '((ess-S-fl-keyword:prompt   . t) ;; comint does that, but misses some prompts
-    ;; (ess-S-fl-keyword:input-line) ;; comint boguously highlights input with text props, no use for this
+  '((ess-S-fl-keyword:prompt   . t) ;; comint is bad at prompt highlighting
     (ess-R-fl-keyword:messages  . t)
     (ess-R-fl-keyword:modifiers . t)
     (ess-R-fl-keyword:fun-defs  . t)

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2252,7 +2252,7 @@ Set to nil if language doesn't support secondary prompt.")
 
 ;; need this to recognise  + + + > > >
 ;; and "+ . + " in tracebug prompt
-(defvar inferior-S-prompt "^[]a-zA-Z0-9.[]*\\(?:[>+.] \\)+"
+(defvar inferior-S-prompt "[]a-zA-Z0-9.[]*\\(?:[>+.] \\)+"
   "Regexp used in S and R inferior and transcript buffers for prompt navigation.
 Must be anchored to BOL.")
 

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -229,18 +229,20 @@ This may be useful for debugging."
               (comint-read-input-ring))
 
             ;; create and run process.
-            (set-buffer
-             (if switches
-                 (inferior-ess-make-comint buf-name-str
-                                           procname
-                                           infargs
-                                           switches)
-               (inferior-ess-make-comint buf-name-str
-                                         procname
-                                         infargs)))
+            (setq buf
+                  (if switches
+                      (inferior-ess-make-comint buf-name-str
+                                                procname
+                                                infargs
+                                                switches)
+                    (inferior-ess-make-comint buf-name-str
+                                              procname
+                                              infargs)))
+            (set-buffer buf)
+            (setq proc (get-buffer-process buf))
 
             ;; Set the process sentinel to save the history
-            (set-process-sentinel (get-process procname) 'ess-process-sentinel)
+            (set-process-sentinel proc 'ess-process-sentinel)
             ;; Add this process to ess-process-name-list, if needed
             (let ((conselt (assoc procname ess-process-name-list)))
               (unless conselt
@@ -251,13 +253,12 @@ This may be useful for debugging."
             (setq ess-sl-modtime-alist nil)
 
             ;; Add the process filter to catch certain output
-            (set-process-filter (get-process procname)
-                                'inferior-ess-output-filter)
-            (inferior-ess-mark-as-busy (get-process procname))
+            (set-process-filter proc 'inferior-ess-output-filter)
+            (inferior-ess-mark-as-busy proc)
 
             (unless no-wait
               (ess-write-to-dribble-buffer "(inferior-ess: waiting for process to start (before hook)\n")
-              (ess-wait-for-process (get-process procname) nil 0.01))
+              (ess-wait-for-process proc nil 0.01))
 
             ;; arguments cache
             (ess-process-put 'funargs-cache (make-hash-table :test 'equal))
@@ -287,7 +288,7 @@ This may be useful for debugging."
             ;; user initialization can take some time ...
             (unless no-wait
               (ess-write-to-dribble-buffer "(inferior-ess 3): waiting for process after hook")
-              (ess-wait-for-process (get-process procname))))
+              (ess-wait-for-process proc)))
 
           (with-current-buffer buf
             (rename-buffer buf-name-str t))

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -121,7 +121,7 @@
     (ess-no-skip-regexp           . (concat "^ *@\\|" (default-value 'ess-no-skip-regexp)))
     ;; inferior-ess-prompt is used by comint for navigation, only if
     ;; comint-use-prompt-regexp is t; (transcript-mode also relies on this regexp)
-    (inferior-ess-prompt           . inferior-S-prompt) ;customizable
+    (inferior-ess-prompt           . inferior-S-prompt)
     (ess-get-help-topics-function  . #'ess-s-get-help-topics-function)
     (ess-getwd-command          . "getwd()\n")
     (ess-setwd-command          . "setwd('%s')\n")

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -1211,8 +1211,14 @@ value from EXPR and then sent to the subprocess."
    (ess-eval-visibly prompt)
    ((eq inferior-ess-replace-long+ 'strip) "> ")
    ((eq inferior-ess-replace-long+ t)
-    (replace-regexp-in-string "\\(\\+ \\)\\{4\\}\\(\\+ \\)+"
-                              ess-long+replacement prompt))
+    (let ((prompt (replace-regexp-in-string "\\(\\+ \\)\\{4\\}\\(\\+ \\)+"
+                                            ess-long+replacement prompt))
+          (len (length prompt)))
+      (if (and (> len 2)
+               (eq (elt prompt (- len 2)) ?+))
+          ;; append > for aesthetic reasons
+          (concat prompt "> ")
+        prompt)))
    (t prompt)))
 
 (defun ess--flush-accumulated-output (proc)
@@ -1280,9 +1286,6 @@ mirrors the output into *ess.dbg* buffer."
                           (string-match ess--dbg-regexp-skip string)
                           (not (string-match ess--dbg-regexp-no-skip string))))
          (match-dbg (or match-skip (and match-input (not match-selection))))
-         ;;check for main  prompt!! the process splits the output and match-end == nil might indicate this only
-         ;; (prompt-regexp "^>\\( [>+]\\)*\\( \\)$") ;; default prompt only
-         (prompt-replace-regexp "\\(^> \\|^\\([>+] \\)\\{2,\\}\\)\\(?1: \\)") ;; works only with the default prompt
          (is-ready (not (inferior-ess-set-status proc string)))
          (new-time (float-time))
          (last-time (process-get proc 'flush-time))

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -498,8 +498,8 @@ If 'strip, remove all such instances.  Otherwise, if non-nil, '+
   "Replacement used for long + prompt.
 Customization of this variable is not recommended. You can set it
 to '. '. If you set it to anything else you will have to change
-`inferior-S-prompt' to assure the correct prompt navigation
-in inferior buffers.  ")
+`inferior-S-prompt' to assure the correct prompt detection
+in inferior buffers.")
 
 (defmacro ess-copy-key (from-map to-map fun)
   `(define-key ,to-map
@@ -525,7 +525,7 @@ in inferior buffers.  ")
     (set (make-local-variable 'compilation-error-regexp-alist)
          ess-error-regexp-alist)
     (let (compilation-mode-font-lock-keywords)
-     (compilation-setup t))
+      (compilation-setup t))
     (setq next-error-function 'ess-tracebug-next-error-function)
     ;; new locals
     (make-local-variable 'ess--tb-last-input)
@@ -1150,7 +1150,7 @@ Kill the *ess.dbg.[R_name]* buffer."
 (defvar ess--dbg-regexp-debug  "\\(\\(?:Browse[][0-9]+\\)\\|\\(?:debug: \\)\\)")
 (defvar ess--dbg-regexp-selection "\\(Selection: \\'\\)")
 (defvar ess--dbg-regexp-input (concat ess--dbg-regexp-debug "\\|"
-                                     ess--dbg-regexp-selection))
+                                      ess--dbg-regexp-selection))
 
 (defvar ess--suppress-next-output? nil)
 

--- a/lisp/essd-els.el
+++ b/lisp/essd-els.el
@@ -213,7 +213,6 @@ DIALECT is the desired ess-dialect. If nil, ask for dialect"
 
     (ess-process-put 'funargs-cache (make-hash-table :test 'equal))
     (ess-process-put 'funargs-pre-cache nil)
-    (ess-process-put 'accum-buffer-name (format " *%s:accum*" ess-local-process-name))
     (ess-load-extras)
 
     (when inferior-ess-language-start


### PR DESCRIPTION
```
When ess-eval-visibly is nil or 'nowait, the inferior process outputs
+ as a part of the output. We don't want these, though, because they
are already inserted when putting the input in. They also throw off
alignment of the first column of the output, which can be annoying.
```
Closes bug #409
