### PR TITLE
Improve documentation for new smart S assignment change.

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -95,7 +95,10 @@ will need to update their customization to
 variables.
 
 @item Customization of ess-smart-S-assign-key has been reworked.
-You should now set the value before ESS is loaded. The following
+Use @code{(setq ess-smart-S-assign-key nil)} to disable smart
+assignment at any time instead of @code{(ess-toggle-underscore nil)}.
+To use another key, you should set the value of
+@code{ess-smart-S-assign-key} before ESS is loaded. The following
 functions have been made obsolete. You should customize
 ess-smart-S-assign-key instead: ess-toggle-S-assign,
 ess-toggle-S-assign-key, ess--unset-smart-S-assign-key,


### PR DESCRIPTION
I had to go to the PR for this change to find the new function I needed to call. I think it would be kind to reference this in the documentation. Calling `ess-toggle-underscore` after ESS is loaded seems to be a fairly common practice - indeed it is done in the Spacemacs ESS layer.  