### PR TITLE
Drop official support for Emacs 24.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: emacs-lisp
 env:
-  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis
   - EVM_EMACS=emacs-git-snapshot-travis

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,7 +4,10 @@
 Changes and New Features in development version:
 @itemize @bullet
 
-@item This is the last release to support Emacs older than 25.1
+@item We have dropped official support for Emacs 24.3 which was
+released 5 years ago.
+
+Note that this is the last release to support Emacs older than 25.1.
 Going forward, only GNU Emacs 25.1 and newer will be supported. Soon
 after this release, support for older Emacs versions will be dropped
 from the git master branch. Note that MELPA uses the git master branch

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,13 @@
 Changes and New Features in development version:
 @itemize @bullet
 
+@item This is the last release to support Emacs older than 25.1
+Going forward, only GNU Emacs 25.1 and newer will be supported. Soon
+after this release, support for older Emacs versions will be dropped
+from the git master branch. Note that MELPA uses the git master branch
+to produce ESS snapshots, so if you are using Emacs < 25.1 from MELPA
+and are unable to upgrade, you should switch to MELPA-stable.
+
 @item @ESS{[R]}: Fontification of roxygen @code{@@param} keywords now
 supports comma-separated parameters.
 

--- a/test/ess-literate-tests.el
+++ b/test/ess-literate-tests.el
@@ -221,7 +221,7 @@
     (search-backward "¶")
     (delete-char 1)
     ;; Fontification must take place after removing "¶"
-    ;; FIXME after Emacs 24.3: Use `font-lock-ensure'
+    ;; FIXME Emacs 25: Use `font-lock-ensure'
     (font-lock-default-fontify-buffer)
     ;; Reset Emacs state
     (unless keep-state


### PR DESCRIPTION
Includes and closes #561.

I stumbled onto issues with Emacs 24.3 while improving the test framework and spent too much time trying to fix these. As 24.3 was released in March 2013, more than 5 years ago, it is likely not worth it to bother maintaining support for it.