### PR TITLE
Add generator for keyword regexps

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -30,6 +30,10 @@ condition system that only potentially impact control flow:
 keywords inherit from @code{ess-modifiers-face} (the face used for
 @code{library()} etc).
 
+@item @ESS{[R]}: New function @code{ess-r-generate-font-lock-regexps}
+that should be called to regenerate the font-lock regexps after having
+modified a keywords variable such as @code{ess-R-keywords}.
+
 @item ESS modes now inherit from @code{prog-mode}.
 
 @item @ESS{[R]}: The package development minor mode now only activates

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -106,3 +106,33 @@ library attach detach source require¶
 
 library() attach() detach() source() require()¶
 
+
+### 6 Assignment operators are fontified -----------------------------
+
+foo¶ <- foo <<- foo -> foo ->> foo
+
+##! (while (not (eolp))
+##>   (should (not (face-at-point)))
+##>   (forward-char)
+##>   (should (eq (face-at-point) 'ess-assignment-face))
+##>   (skip-syntax-forward ".")
+##>   (should (not (face-at-point)))
+##>   (ignore-errors (forward-word)))
+
+foo <- foo <<- foo -> foo ->> foo¶
+
+
+### 7 Constants are fontified ----------------------------------------
+
+¶TRUE FALSE NA NULL Inf NaN
+NA_integer_ NA_real_ NA_complex_ NA_character_
+
+##! (while (not (eolp))
+##>   (should (eq (face-at-point) 'ess-constant-face))
+##>   (ignore-errors
+##>     (ess-forward-sexp)
+##>     (forward-char)))
+
+TRUE FALSE NA NULL Inf NaN
+NA_integer_ NA_real_ NA_complex_ NA_character_¶
+

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -136,3 +136,32 @@ NA_integer_ NA_real_ NA_complex_ NA_character_
 TRUE FALSE NA NULL Inf NaN
 NA_integer_ NA_real_ NA_complex_ NA_character_¶
 
+
+### 8 Can regenerate regexps after modifying keywords ----------------
+
+¶foobar foobaz()
+
+##! (setq-local ess-R-keywords (append '("foobaz") ess-R-keywords))
+##> (ess-r-generate-font-lock-regexps)
+##> (ess-r-mode)
+##> (font-lock-ensure)
+##> (should (not (face-at-point)))
+##> (forward-word)
+##> (forward-char)
+##> (should (eq (face-at-point) 'ess-keyword-face))
+
+foobar ¶foobaz()
+
+
+### 9 Can set keywords variable to nil -------------------------------
+
+¶stop()
+
+##! (setq-local ess-R-control-flow-keywords nil)
+##> (ess-r-generate-font-lock-regexps)
+##> (ess-r-mode)
+##> (font-lock-ensure)
+##> (should (not (face-at-point)))
+
+¶stop()
+

--- a/test/literate/fontification.el
+++ b/test/literate/fontification.el
@@ -1,3 +1,7 @@
 
+;; FIXME Emacs 25
+(unless (fboundp 'font-lock-ensure)
+  (defalias 'font-lock-ensure 'font-lock-default-fontify-buffer))
+
 (defun face-at-point ()
   (get-char-property (point) 'face))


### PR DESCRIPTION
It is currently quite tricky to modify variables like `ess-R-keywords`. If you modify those

* after loading ESS, this has no effect because the font-lock regexps are not updated;
* before loading ESS, you can't append to these variables as they are not defined yet

With `ess-r-generate-font-lock-regexps` implemented in this PR, users can update the keyword variables and regenerate the regexps manually afterwards.
