### PR TITLE
Provide "R" as a fallback for inferior-ess-r-program

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1679,7 +1679,8 @@ non-nil."
 
 
 (defcustom inferior-ess-r-program (or (executable-find "Rterm")
-                                      (executable-find "R"))
+                                      (executable-find "R")
+                                      "R")
   "Program name for invoking an inferior ESS with \\[R]."
   :group 'ess-R
   :type '(choice (string) file))


### PR DESCRIPTION
If we don't find R in PATH, we need a fallback option so that this is non-nil.