### PR TITLE
Rework ess-insert-S-assign, ess-smart-S-assign, ess-cycle-assignment

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -107,15 +107,21 @@ will need to update their customization to
 @code{inferior-ess-R-program}. These variables are treated as risky
 variables.
 
-@item Customization of ess-smart-S-assign-key has been reworked.
-Use @code{(setq ess-smart-S-assign-key nil)} to disable smart
-assignment at any time instead of @code{(ess-toggle-underscore nil)}.
-To use another key, you should set the value of
-@code{ess-smart-S-assign-key} before ESS is loaded. The following
-functions have been made obsolete. You should customize
-ess-smart-S-assign-key instead: ess-toggle-S-assign,
-ess-toggle-S-assign-key, ess--unset-smart-S-assign-key,
-ess--activate-smart-S-assign-key, ess-disable-smart-S-assign
+@item @code{ess-smart-S-assign} changed name to @code{ess-insert-S-assign}.
+By default, it provides similar functionality. Since many users
+dislike this functionality, it is easier to disable; set
+@code{ess-smart-S-assign-key} to nil. The following functions have
+been made obsolete and will be removed in the next release of ESS:
+ess-smart-S-assign, ess-toggle-S-assign, ess-toggle-S-assign-key,
+ess-disable-smart-S-assign.
+
+@item The option ess-S-assign has been removed.
+Customize new option @code{ess-assign-list} instead.
+
+@item @code{C-c C-=} is now bound to @code{ess-cycle-assignment} by default
+See the docstring for details. New user customization option
+@code{ess-assign-list} controls what assignment operators are cycled
+through.
 
 @end itemize
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -549,12 +549,6 @@ ess-smart-comma only, but will be enriched in the near future.")
 Used to avoid annoying jumping by ess-eval.*-and-step to end of
 buffer or end chunks etc.")
 
-(defcustom ess-S-assign " <- "
-  "String used for left assignment in all S dialects.
-Used by \\[ess-smart-S-assign]."
-  :group 'ess-S
-  :type 'string)
-
 (defcustom ess-smart-S-assign-key "_"
   "Key used by `ess-smart-S-assign'.
 Should be nil or a \"simple\" key, in other words no key
@@ -564,6 +558,19 @@ You may change this to nil at any time. However, if you change it
 to another string, it must be set before ESS is loaded."
   :group 'ess-S
   :type '(choice (const :tag "Nothing" :value nil) string))
+
+(defcustom ess-assign-list (cons (if (boundp 'ess-S-assign) ess-S-assign " <- ")
+                                 '(" <<- " " = " " -> " " ->> "))
+  "List of assignment operators.
+`ess-cycle-assignment' uses this list.  These strings must
+contain spaces on either side."
+  ;; Note that spaces on either side is not strictly true (as in the
+  ;; function won't error), but matching <-/<<- is broken without
+  ;; them.
+  :type '(repeat string)
+  :group 'ess)
+(defvar ess-S-assign)
+(make-obsolete-variable 'ess-S-assign 'ess-assign-list "2018-07-01")
 
 (defcustom ess-r-prettify-symbols
   '(("<-" . (?\s (Br . Bl) ?\s (Bc . Bc) ?←))

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1952,12 +1952,12 @@ for `ess-eval-region'."
     (define-key map "\M-?"     'ess-list-object-completions)
     (define-key map "\C-c\C-k" 'ess-request-a-process)
     (define-key map ","        'ess-smart-comma)
-
+    (define-key map (kbd "C-c C-=") 'ess-cycle-assignment)
     (define-key map "\C-c\C-d"   'ess-doc-map)
     (define-key map "\C-c\C-e"   'ess-extra-map)
     (define-key map "\C-c\C-t"   'ess-dev-map)
     (when ess-smart-S-assign-key
-      (define-key map ess-smart-S-assign-key #'ess-smart-S-assign))
+      (define-key map ess-smart-S-assign-key 'ess-insert-assign))
     map)
   "Keymap for `inferior-ess' mode.")
 

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -107,7 +107,8 @@
     (define-key map "\C-c\C-e"   'ess-extra-map)
     (define-key map "\C-c\C-t"   'ess-dev-map)
     (when ess-smart-S-assign-key
-      (define-key map ess-smart-S-assign-key #'ess-smart-S-assign))
+      (define-key map ess-smart-S-assign-key 'ess-insert-assign))
+    (define-key map (kbd "C-c C-=") 'ess-cycle-assignment)
     map)
   "Keymap for `ess-mode'.")
 

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -1287,15 +1287,14 @@ symbols (like aaa$bbb and aaa@bbb in R)."
         (ess-symbol-start)))))
 
 (defun ess-inside-string-or-comment-p (&optional pos)
-  "Return non-nil if POSition [defaults to (point)] is inside string or comment
- (according to syntax)."
-  ;;FIXME (defun ess-calculate-indent ..)  can do that ...
-  (interactive)
-  (setq pos (or pos (point)))
-  (let ((ppss (syntax-ppss pos)))
-    (or (car (setq ppss (nthcdr 3 ppss)))
-        (car (setq ppss (cdr ppss)))
-        (nth 3 ppss))))
+  "Return non-nil if POS is inside a string or comment.
+POS defaults to `point.'"
+  (save-excursion
+    (let* ((pos (or pos (point)))
+           (state (syntax-ppss pos)))
+      (or (nth 3 state) (nth 4 state)))))
+
+
 
 (defun ess-inside-string-p (&optional pos)
   "Return non-nil if point is inside string (according to syntax)."

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -151,35 +151,11 @@
                                          ("2005-12-30" . "R-2.0")))
                  "R-dev")))
 
-(ert-deftest ess-smart-S-assign ()
+(ert-deftest ess-insert-S-assign ()
   ;; one call should insert assignment:
   (should
    (string= " <- "
             (ess-r-test-with-temp-text ""
               (progn
-                (ess-smart-S-assign)
-                (buffer-substring (point-min) (point-max))))))
-  ;; Two calls should insert underscore:
-  (should
-   (string= "_"
-            (ess-r-test-with-temp-text ""
-              (progn
-                (ess-smart-S-assign)
-                (ess-smart-S-assign)
-                (buffer-substring (point-min) (point-max))))))
-  ;; One call should insert underscore in comments
-  (should
-   (string= "## _"
-            (ess-r-test-with-temp-text "## ¶"
-              (progn
-                (ess-smart-S-assign)
-                (buffer-substring (point-min) (point-max))))))
-  ;; Users can set this to other keys, test =
-  (should
-   (string= "="
-            (ess-r-test-with-temp-text ""
-              (let ((ess-smart-S-assign-key "="))
-                (progn
-                  (ess-smart-S-assign)
-                  (ess-smart-S-assign)
-                  (buffer-substring (point-min) (point-max))))))))
+                (call-interactively 'ess-insert-S-assign)
+                (buffer-substring (point-min) (point-max)))))))


### PR DESCRIPTION
* ess-insert-S-assign now inserts ess-S-assign, and only replaces it
  if new defcustom ess-maybe-replace-S-assign is non-nil. Since
  ess-maybe-replace-S-assign is nil by default, this changes current
  behavior. It is removed from ess-mode-map and inferior-ess-mode-map.

* New function ess-cycle-assignment cycles through the assignment
  operators in new defcustom ess-assign-list. It is bound to C-c C-=
  in ess-mode-map and inferior-ess-mode-map

Closes #584