### PR TITLE
Set dialect variables in package files for smoother interaction

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,7 +4,12 @@
 Changes and New Features in development version:
 @itemize @bullet
 
-@item @ESS{[R]}: @code{ess-r-package-use-dir} now works with any mode
+@item @ESS{[R]}: The R package mode now sets @code{ess-dialect} to
+@code{"R"} for all modes. This way interactive commands called from C or
+C++ files automatically select relevant inferior processes.
+
+@item @ESS{[R]}: @code{ess-r-package-use-dir} (which sets the working
+directory to the root of the current package) now works with any mode
 (e.g. in C or C++ files within @code{/src}).
 
 @item This is the last release to support Emacs older than 25.1

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -6,7 +6,11 @@ Changes and New Features in development version:
 
 @item @ESS{[R]}: The R package mode now sets @code{ess-dialect} to
 @code{"R"} for all modes. This way interactive commands called from C or
-C++ files automatically select relevant inferior processes.
+C++ files automatically select relevant inferior processes. We
+selectively forward settings that are relevant for interaction with the
+inferior from any mode. If an ESS command doesn't work as expected from
+a C or C++ file within a package (or any other mode), please file an
+issue.
 
 @item @ESS{[R]}: @code{ess-r-package-use-dir} (which sets the working
 directory to the root of the current package) now works with any mode

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,9 @@
 Changes and New Features in development version:
 @itemize @bullet
 
+@item @ESS{[R]}: @code{ess-r-package-use-dir} now works with any mode
+(e.g. in C or C++ files within @code{/src}).
+
 @item This is the last release to support Emacs older than 25.1
 Going forward, only GNU Emacs 25.1 and newer will be supported. Soon
 after this release, support for older Emacs versions will be dropped

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,13 +4,9 @@
 Changes and New Features in development version:
 @itemize @bullet
 
-@item @ESS{[R]}: The R package mode now sets @code{ess-dialect} to
-@code{"R"} for all modes. This way interactive commands called from C or
-C++ files automatically select relevant inferior processes. We
-selectively forward settings that are relevant for interaction with the
-inferior from any mode. If an ESS command doesn't work as expected from
-a C or C++ file within a package (or any other mode), please file an
-issue.
+@item @ESS{[R]}: Interaction with inferior process in non-R files within
+packages (for instance C or C++ files) has been improved. This is a work
+in progress.
 
 @item @ESS{[R]}: @code{ess-r-package-use-dir} (which sets the working
 directory to the root of the current package) now works with any mode

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -2634,6 +2634,7 @@ command (%s) like this, or a version with explicit options(max.print=1e6):
 
 local({ out <- try({%s}); print(out, max=1e6) })\n
 "
+  (inferior-ess-force)
   (let* ((tbuffer (get-buffer-create
                    " *ess-get-words*")); initial space: disable-undo
          (word-RE

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -3037,7 +3037,7 @@ prefix argument NO-FORCE-CURRENT is non-nil."
 (defun ess-get-working-directory (&optional no-error)
   "Retrive the current working directory from the current ess process."
   (if ess-getwd-command
-      (car (ess-get-words-from-vector ess-getwd-command))
+      (abbreviate-file-name (car (ess-get-words-from-vector ess-getwd-command)))
     (unless no-error
       (error "Not implemented for dialect %s" ess-dialect))))
 

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -476,7 +476,9 @@ disable the mode line entirely."
         ;; processes from any mode
         (let ((vars '(ess-dialect
                       ess-setwd-command
-                      ess-getwd-command)))
+                      ess-getwd-command
+                      ess-quit-function
+                      inferior-ess-reload-function)))
           (mapc (lambda (var) (set (make-local-variable var)
                               (eval (cdr (assq var ess-r-customize-alist)))))
                 vars))

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -472,14 +472,14 @@ disable the mode line entirely."
   :lighter ess-r-package-mode-line
   (if ess-r-package-mode
       (progn
-        ;; Forward R' setwd command so `ess-r-package-use-dir' works
-        ;; for all modes. May want to use a more general package-wide
-        ;; customize-alist in the future.
-        (let ((setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist)))
-              (getwd-cmd (cdr (assq 'ess-getwd-command ess-r-customize-alist))))
-          (setq-local ess-setwd-command setwd-cmd)
-          (setq-local ess-getwd-command getwd-cmd))
-        (setq-local ess-dialect "R")
+        ;; Forward relevant R settings for interacting with inferior
+        ;; processes from any mode
+        (let ((vars '(ess-dialect
+                      ess-setwd-command
+                      ess-getwd-command)))
+          (mapc (lambda (var) (set (make-local-variable var)
+                              (eval (cdr (assq var ess-r-customize-alist)))))
+                vars))
         (add-hook 'project-find-functions #'ess-r-package-project)
         (run-hooks 'ess-r-package-enter-hook))
     (remove-hook 'project-find-functions #'ess-r-package-project)

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -472,6 +472,11 @@ disable the mode line entirely."
   :lighter ess-r-package-mode-line
   (if ess-r-package-mode
       (progn
+        ;; Forward R' setwd command so `ess-r-package-use-dir' works
+        ;; for all modes. May want to use a more general package-wide
+        ;; customize-alist in the future.
+        (let ((cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist))))
+          (setq-local ess-setwd-command cmd))
         (add-hook 'project-find-functions #'ess-r-package-project)
         (run-hooks 'ess-r-package-enter-hook))
     (remove-hook 'project-find-functions #'ess-r-package-project)

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -475,8 +475,10 @@ disable the mode line entirely."
         ;; Forward R' setwd command so `ess-r-package-use-dir' works
         ;; for all modes. May want to use a more general package-wide
         ;; customize-alist in the future.
-        (let ((cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist))))
-          (setq-local ess-setwd-command cmd))
+        (let ((setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist)))
+              (getwd-cmd (cdr (assq 'ess-getwd-command ess-r-customize-alist))))
+          (setq-local ess-setwd-command setwd-cmd)
+          (setq-local ess-getwd-command getwd-cmd))
         (setq-local ess-dialect "R")
         (add-hook 'project-find-functions #'ess-r-package-project)
         (run-hooks 'ess-r-package-enter-hook))

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -477,6 +477,7 @@ disable the mode line entirely."
         ;; customize-alist in the future.
         (let ((cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist))))
           (setq-local ess-setwd-command cmd))
+        (setq-local ess-dialect "R")
         (add-hook 'project-find-functions #'ess-r-package-project)
         (run-hooks 'ess-r-package-enter-hook))
     (remove-hook 'project-find-functions #'ess-r-package-project)

--- a/test/ess-r-tests-utils.el
+++ b/test/ess-r-tests-utils.el
@@ -13,6 +13,19 @@
       (R-mode)
       (mapcar #'eval body))))
 
+(defmacro with-c-file (file &rest body)
+  (declare (indent 1) (debug (&rest body)))
+  `(apply #'with-c-file- (list ,file '(,@body))))
+
+(defun with-c-file- (file body)
+  (let ((c-file-buffer (if file
+                           (find-file-noselect file)
+                         (generate-new-buffer " *with-c-file-temp*"))))
+    (save-window-excursion
+      (switch-to-buffer c-file-buffer)
+      (c-mode)
+      (mapcar #'eval body))))
+
 ;; Borrowed from org
 (defmacro ess-r-test-with-temp-text (text &rest body)
   "Run body in a temporary buffer with `R-mode' as the active

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -102,6 +102,12 @@
       (should (not ess-r-package-mode))
       (kill-buffer))))
 
+(ert-deftest ess-r-package-setwd ()
+  (with-r-file "dummy-pkg/src/test.c"
+    (let ((r-setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist))))
+      (should (string= ess-setwd-command r-setwd-cmd)))))
+
+
 ;;; Namespaced evaluation
 
 (ert-deftest ess-r-run-presend-hooks ()

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -113,7 +113,7 @@
           (r-getwd-cmd (cdr (assq 'ess-getwd-command ess-r-customize-alist))))
       (should (string= ess-setwd-command r-setwd-cmd))
       (should (string= ess-getwd-command r-getwd-cmd)))
-    (let ((pkg-dir (cdr (ess-r-package-project)))
+    (let ((pkg-dir (abbreviate-file-name (cdr (ess-r-package-project))))
           ;; Not sure why this is needed:
           ess-ask-for-ess-directory)
       (ess-set-working-directory (expand-file-name "src" pkg-dir))
@@ -124,7 +124,7 @@
       (ess-wait-for-process)
       (let ((proc-buffer (ess-get-process-buffer)))
         (inferior-ess-reload)
-        (should (string-match "Process R:2 finished"
+        (should (string-match "Process R\\(:.\\)? finished"
                               (with-current-buffer proc-buffer
                                 (buffer-string))))))))
 

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -108,7 +108,7 @@
       (kill-buffer))))
 
 (ert-deftest ess-r-package-vars ()
-  (with-r-file "dummy-pkg/src/test.c"
+  (with-c-file "dummy-pkg/src/test.c"
     (let ((r-setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist)))
           (r-getwd-cmd (cdr (assq 'ess-getwd-command ess-r-customize-alist))))
       (should (string= ess-setwd-command r-setwd-cmd))
@@ -120,7 +120,13 @@
       (ess-r-package-use-dir)
       (should (string= (directory-file-name default-directory) pkg-dir))
       (ess-wait-for-process)
-      (should (string= (ess-get-working-directory) pkg-dir)))))
+      (should (string= (ess-get-working-directory) pkg-dir))
+      (ess-wait-for-process)
+      (let ((proc-buffer (ess-get-process-buffer)))
+        (inferior-ess-reload)
+        (should (string-match "Process R:2 finished"
+                              (with-current-buffer proc-buffer
+                                (buffer-string))))))))
 
 
 ;;; Namespaced evaluation

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -107,16 +107,20 @@
       (should (not ess-r-package-mode))
       (kill-buffer))))
 
-(ert-deftest ess-r-package-setwd ()
+(ert-deftest ess-r-package-vars ()
   (with-r-file "dummy-pkg/src/test.c"
-    (let ((r-setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist))))
-      (should (string= ess-setwd-command r-setwd-cmd)))
+    (let ((r-setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist)))
+          (r-getwd-cmd (cdr (assq 'ess-getwd-command ess-r-customize-alist))))
+      (should (string= ess-setwd-command r-setwd-cmd))
+      (should (string= ess-getwd-command r-getwd-cmd)))
     (let ((pkg-dir (cdr (ess-r-package-project)))
           ;; Not sure why this is needed:
           ess-ask-for-ess-directory)
       (ess-set-working-directory (expand-file-name "src" pkg-dir))
       (ess-r-package-use-dir)
-      (should (string= (directory-file-name default-directory) pkg-dir)))))
+      (should (string= (directory-file-name default-directory) pkg-dir))
+      (ess-wait-for-process)
+      (should (string= (ess-get-working-directory) pkg-dir)))))
 
 
 ;;; Namespaced evaluation

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -105,7 +105,13 @@
 (ert-deftest ess-r-package-setwd ()
   (with-r-file "dummy-pkg/src/test.c"
     (let ((r-setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist))))
-      (should (string= ess-setwd-command r-setwd-cmd)))))
+      (should (string= ess-setwd-command r-setwd-cmd)))
+    (let ((pkg-dir (cdr (ess-r-package-project)))
+          ;; Not sure why this is needed:
+          ess-ask-for-ess-directory)
+      (ess-set-working-directory (expand-file-name "src" pkg-dir))
+      (ess-r-package-use-dir)
+      (should (string= (directory-file-name default-directory) pkg-dir)))))
 
 
 ;;; Namespaced evaluation

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -67,6 +67,11 @@
               "setwd('/')\n> [1] \"/\""))
     (should (string= default-directory "/"))))
 
+(ert-deftest ess-inferior-force ()
+  (with-r-running nil
+    (should (equal (ess-get-words-from-vector "letters[1:2]\n")
+                   (list "a" "b")))))
+
 
 ;;; ess-r-package-mode
 


### PR DESCRIPTION
This sets `ess-dialect` and `ess-setwd-command` in all package files. The goal is for inferior commands to work out of the box in all modes. In the future it might make sense to create a customize-alist for the package mode.