### PR TITLE
Disable flymake during tests

### DIFF
--- a/test/run-tests
+++ b/test/run-tests
@@ -13,6 +13,9 @@
 
 (require 'ess-site)
 
+;; lintr probably isn't installed in the test suite and flymake will
+;; complain about that. Disable it during tests.
+(setq ess-use-flymake nil)
 
 (when (= (length argv) 0)
   (setq argv '("--ess" "--inf" "--rstats" "--rstats-indent" "--literate")))


### PR DESCRIPTION
Flymake complains about lintr not existing, which results in a lot of
unnecessary output in the travis tests. This stops that.