### PR TITLE
Separate R/S runner definition

### DIFF
--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -963,9 +963,11 @@ Function defined using `ess-define-runner'."
                      (R start-args)))
                   ((string= dialect "S")
                    (let ((inferior-S+-program name))
+                     (require 'ess-sp6-d)
                      (S+)))
                   ((string= dialect "SAS")
                    (let ((inferior-SAS-program name))
+                     (require 'ess-sas-d)
                      (SAS))))))))
 
 (defun ess-version ()

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -434,11 +434,6 @@ Set this variable to nil to disable searching for other versions of R.
 If you set this variable, you need to restart Emacs (and set this variable
 before ess-site is loaded) for it to take effect.")
 
-;; Create functions for calling different (older or newer than default)
-;; versions of R and S(qpe).
-(defvar ess-versions-created nil
-  "List of strings of all S- and R-versions found on the system.")
-
 (defvar ess-r-created-runners nil
   "List of R-versions found from `ess-r-versions' on the system.")
 (define-obsolete-variable-alias 'ess-r-versions-created 'ess-r-created-runners "2018-05-05")
@@ -665,14 +660,12 @@ as `ess-r-created-runners' upon ESS initialization."
       ;; Iterate over each string in VERSIONS, creating a new defun each time.
       (setq ess-r-created-runners
             (mapc (lambda (v) (ess-define-runner v "R")) versions))
-      (setq ess-versions-created (append ess-versions-created
-                                         ess-r-created-runners))
       ;; Add to menu
-      (when ess-versions-created
+      (when ess-r-created-runners
         ;; new-menu will be a list of 3-vectors, of the form:
         ;; ["R-1.8.1" R-1.8.1 t]
         (let ((new-menu (mapcar (lambda(x) (vector x (intern x) t))
-                                ess-versions-created)))
+                                ess-r-created-runners)))
           (easy-menu-add-item ess-mode-menu '("Start Process")
                               (cons "Other" new-menu)))))))
 (define-obsolete-function-alias

--- a/lisp/ess-rutils.el
+++ b/lisp/ess-rutils.el
@@ -51,7 +51,7 @@
 ;;; Code:
 
 ;; Autoloads and requires
-(require 'ess-site)
+(require 'ess-r-mode)
 (require 'ess-rdired)
 
 (defvar ess-rutils-buf "*R temp*"

--- a/lisp/ess-sas-l.el
+++ b/lisp/ess-sas-l.el
@@ -49,7 +49,6 @@
 
 ;;; Code:
 
-(require 'ess)
 (require 'ess-mode)
 (require 'ess-custom)
 (require 'ess-sas-a)

--- a/lisp/ess-site.el
+++ b/lisp/ess-site.el
@@ -42,9 +42,6 @@
 
 ;;; Code:
 
-;; Provide here; otherwise we'll get infinite loops of (require ..):
-(provide 'ess-site)
-
 ;;;; Load path, autoloads, and major modes
 ;;;; ========================================
 ;;
@@ -95,10 +92,6 @@ for ESS, such as icons.")
   (add-to-list 'Info-default-directory-list (expand-file-name "../doc/info/" ess-lisp-directory)))
 
 
-;; Loads ess-custom.el and more
-(require 'ess)
-
-
 ;;; Loading popular dialects (they should become optional in the future)
 
 ;; R and Julia
@@ -137,20 +130,9 @@ for ESS, such as icons.")
 ;;; Toolbar support
 (require 'ess-toolbar)
 
-;;;  Site Specific setup
-;;;; ===============================================
-
-(eval-after-load "ess-r-mode"
-  '(progn
-     (ess-write-to-dribble-buffer "[ess-site:] before creating ess-versions-* ...")
-     (ess-r-s-define-runners+menu)
-     (ess-write-to-dribble-buffer "[ess-site:] after ess-versions-created ...")))
-
-;; Check to see that inferior-ess-r-program points to a working version
-;; of R; if not, try to find the newest version:
-(ess-check-R-program) ;; -> (ess-find-newest-R) if needed, in ./ess-r-d.el
 (ess-write-to-dribble-buffer "[ess-site:] *very* end ...")
 
 
+(provide 'ess-site)
 
 ;;; ess-site.el ends here

--- a/lisp/ess-sp6-d.el
+++ b/lisp/ess-sp6-d.el
@@ -187,9 +187,27 @@ ESS initialization."
       ;; Iterate over each string in VERSIONS, creating a new defun
       ;; each time.
       (setq ess-s-created-runners
-            (mapc (lambda (v) (ess-define-runner v "S")) versions)))))
+            (mapc (lambda (v) (ess-define-runner v "S")) versions))
+      (setq ess-versions-created (append ess-versions-created
+                                         ess-r-created-runners))
+      ;; Add to menu
+      (when ess-versions-created
+        ;; new-menu will be a list of 3-vectors, of the form:
+        ;; ["R-1.8.1" R-1.8.1 t]
+        (let ((new-menu (mapcar (lambda (x) (vector x (intern x) t))
+                                ess-versions-created)))
+          (easy-menu-add-item ess-mode-menu '("Start Process")
+                              (cons "Other" new-menu)))))))
+;; Define the runners
+(if ess-microsoft-p
+    (nconc
+     (ess-sqpe-versions-create ess-SHOME-versions) ;; 32-bit
+     (ess-sqpe-versions-create ess-SHOME-versions-64 "-64-bit")) ;; 64-bit
+  (ess-s-define-runners))
 (define-obsolete-function-alias
   'ess-s-versions-create 'ess-s-define-runners "2018-05-12")
+
+
 
  ; Provide package
 

--- a/lisp/ess-sp6-d.el
+++ b/lisp/ess-sp6-d.el
@@ -188,14 +188,12 @@ ESS initialization."
       ;; each time.
       (setq ess-s-created-runners
             (mapc (lambda (v) (ess-define-runner v "S")) versions))
-      (setq ess-versions-created (append ess-versions-created
-                                         ess-r-created-runners))
       ;; Add to menu
-      (when ess-versions-created
+      (when ess-s-created-runners
         ;; new-menu will be a list of 3-vectors, of the form:
         ;; ["R-1.8.1" R-1.8.1 t]
         (let ((new-menu (mapcar (lambda (x) (vector x (intern x) t))
-                                ess-versions-created)))
+                                ess-s-created-runners)))
           (easy-menu-add-item ess-mode-menu '("Start Process")
                               (cons "Other" new-menu)))))))
 ;; Define the runners

--- a/lisp/ess-swv.el
+++ b/lisp/ess-swv.el
@@ -81,8 +81,7 @@
 ;;; Autoloads and Requires
 
 (eval-when-compile
-  (require 'ess-custom)
-  (require 'ess))
+  (require 'ess-custom))
 
 (require 'ess-utils)
 (require 'ess-noweb-mode)

--- a/lisp/ess-trns.el
+++ b/lisp/ess-trns.el
@@ -33,7 +33,7 @@
 
  ; Requires and autoloads
 
-(require 'ess)
+(require 'ess-mode)
 (require 'ess-inf)
 (require 'comint)
 

--- a/lisp/obsolete/ess-r-args.el
+++ b/lisp/obsolete/ess-r-args.el
@@ -174,8 +174,6 @@
 (eval-when-compile
   (require 'tooltip)); for tooltip-show
 
-(require 'ess)
-
 ;; These defvars were previously defcustoms in ess-custom
 (defvar ess-r-args-noargsmsg "No args found."
   "Message returned if \\[ess-r-args-get] cannot find a list of arguments.")


### PR DESCRIPTION
R runners created when ess-r-mode is loaded, S runners when ess-sp6-d is loaded.

Moving code around I got into the fun land of ESS's requires/provides dance, let me know if something looks wrong/off. 

Closes #596 