### PR TITLE
Fix many compiler warnings

### DIFF
--- a/lisp/ess-bugs-l.el
+++ b/lisp/ess-bugs-l.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'font-lock)
+(require 'shell)
 (require 'comint)
 (require 'ess-utils)
 (require 'ess-custom)
@@ -270,7 +271,6 @@ add path to the command name."
 (defun ess-bugs-shell ()
   "Create a buffer with BUGS running as a subprocess."
   (interactive)
-  (require 'shell)
   (switch-to-buffer (concat "*" ess-bugs-shell-buffer-name "*"))
   (make-comint ess-bugs-shell-buffer-name ess-bugs-shell-command nil
                ess-bugs-default-bins ess-bugs-shell-default-output-file-root)

--- a/lisp/ess-dde.el
+++ b/lisp/ess-dde.el
@@ -31,8 +31,9 @@
 
 ;;; Code:
 
-
-;; *NO* Requires and autoloads
+(require 'ess-custom)
+(require 'ess)
+(require 'ess-utils)
 
 (defun ess-ddeclient-p ()
   "Returns t iff `ess-local-process-name' is associated with an

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -40,11 +40,15 @@
 (eval-when-compile
   (require 'cl-lib)
   (require 'tramp)
-  (require 'reporter)
-  (require 'ess-inf)
-  (require 'info))
+  (require 'reporter))
 
+(require 'info)
 (require 'ess)
+(require 'ess-inf)
+(require 'ess-utils)
+
+(defvar ess--help-frame nil
+  "Stores the frame used for displaying R help buffers.")
 
  ; ess-help-mode
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -536,9 +540,6 @@ For internal use.  Take into account variable `ess-help-own-frame'."
         (pop-to-buffer buff action)
       (display-buffer buff action))))
 
-(defvar ess--help-frame nil
-  "Stores the frame used for displaying R help buffers.")
-
 (defun ess-help-web-search ()
   "Search the web for documentation"
   (interactive)
@@ -694,7 +695,6 @@ Other keybindings are as follows:
   (require 'easymenu)
   (easy-menu-define ess-help-mode-menu-map ess-help-mode-map
     "Menu keymap for ess-help mode." ess-help-mode-menu)
-  (easy-menu-add ess-help-mode-menu-map ess-help-mode-map)
 
   ;; Add the keys for navigating among sections; this is done
   ;; dynamically since different languages (e.g. S vs R) have different

--- a/lisp/ess-jags-d.el
+++ b/lisp/ess-jags-d.el
@@ -26,6 +26,7 @@
 (require 'ess-bugs-l)
 (require 'ess-utils)
 (require 'ess-inf)
+(require 'ess)
 
 (setq auto-mode-alist
       (append '(("\\.[jJ][aA][gG]\\'" . ess-jags-mode)) auto-mode-alist))

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -50,6 +50,22 @@
 (declare-function company-in-string-or-comment "company")
 (declare-function company-doc-buffer "company")
 
+;; Silence the byte compiler. It emits wonky warnings because most of
+;; this file is only loaded if julia-mode is found.
+(declare-function ess-julia--get-objects "ess-julia")
+(declare-function ess-julia--retrive-topics "ess-julia")
+(declare-function ess-julia--get-components "ess-julia")
+(declare-function ess-julia-objects "ess-julia")
+(declare-function ess-julia-get-object-help-string "ess-julia")
+(declare-function julia-latexsub "julia-mode")
+(declare-function julia-mode "julia-mode")
+
+
+(defcustom inferior-julia-args ""
+  "String of arguments (see 'julia --help') used when starting julia."
+  :group 'ess-julia
+  :type 'string)
+
 ;;;--- ALL the following only if  julia-mode is found and loaded correctly : ----------
 (condition-case nil
       (progn
@@ -353,11 +369,6 @@ to look up any doc strings."
     (ess-setwd-command             . "cd(expanduser(\"%s\"))\n")
     )
   "Variables to customize for Julia -- set up later than emacs initialization.")
-
-(defcustom inferior-julia-args ""
-  "String of arguments (see 'julia --help') used when starting julia."
-  :group 'ess-julia
-  :type 'string)
 
 (defvar ess-julia-completion-syntax-table
   (let ((table (make-syntax-table ess-r-syntax-table)))

--- a/lisp/ess-noweb-mode.el
+++ b/lisp/ess-noweb-mode.el
@@ -81,6 +81,9 @@
 
 ;;; Code:
 
+(require 'ess-custom)
+(require 'ess-utils)
+
 (defvar weave-process)
 
 
@@ -175,6 +178,12 @@ mouse-1, this will override your binding.")
 \"[[\" .. \"]]\" pairs.  Note that rarely this has been found to be buggy
 with the \"catastrophic\" consequence of whole parts of your document being
 replaced by sequences of '*'.")
+
+(defvar ess-noweb-doc-mode ess-noweb-default-doc-mode
+  "Default major mode for editing noweb documentation chunks.
+It is not possible to have more than one doc-mode in a file.
+However, this variable is used to determine whether the doc-mode needs
+to by added to the mode-line")
 
 ;; The following is apparently broken -- dangling code that was
 ;; commented out.  Need to see if we can get it working?
@@ -1289,12 +1298,6 @@ in the middle and and update the chunk vector."
               (run-hooks 'ess-noweb-select-mode-hook)
               (run-hooks 'ess-noweb-select-doc-mode-hook)))
           (run-hooks 'ess-noweb-changed-chunk-hook)))))
-
-(defvar ess-noweb-doc-mode ess-noweb-default-doc-mode
-  "Default major mode for editing noweb documentation chunks.
-It is not possible to have more than one doc-mode in a file.
-However, this variable is used to determine whether the doc-mode needs
-to by added to the mode-line")
 
 (defun ess-noweb-set-doc-mode (mode)
   "Change the major mode for editing documentation chunks."

--- a/lisp/ess-noweb.el
+++ b/lisp/ess-noweb.el
@@ -35,6 +35,8 @@
 
  ; Requires and autoloads
 
+(require 'ess-custom)
+(require 'ess-inf)
 (require 'ess-noweb-mode)
 
  ; Variables

--- a/lisp/ess-omg-d.el
+++ b/lisp/ess-omg-d.el
@@ -34,6 +34,7 @@
 ;;; Requires and Autoloads:
 
 (require 'ess-omg-l)
+(require 'ess-trns)
 
 (defvar OMG-dialect-name "OMG"
   "Name of 'dialect' for Omega.") ;easily changeable in a user's .emacs

--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -33,6 +33,8 @@
 (eval-when-compile
   (require 'cl-lib))
 (require 'ess-utils)
+(require 'ess-inf)
+(require 'ess-help)
 
 (defvar ac-auto-start)
 (defvar ac-prefix)
@@ -167,6 +169,11 @@ or \\[ess-internal-complete-object-name] otherwise."
     (when (string-match "complete" (symbol-name last-command))
       (message "No ESS process associated with current buffer")
       nil)))
+
+(defun ess-list-object-completions nil
+  "List all possible completions of the object name at point."
+  (interactive)
+  (ess-complete-object-name))
 
 (defun ess-complete-object-name-deprecated ()
   "Gives a deprecated message "

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -908,9 +908,11 @@ See `ess-noweb-mode' and `R-mode' for more help."
 ;;;###autoload
 (add-to-list 'interpreter-mode-alist '("r" . R-mode))
 
-(defun R-fix-T-F (&optional from quietly)
-  "Fix T/F into TRUE and FALSE *cautiously*, i.e. not in comments and strings;
- starting from the current position (point)."
+(defun ess-r-fix-T-F (&optional from quietly)
+  "Change T/F into TRUE and FALSE cautiously.
+Do not change in comments and strings. Start at FROM, which
+defaults to point, and change to end of buffer. When QUIETLY, do
+not issue messages."
   (interactive "d\nP"); point and prefix (C-u)
   (save-excursion
     (goto-char from)
@@ -919,6 +921,8 @@ See `ess-noweb-mode' and `R-mode' for more help."
     (goto-char from)
     (ess-rep-regexp "\\(\\([][=,()]\\|<-\\) *\\)F\\>" "\\1FALSE"
                     'fixcase nil (not quietly))))
+(define-obsolete-function-alias 'R-fix-T-F 'ess-r-fix-T-F
+  "2018-07-25")
 
 (defvar ess--packages-cache nil
   "Cache var to store package names. Used by

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -45,7 +45,10 @@
 (require 'ess-r-completion)
 (require 'ess-r-syntax)
 (require 'ess-r-package)
+(require 'ess-trns)
 (when (>= emacs-major-version 25) (require 'ess-r-xref)) ;; Xref API was added in Emacs 25.1
+;; TODO: Remove when we drop support for Emacs 24:
+(declare-function ess-r-xref-backend "exx-r-xref")
 (when (>= emacs-major-version 26) (require 'ess-r-flymake)) ; Flymake rewrite in Emacs 26
 
 ;; TODO: Refactor so as to not rely on dynamic scoping.  After that
@@ -249,6 +252,13 @@
     table)
   "Syntax table used for completion and help symbol lookup.
 It makes underscores and dots word constituent chars.")
+
+(defvar ess-r-namespaced-load-verbose t
+  "Whether to display information on namespaced loading.
+
+When t, loading a file into a namespaced will output information
+about which objects are exported and which stay hidden in the
+namespace.")
 
 (defun ess-r-font-lock-syntactic-face-function (state)
   (let ((string-end (save-excursion
@@ -1063,10 +1073,6 @@ variable.")
       (and ess-current-process-name
            (ess-get-process-variable 'ess-r-evaluation-env))))
 
-(defvar ess-r-prompt-for-attached-pkgs-only nil
-  "If nil provide completion for all installed R packages.
-If non-nil, only look for attached packages.")
-
 (defun ess-r-set-evaluation-env (&optional arg)
   "Select a package namespace for evaluation of R code.
 
@@ -1102,13 +1108,6 @@ attached packages."
                                      'face 'mode-line-emphasis))
               ""))))
 (put 'ess-r--evaluation-env-mode-line 'risky-local-variable t)
-
-(defvar ess-r-namespaced-load-verbose t
-  "Whether to display information on namespaced loading.
-
-When t, loading a file into a namespaced will output information
-about which objects are exported and which stay hidden in the
-namespace.")
 
 (defvar ess-r-namespaced-load-only-existing t
   "Whether to load only objects already existing in a namespace.")

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -30,7 +30,19 @@
 
 ;;; Code:
 
+(require 'ess-custom)
+(require 'ess-inf)
 (require 'ess-utils)
+;; Silence the byte compiler, OK because this file is only loaded by
+;; ess-r-mode and has no autoloads.
+(defvar ess-r-customize-alist)
+(declare-function inferior-ess-r-force "ess-r-mode")
+(declare-function ess-r-get-evaluation-env "ess-r-mode")
+(declare-function ess-r-set-evaluation-env "ess-r-mode")
+
+(defvar ess-r-prompt-for-attached-pkgs-only nil
+  "If nil provide completion for all installed R packages.
+If non-nil, only look for attached packages.")
 
 (defcustom ess-r-package-auto-enable-namespaced-evaluation t
   "If non-nil, evaluation env is set to package env automatically.

--- a/lisp/ess-r-syntax.el
+++ b/lisp/ess-r-syntax.el
@@ -187,6 +187,12 @@ Cons cell containing the token type and string representation."
       (list (ess-token--cons token-type token-value)
             (cons (point) token-end)))))
 
+(defsubst ess-climb-token--char (&rest chars)
+  (ess-while (and chars
+                  (eq (char-before) (car chars))
+                  (ess-backward-char))
+    (setq chars (cdr chars))))
+
 ;; Difficult to use regexps here because we want to match greedily
 ;; backward
 (defun ess-climb-token--operator ()
@@ -217,12 +223,6 @@ Cons cell containing the token type and string representation."
            (prog1 (ess-backward-char)
              (ess-climb-token--char ?: ?:))))
     'self))
-
-(defsubst ess-climb-token--char (&rest chars)
-  (ess-while (and chars
-                  (eq (char-before) (car chars))
-                  (ess-backward-char))
-    (setq chars (cdr chars))))
 
 (defun ess-climb-token--back-and-forth ()
   (let ((limit (point)))

--- a/lisp/ess-r-xref.el
+++ b/lisp/ess-r-xref.el
@@ -31,10 +31,18 @@
 (when (>= emacs-major-version 25)
   (require 'subr-x)
   (require 'xref))
-
+;; Cludge to silence the byte compiler until we drop support for Emacs 24.
+(declare-function xref-make "xref")
+(declare-function xref-make-buffer-location "xref")
+(declare-function xref-make-file-location "xref")
+(require 'ess-inf)
 (require 'ess-utils)
 (require 'ess-r-package)
 (require 'ess-tracebug)
+
+;; Silence the byte compiler. OK because this file is only loaded by ess-r-mode.
+(declare-function inferior-ess-r-force "ess-r-mode")
+
 
 (defvar ess-r-xref-pkg-sources nil
   "Alist of R package->directory associations.

--- a/lisp/ess-rd.el
+++ b/lisp/ess-rd.el
@@ -25,10 +25,13 @@
 ;; Ave, Cambridge, MA 02139, USA.
 
 ;;; Code:
-
+(require 'ess-custom)
 (require 'ess-utils)
 (require 'ess-help)
 (require 'ess-inf)
+;; Silence the byte compiler, see TODO below; can we remove these?
+(defvar ess-help-r-sec-regex)
+(defvar ess-help-r-sec-keys-alist)
 
 (defvar essddr-version "0.9-1"
   "Current version of ess-rd.el.")
@@ -302,7 +305,6 @@ following lines to your `.emacs' file:
   (require 'easymenu)
   (easy-menu-define Rd-mode-menu-map Rd-mode-map
     "Menu keymap for Rd mode." Rd-mode-menu)
-  (easy-menu-add Rd-mode-menu-map Rd-mode-map)
 
   (turn-on-auto-fill)
   (message "Rd mode version %s" essddr-version)

--- a/lisp/ess-rdired.el
+++ b/lisp/ess-rdired.el
@@ -79,6 +79,9 @@
 
 ;;; Code:
 
+(require 'ess-custom)
+(require 'ess-inf)
+
 (defvar ess-rdired-objects "{.rdired.objects <- function(objs) {
   if (length(objs)==0) {
     \"No objects to view!\"

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -112,6 +112,10 @@
   "When non-nil, the `@examples' field is fontified as ordinary code.
 Experimental feature with known bugs.")
 
+(defvar ess-roxy-fold-examples nil
+  "Whether to fold `@examples' when opening a buffer.
+Use you regular key for `outline-show-entry' to reveal it.")
+
 (defun ess-roxy-extend-region-to-field (start end)
   (if (or (progn
             (goto-char start)
@@ -246,10 +250,6 @@ Experimental feature with known bugs.")
 
 
 ;;*;; Outline Integration
-
-(defvar ess-roxy-fold-examples nil
-  "Whether to fold `@examples' when opening a buffer.
-Use you regular key for `outline-show-entry' to reveal it.")
 
 (defvar ess-roxy-outline-regexp "^#+' +@examples\\|^[^#]")
 

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -521,10 +521,9 @@ and one that is well formatted in emacs ess-mode."
    (format "ess-fix-misc begin (from = %s, verbose = %s)\n" from verbose))
   (save-excursion
 
-    (if (string= ess-dialect "R")
-        (progn
-          (require 'ess-r-mode)
-          (R-fix-T-F from (not verbose))))
+    (when (and (string= ess-dialect "R")
+               (fboundp 'ess-r-fix-T-F))
+      (ess-r-fix-T-F from (not verbose)))
 
     ;; activate by (setq ess-verbose t)
     (ess-if-verbose-write "ess-fix-misc: after fix-T-F\n");___D___

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -32,7 +32,10 @@
 
  ; Requires and autoloads
 
+(require 'ess)
+(require 'ess-help)
 (require 'ess-utils)
+(require 'ess-inf)
 
 (autoload 'speedbar-add-supported-extension "speedbar.el")
 
@@ -227,7 +230,9 @@
           (and (looking-at "#!") (= 1 (line-number-at-pos))))
       (current-column)
     (if (looking-at "##")
-        (let ((tem (ess-calculate-indent)))
+        (let ((tem (when ;; FIXME ess-calculate-indent is R specific
+                       (fboundp 'ess-calculate-indent)
+                     (ess-calculate-indent))))
           (if (listp tem) (car tem) tem))
       (skip-chars-backward " \t")
       (max (if (bolp) 0 (1+ (current-column)))
@@ -731,7 +736,8 @@ return it.  Otherwise, return `ess-help-topics-list'."
   (with-ess-process-buffer nil
     (ess-write-to-dribble-buffer
      (format "(ess-get-help-topics-list %s) .." name))
-    (ess-help-r--check-last-help-type)
+    (when (fboundp 'ess-help-r--check-last-help-type)
+      (ess-help-r--check-last-help-type))
     (cond
      ;; (Re)generate the list of topics
      ((or (not ess-help-topics-list)

--- a/lisp/ess-sas-l.el
+++ b/lisp/ess-sas-l.el
@@ -53,6 +53,8 @@
 (require 'ess-custom)
 (require 'ess-sas-a)
 
+(declare-function SAS-mode "ess-sas-d")
+
 (put 'ess-transcript-minor-mode 'permanent-local t)
 (or (assq 'ess-transcript-minor-mode minor-mode-alist)
     (setq minor-mode-alist

--- a/lisp/ess-sp3-d.el
+++ b/lisp/ess-sp3-d.el
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'ess-s-lang)
+(require 'ess-trns)
 
 (defvar S+3-dialect-name "S+3"
   "Name of 'dialect' for S-PLUS 3.x.");easily changeable in a user's .emacs

--- a/lisp/ess-sp4-d.el
+++ b/lisp/ess-sp4-d.el
@@ -38,6 +38,7 @@
 (require 'ess-inf)
 (require 'ess-s-lang)
 (require 'ess-dde)
+(require 'ess-trns)
 
 (defvar ess-S+-startup-delay)
 

--- a/lisp/ess-sp5-d.el
+++ b/lisp/ess-sp5-d.el
@@ -37,6 +37,7 @@
 ;;; Code:
 
 (require 'ess-s-lang)
+(require 'ess-trns)
 
 ;; You now need to make sure you've defined if you are running 5.0 or 5.1.
 ;; Lots of things are broken between them, GRR...

--- a/lisp/ess-sp6-d.el
+++ b/lisp/ess-sp6-d.el
@@ -40,6 +40,8 @@
 (require 'ess-inf)
 (require 'ess-s-lang)
 (require 'ess-dde)
+(require 'ess-trns)
+
 
 ;; You now need to make sure you've defined if you are running 5.0 or 5.1.
 ;; Lots of things are broken between them, GRR...
@@ -100,21 +102,6 @@
   "Functions run in process buffer after the initialization of S+
   process.")
 
-(defalias 'S+6 'S+)
-(defun S+ (&optional proc-name)
-  "Call 'Splus6', based on S version 4, from Bell Labs.
-New way to do it."
-  (interactive)
-  (setq ess-customize-alist S+-customize-alist)
-  (ess-write-to-dribble-buffer
-   (format "\n(S+): ess-dialect=%s, buf=%s\n" ess-dialect (current-buffer)))
-  (inferior-ess)
-  (ess-command ess-S+--injected-code)
-  (if inferior-ess-language-start
-      (ess-eval-linewise inferior-ess-language-start))
-  (with-ess-process-buffer nil
-    (run-mode-hooks 'ess-S+-post-run-hook)))
-
 (defvar ess-S+--injected-code
   ".ess_funargs <- function(funname){
   ## funname <- deparse(substitute(object))
@@ -132,6 +119,21 @@ New way to do it."
   }
 }
 ")
+
+(defalias 'S+6 'S+)
+(defun S+ (&optional proc-name)
+  "Call 'Splus6', based on S version 4, from Bell Labs.
+New way to do it."
+  (interactive)
+  (setq ess-customize-alist S+-customize-alist)
+  (ess-write-to-dribble-buffer
+   (format "\n(S+): ess-dialect=%s, buf=%s\n" ess-dialect (current-buffer)))
+  (inferior-ess)
+  (ess-command ess-S+--injected-code)
+  (if inferior-ess-language-start
+      (ess-eval-linewise inferior-ess-language-start))
+  (with-ess-process-buffer nil
+    (run-mode-hooks 'ess-S+-post-run-hook)))
 
 
 (defalias 'S+6-mode 'S+-mode)

--- a/lisp/ess-sp6w-d.el
+++ b/lisp/ess-sp6w-d.el
@@ -37,6 +37,7 @@
 ;;; Requires and Autoloads:
 
 (require 'ess-s-lang)
+(require 'ess-trns)
 (defvar ess-S+-startup-delay)
 (defvar version-function-name)
 ;;NO: this is autoloaded from other places (require 'ess-dde)

--- a/lisp/ess-stata-lang.el
+++ b/lisp/ess-stata-lang.el
@@ -53,6 +53,8 @@
 ;; only needed in Emacs >= 22.x
 (unless (boundp 'c-emacs-features)
   (require 'cc-vars));; for syntax-table
+(require 'comint)
+(require 'ess-trns)
 
                                         ;(setq max-lisp-eval-depth 500)
 (eval-when-compile

--- a/lisp/ess-swv.el
+++ b/lisp/ess-swv.el
@@ -93,6 +93,22 @@
 (defvar TeX-file-extensions)
 (declare-function TeX-normal-mode "tex")
 
+(defcustom ess-swv-processing-command ".ess_weave(%s, %s)"
+  "Command used by `ess-swv-run-in-R'.
+
+First %s is literally replaced by the processing command (for
+example: Sweave) second %s is replaced with a string containing a
+processed file and possibly additional argument encoding (example:
+\"path/to/foo.Rnw\", encoding='utf-8')
+
+.ess_weave changes the working directory to that of the supplied
+file.
+
+If you want to simply call knitr or Sweave in global environment
+set this command to \"%s(%s)\"."
+  :group 'ess-R
+  :type 'string)
+
 ;; currently use exactly for "Sweave", "Stangle", "knit", and "purl"
 (defun ess-swv-run-in-R (cmd &optional choose-process block)
   "Run \\[cmd] on the current .Rnw file.  Utility function not called by user."
@@ -135,22 +151,6 @@
           (ess-execute Sw-cmd 'buffer nil nil)
           (switch-to-buffer rnw-buf)
           (ess-show-buffer (buffer-name sbuffer) nil))))))
-
-(defcustom ess-swv-processing-command ".ess_weave(%s, %s)"
-  "Command used by `ess-swv-run-in-R'.
-
-First %s is literally replaced by the processing command (for
-example: Sweave) second %s is replaced with a string containing a
-processed file and possibly additional argument encoding (example:
-\"path/to/foo.Rnw\", encoding='utf-8')
-
-.ess_weave changes the working directory to that of the supplied
-file.
-
-If you want to simply call knitr or Sweave in global environment
-set this command to \"%s(%s)\"."
-  :group 'ess-R
-  :type 'string)
 
 (defcustom ess-swv-processor 'sweave
   "Processor to use for weaving and tangling.

--- a/lisp/ess-toolbar.el
+++ b/lisp/ess-toolbar.el
@@ -50,6 +50,9 @@
 
 ;;; Code:
 
+(require 'ess-utils)
+(require 'ess)
+
 (defgroup ess-toolbar nil
   "ESS: toolbar support."
   :group 'ess

--- a/lisp/ess-vst-d.el
+++ b/lisp/ess-vst-d.el
@@ -33,7 +33,10 @@
 
 ;;; Requires and Autoloads:
 
+(require 'ess-custom)
 (require 'ess-lsp-l)
+(require 'ess-utils)
+(require 'ess-inf)
 
 (defvar VST-customize-alist
   '((ess-customize-alist           .  VST-customize-alist )

--- a/lisp/ess-xls-d.el
+++ b/lisp/ess-xls-d.el
@@ -34,7 +34,12 @@
 
 ;;; Requires and Autoloads:
 
+(require 'ess-custom)
 (require 'ess-lsp-l)
+(require 'ess-utils)
+(require 'ess)
+(require 'ess-inf)
+(require 'ess-trns)
 
 (defvar ess-help-XLS-sec-keys-alist
   '((?a . "Args:"))

--- a/lisp/essd-els.el
+++ b/lisp/essd-els.el
@@ -45,6 +45,7 @@
 (require 'ess-sp6-d)
 (require 'ess-sp6w-d)
 (require 'ess-stata-mode)
+(require 'ess-trns)
 (require 'ess-utils)
 (require 'ess-vst-d)
 (require 'ess-xls-d)

--- a/lisp/obsolete/ess-r-args.el
+++ b/lisp/obsolete/ess-r-args.el
@@ -171,6 +171,8 @@
 ;;; Code:
 
 (require 'ess-custom)
+(require 'ess-inf)
+(require 'ess-utils)
 (eval-when-compile
   (require 'tooltip)); for tooltip-show
 


### PR DESCRIPTION
This PR fixes up a lot of the ESS files to fix byte compiler warnings (#506) 

On current `master`, M-x compile in the `lisp` subdir results in 124 warnings (this actually undercounts by quite a bit because it groups some together). 

After this PR, I get 11 (one of which is in julia-mode, which we can't do anything about directly). 

Closes #612 