### PR TITLE
Support rectangle-mark-mode in ess-eval-region

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -142,6 +142,10 @@ init file. Users of the popular @code{use-package} Emacs package can
 now do @code{(use-package ess :defer t)} to take advantage of this
 behavior.
 
+@item Commands that send the region to the inferior process now deal with rectangular regions.
+See the docstring of @code{ess-eval-region} for details. This only
+works on Emacs 25.1 and newer.
+
 @end itemize
 
 

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -57,7 +57,25 @@
     (insert "\"hop\"\n")
     (let (ess-eval-visibly)
       (should (output= (ess-eval-buffer nil)
-                       "[1] \"hop\"")))))
+                "[1] \"hop\"")))))
+
+(when (> emacs-major-version 24)
+  ;; Skip before Emacs 25 when rectangle-mark-mode was improved. We
+  ;; have to wrap the whole thing in that when statement because ert's
+  ;; skip-unless was only introduced in Emacs 24.4 and we're testing
+  ;; all the way back to Emacs 24.3 still, ugh.
+  (ert-deftest ess-r-eval-rectangle-mark-mode ()
+    (with-r-running nil
+      (insert "x <- 1\nx\nx + 1\nx  +  2\n")
+      (let (ess-eval-visibly)
+        (should (output= (progn
+                           (goto-char (point-min))
+                           (transient-mark-mode)
+                           (rectangle-mark-mode)
+                           (forward-line 3)
+                           (end-of-line)
+                           (ess-eval-region-or-line-and-step))
+                  "> [1] 1\n> [1] 2\n> [1] 3"))))))
 
 (ert-deftest ess-set-working-directory ()
   (with-r-running nil


### PR DESCRIPTION
If we're in rectangle-mark-mode, loop over each line of the rectangle
and send it to the inferior process.

Closes #45