### PR TITLE
Allow lazily generated keyword regexps

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,11 @@
 Changes and New Features in development version:
 @itemize @bullet
 
+@item @ESS: Font-lock keywords are now generated lazily. That means you
+can now add or remove keywords from variables like @code{ess-R-keywords}
+in your Emacs config after loading ESS (i.e. in the @code{:config}
+section for @code{use-package} users).
+
 @item @ESS{[R]}: Interaction with inferior process in non-R files within
 packages (for instance C or C++ files) has been improved. This is a work
 in progress.

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2768,46 +2768,46 @@ default or not."
 
 ;;; fl-keywords R
 (defvar ess-R-fl-keyword:modifiers
-  (cons (concat "\\(" (regexp-opt ess-R-modifyiers 'words) "\\)\\s-*(")
-        '(1 ess-modifiers-face))     ; modify search list or source (i.e. directives)
+  '(eval . (cons (concat "\\(" (regexp-opt ess-R-modifyiers 'words) "\\)\\s-*(")
+                 '(1 ess-modifiers-face)))
   "Font-lock keyword R modifiers.")
 
 (defvar ess-R-fl-keyword:fun-defs
-  (cons ess-R-function-name-regexp
-        '(1 font-lock-function-name-face nil))
+  '(eval . (cons ess-R-function-name-regexp
+                 '(1 font-lock-function-name-face nil)))
   "Font-lock keyword - function defintions for R.")
 
 (defvar ess-r--bare-keywords
   '("in" "else" "break" "next" "repeat"))
 
 (defvar ess-R-fl-keyword:bare-keywords
-  (cons (regexp-opt ess-r--bare-keywords 'words)
-        'ess-keyword-face)
+  '(eval . (cons (regexp-opt ess-r--bare-keywords 'words)
+                 'ess-keyword-face))
   "Font-lock keywords that do not precede an opening parenthesis.")
 
 (defvar ess-R-fl-keyword:keywords
-  (let ((function-kwords
-         (delq nil
-               (mapcar (lambda (k) (unless (member k ess-r--bare-keywords) k))
-                       ess-R-keywords))))
-    (cons (concat "\\(" (regexp-opt function-kwords 'words) "\\)\\s-*(")
-          '(1 ess-keyword-face)))
+  '(eval . (let ((function-kwords
+                  (delq nil
+                        (mapcar (lambda (k) (unless (member k ess-r--bare-keywords) k))
+                                ess-R-keywords))))
+             (cons (concat "\\(" (regexp-opt function-kwords 'words) "\\)\\s-*(")
+                   '(1 ess-keyword-face))))
   "Font-lock keywords that precede an opening parenthesis.")
 
 (defvar ess-R-fl-keyword:control-flow-keywords
-  (cons (concat "\\(" (regexp-opt ess-R-control-flow-keywords 'words) "\\)\\s-*(")
-        '(1 ess-r-control-flow-keyword-face)))
+  '(eval . (cons (concat "\\(" (regexp-opt ess-R-control-flow-keywords 'words) "\\)\\s-*(")
+                 '(1 ess-r-control-flow-keyword-face))))
 
 (defvar ess-R-fl-keyword:signal-keywords
-  (cons (concat "\\(" (regexp-opt ess-R-signal-keywords 'words) "\\)\\s-*(")
-        '(1 ess-r-signal-keyword-face)))
+  '(eval . (cons (concat "\\(" (regexp-opt ess-R-signal-keywords 'words) "\\)\\s-*(")
+                 '(1 ess-r-signal-keyword-face))))
 
 (defvar ess-R-fl-keyword:assign-ops
-  (cons (regexp-opt ess-R-assign-ops) 'ess-assignment-face)
+  '(eval . (cons (regexp-opt ess-R-assign-ops) 'ess-assignment-face))
   "Font-lock assign operators.")
 
 (defvar ess-R-fl-keyword:constants
-  (cons (regexp-opt ess-R-constants 'words) 'ess-constant-face)
+  '(eval . (cons (regexp-opt ess-R-constants 'words) 'ess-constant-face))
   "Font-lock constants keyword.")
 
 (defvar ess-R-fl-keyword:F&T

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -116,3 +116,33 @@ foo <-¶ foo <<-¶ foo ->¶ foo ->>¶ foo
 ¶TRUE ¶FALSE ¶NA ¶NULL ¶Inf ¶NaN
 ¶NA_integer_ ¶NA_real_ ¶NA_complex_ ¶NA_character_
 
+
+### 8 Can modify keywords --------------------------------------------
+
+¶foobar foobaz()
+
+##! (let ((ess-R-keywords (append '("foobaz") ess-R-keywords)))
+##>   (ess-r-mode)
+##>   (font-lock-ensure))
+##> (should (not (face-at-point)))
+##> (forward-word)
+##> (forward-char)
+
+foobar ¶foobaz()
+
+##> (should (eq (face-at-point) 'ess-keyword-face))
+
+foobar ¶foobaz()
+
+
+### 9 Can set keywords variable to nil -------------------------------
+
+¶stop()
+
+##! (let (ess-R-control-flow-keywords)
+##>   (ess-r-mode)
+##>   (font-lock-ensure))
+##> (should (not (face-at-point)))
+
+¶stop()
+


### PR DESCRIPTION
Closes #582

* Allow quoted forms in fontlock regexps variables. These should be used when regexp generation depends on user-configurable variables.

* Pick up bare keywords from `ess-R-keywords` so users can remove them.

* Use new multiple cursors feature to simplify fontlock tests

Using laziness in these variables was a great idea @vspinu.