### PR TITLE
Improve ess defgroup

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -42,7 +42,9 @@
 
 (defgroup ess nil
   "ESS: Emacs Speaks Statistics."
-  :group 'local)
+  :group 'languages
+  :link '(info-link "(ESS)")
+  :link '(url-link "https://ess.r-project.org/"))
 
 (defgroup ess-edit nil
   "ESS: editing behavior, including coments/indentation."


### PR DESCRIPTION
Link ess custom group to manual, webpage, and make languages the
parent group