### PR TITLE
Simplify ess-inside-{comment|string}-p

### DIFF
--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -1418,7 +1418,7 @@ Returns nil if line starts inside a string, t if in a comment."
       (ess-back-to-indentation)
       (cond
        ;; Strings
-       ((ess-within-string-p state)
+       ((ess-inside-string-p)
         (current-indentation))
        ;; Comments
        ((ess-calculate-indent--comments))

--- a/lisp/ess-r-syntax.el
+++ b/lisp/ess-r-syntax.el
@@ -791,14 +791,6 @@ return the prefix."
   (save-excursion
     (ess-escape-prefixed-block call)))
 
-(defun ess-within-comment-p (&optional state)
-  (let ((state (or state (syntax-ppss))))
-        (eq (syntax-ppss-context state) 'comment)))
-
-(defun ess-within-string-p (&optional state)
-  (let ((state (or state (syntax-ppss))))
-        (eq (syntax-ppss-context state) 'string)))
-
 
 ;;*;; Syntactic Travellers and Predicates
 
@@ -841,7 +833,7 @@ into account."
       (goto-char (match-end 0)))))
 
 (defun ess-escape-comment ()
-  (when (ess-within-comment-p)
+  (when (ess-inside-comment-p)
     (prog1 (comment-beginning)
      (skip-chars-backward "#+[ \t]*"))))
 

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -972,7 +972,7 @@ list of strings."
     (ess-roxy-with-filling-context t
       ad-do-it))
    ((and (not (ess-roxy-entry-p))
-         (ess-within-comment-p))
+         (ess-inside-comment-p))
     ad-do-it)
    ;; Filling of call arguments with point on call name
    ((and ess-fill-calls

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -1304,33 +1304,23 @@ symbols (like aaa$bbb and aaa@bbb in R)."
           (point)
         (ess-symbol-start)))))
 
-(defun ess-inside-string-or-comment-p (&optional pos)
-  "Return non-nil if POS is inside a string or comment.
-POS defaults to `point.'"
-  (save-excursion
-    (let* ((pos (or pos (point)))
-           (state (syntax-ppss pos)))
-      (or (nth 3 state) (nth 4 state)))))
-
 (defun ess-inside-string-p (&optional pos)
-  "Return non-nil if point is inside string (according to syntax)."
-  (interactive)
-  ;; when narrowing the buffer in iESS the ppss cahce is screwed:( But it is
-  ;; very fast, so don't bother for now.
-  (let ((pps (syntax-ppss pos)))
-    (nth 3 pps))
-  ;; (nth 3 (parse-partial-sexp (point-min) pos))
-  )
+  "Return non-nil if POS is inside string.
+POS defaults to `point'."
+  (let ((pos (or pos (point))))
+    (nth 3 (syntax-ppss pos))))
 
 (defun ess-inside-comment-p (&optional pos)
-  "Return non-nil if point is inside string (according to syntax)."
-  (interactive)
-  (setq pos (or pos (point)))
-  (save-excursion
-    (or (when font-lock-mode ;; this is a shortcut (works well usually)
-	  (let ((face (get-char-property pos 'face)))
-	    (eq 'font-lock-comment-face face)))
-	(nth 4 (parse-partial-sexp (progn (goto-char pos) (point-at-bol)) pos)))))
+  "Return non-nil if POS is inside string.
+POS defaults to `point'."
+  (let ((pos (or pos (point))))
+    (nth 4 (syntax-ppss pos))))
+
+(defun ess-inside-string-or-comment-p (&optional pos)
+  "Return non-nil if POS is inside a string or comment.
+POS defaults to `point'."
+  (or (ess-inside-string-p pos)
+      (ess-inside-comment-p pos)))
 
 (defun ess-inside-brackets-p (&optional pos curly?)
   "Return t if position POS is inside brackets.


### PR DESCRIPTION
Removes ess-within-{comment|string}-p since these are functionally equivalent.

Also redefines ess-inside-{comment|string}-p to be a little simpler and removes the `(interactive)` call.

This is just cleaning up code - it shouldn't have any user visible effects (other than removing the interactive bit, which I assume no one was using?)