### PR TITLE
Change obsolete 'when' to ESS 18.09

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -385,7 +385,7 @@ Avoids the plain dialect name."
   :type 'boolean)
 (define-obsolete-variable-alias
   'ess-use-inferior-program-name-in-buffer-name
-  'ess-use-inferior-program-in-buffer-name "2018-05-23")
+  'ess-use-inferior-program-in-buffer-name "ESS 18.09")
 
 (defcustom  ess-use-ido t
   "If t ess will try to use ido completion whenever possible.
@@ -575,7 +575,7 @@ contain spaces on either side."
   :type '(repeat string)
   :group 'ess)
 (defvar ess-S-assign)
-(make-obsolete-variable 'ess-S-assign 'ess-assign-list "2018-07-01")
+(make-obsolete-variable 'ess-S-assign 'ess-assign-list "ESS 18.09")
 
 (defcustom ess-r-prettify-symbols
   '(("<-" . (?\s (Br . Bl) ?\s (Bc . Bc) ?←))
@@ -1698,9 +1698,9 @@ non-nil."
   :type '(choice (string) file))
 (defvaralias 'inferior-R-program 'inferior-ess-r-program)
 (define-obsolete-variable-alias 'inferior-R-program-name
-  'inferior-ess-r-program "2018-05-23")
+  'inferior-ess-r-program "ESS 18.09")
 (define-obsolete-variable-alias 'inferior-ess-r-program-name
-  'inferior-ess-r-program "2018-05-23")
+  'inferior-ess-r-program "ESS 18.09")
 
 (defcustom inferior-R-args ""
   "String of arguments (see 'R --help') used when starting R,
@@ -1855,7 +1855,7 @@ menu."
   :group 'ess-S
   :type 'string)
 (define-obsolete-variable-alias 'inferior-S3-program-name
-  'inferior-S3-program "2018-05-23")
+  'inferior-S3-program "ESS 18.09")
 
 (defcustom inferior-S+3-program (or (executable-find "Splus")
                                     "Splus")
@@ -1863,7 +1863,7 @@ menu."
   :group 'ess-SPLUS
   :type '(choice (string) file))
 (define-obsolete-variable-alias 'inferior-S+3-program-name
-  'inferior-S+3-program "2018-05-23")
+  'inferior-S+3-program "ESS 18.09")
 
 (defcustom inferior-S+4-program
   (concat ess-program-files "/spls45se/cmd/Splus.exe")
@@ -1876,7 +1876,7 @@ Use double backslashes if you use the msdos shell."
   :group 'ess-SPLUS
   :type 'string)
 (define-obsolete-variable-alias 'inferior-S+4-program-name
-  'inferior-S+4-program "2018-05-23")
+  'inferior-S+4-program "ESS 18.09")
 
 (defcustom inferior-S+4-print-command "S_PRINT_COMMAND=emacsclientw.exe"
   "Destination of print icon in S+4 Commands window."
@@ -1896,7 +1896,7 @@ in S+4 Commands window and in Sqpe+4 buffer."
   :group 'ess-SPLUS
   :type '(choice (const nil) (string)))
 (define-obsolete-variable-alias 'inferior-Sqpe+4-program-name
-  'inferior-Sqpe+4-program "2018-05-23")
+  'inferior-Sqpe+4-program "ESS 18.09")
 
 (defcustom inferior-Sqpe+4-SHOME-name
   (if ess-microsoft-p (concat ess-program-files "/spls45se" ""))
@@ -1930,7 +1930,7 @@ version of the pathname."
   :type 'string)
 (define-obsolete-variable-alias
   'inferior-S-elsewhere-program-name
-  'inferior-S-elsewhere-program "2018-05-23")
+  'inferior-S-elsewhere-program "ESS 18.09")
 
 (defcustom inferior-ESS-elsewhere-program "sh"
   "Program name to invoke an inferior ESS with program on a
@@ -1939,7 +1939,7 @@ different computer."
   :type 'string)
 (define-obsolete-variable-alias
   'inferior-ESS-elsewhere-program-name
-  'inferior-ESS-elsewhere-program "2018-05-23")
+  'inferior-ESS-elsewhere-program "ESS 18.09")
 
 (defcustom inferior-S4-program (or (executable-find "S4")
                                    "S4")
@@ -1947,7 +1947,7 @@ different computer."
   :group 'ess-S
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-S4-program-name
-  'inferior-S4-program "2018-05-23")
+  'inferior-S4-program "ESS 18.09")
 
 (defcustom inferior-S+5-program (or (executable-find "Splus5")
                                     "Splus5")
@@ -1955,7 +1955,7 @@ different computer."
   :group 'ess-SPLUS
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-S+5-program-name
-  'inferior-S+5-program "2018-05-23")
+  'inferior-S+5-program "ESS 18.09")
 
 (defvaralias 'S+6-dialect-name 'S+-dialect-name)
 (defcustom S+-dialect-name "S+"
@@ -1966,7 +1966,7 @@ Easily changeable in a user's `.emacs'."
 
 (defvaralias 'inferior-S+6-program 'inferior-S+-program)
 (define-obsolete-variable-alias 'inferior-S+6-program-name
-  'inferior-S+-program "2018-05-23")
+  'inferior-S+-program "ESS 18.09")
 
 (defcustom inferior-S+-program
   (if ess-microsoft-p
@@ -1983,7 +1983,7 @@ msdos shell."
   :group 'ess-SPLUS
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-S+-program-name
-  'inferior-S+-program "2018-05-23")
+  'inferior-S+-program "ESS 18.09")
 
 (defvaralias 'inferior-S+6-start-args 'inferior-S+-start-args)
 (defvaralias 'inferior-Splus-args 'inferior-S+-start-args)
@@ -2032,7 +2032,7 @@ for Windows Commands window and in Sqpe+6 for Windows buffer."
   :group 'ess-S
   :type '(choice (const nil) (string)))
 (define-obsolete-variable-alias 'inferior-Sqpe+-program-name
-  'inferior-Sqpe+-program "2018-05-23")
+  'inferior-Sqpe+-program "ESS 18.09")
 
 (defvaralias 'inferior-Sqpe+6-SHOME-name 'inferior-Sqpe+-SHOME-name)
 (defcustom inferior-Sqpe+-SHOME-name
@@ -2076,7 +2076,7 @@ ask - ask the user whether the S buffers should be killed."
   :group 'ess-XLS
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-XLS-program-name
-  'inferior-XLS-program "2018-05-23")
+  'inferior-XLS-program "ESS 18.09")
 
 (defcustom inferior-VST-program (or (executable-find "vista")
                                     "vista")
@@ -2084,7 +2084,7 @@ ask - ask the user whether the S buffers should be killed."
   :group 'ess-XLS
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-VST-program-name
-  'inferior-VST-program "2018-05-23")
+  'inferior-VST-program "ESS 18.09")
 
 (defcustom inferior-ARC-program (or (executable-find "arc")
                                     "arc")
@@ -2092,7 +2092,7 @@ ask - ask the user whether the S buffers should be killed."
   :group 'ess-XLS
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-ARC-program-name
-  'inferior-ARC-program "2018-05-23")
+  'inferior-ARC-program "ESS 18.09")
 
 (defcustom inferior-SAS-program (or (executable-find "sas")
                                     "sas")
@@ -2100,7 +2100,7 @@ ask - ask the user whether the S buffers should be killed."
   :group 'ess-sas
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-SAS-program-name
-  'inferior-SAS-program "2018-05-23")
+  'inferior-SAS-program "ESS 18.09")
 
 (defcustom inferior-STA-program (or (executable-find "stata")
                                     "stata")
@@ -2110,7 +2110,7 @@ order for it to work right.  And Emacs is too smart for it."
   :group 'ess-Stata
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-STA-program-name
-  'inferior-STA-program "2018-05-23")
+  'inferior-STA-program "ESS 18.09")
 
 (defcustom ess-sta-delimiter-friendly nil
   "Non-nil means convert embedded semi-colons to newlines for Stata processing."
@@ -2123,7 +2123,7 @@ order for it to work right.  And Emacs is too smart for it."
   :group 'ess-OMG
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-OMG-program-name
-  'inferior-OMG-program "2018-05-23")
+  'inferior-OMG-program "ESS 18.09")
 
 
 ;;;;; names for setting the pager and editor options of the
@@ -2222,14 +2222,14 @@ for help files.  The default value is nil for other systems."
 ;;-         ))
 ;;(make-local-variable 'inferior-S-program)
 (define-obsolete-variable-alias 'inferior-S-program-name
-  'inferior-S+3-program "2018-05-23")
+  'inferior-S+3-program "ESS 18.09")
 
 (defvar inferior-ess-program nil ;inferior-S-program
   "Default program name for invoking inferior-ess.
 The other variables ...-program should be changed, for the
 corresponding program.")
 (define-obsolete-variable-alias 'inferior-ess-program-name
-  'inferior-ess-program "2018-05-23")
+  'inferior-ess-program "ESS 18.09")
 
 (make-variable-buffer-local 'inferior-ess-program)
 ;; (setq-default inferior-ess-program inferior-S-program)
@@ -3101,7 +3101,7 @@ Should be an absolute path to the julia executable."
   :group 'ess-Julia
   :type '(choice (string) (file)))
 (define-obsolete-variable-alias 'inferior-julia-program-name
-  'inferior-julia-program "2018-05-23")
+  'inferior-julia-program "ESS 18.09")
 
 (defvar julia-basic-offset 4
   "Offset for julia code editing.")

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -3008,7 +3008,7 @@ NO-ERROR prevents errors when this has not been implemented for
 
 (defalias 'ess-change-directory 'ess-set-working-directory)
 (define-obsolete-function-alias
-  'ess-use-dir 'ess-set-working-directory "2018-06-11")
+  'ess-use-dir 'ess-set-working-directory "ESS 18.09")
 
 (defun ess-use-this-dir (&optional no-force-current)
   "Set the current process directory to the directory of this file.

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -446,7 +446,7 @@ before ess-site is loaded) for it to take effect.")
 
 (defvar ess-r-created-runners nil
   "List of R-versions found from `ess-r-versions' on the system.")
-(define-obsolete-variable-alias 'ess-r-versions-created 'ess-r-created-runners "2018-05-05")
+(define-obsolete-variable-alias 'ess-r-versions-created 'ess-r-created-runners "ESS 18.09")
 
 ;;;*;;; Mode init
 
@@ -684,7 +684,7 @@ as `ess-r-created-runners' upon ESS initialization."
         (easy-menu-add-item ess-mode-menu '("Start Process")
                             (cons "Other" new-menu)))))))
 (define-obsolete-function-alias
-  'ess-r-versions-create 'ess-r-define-runners "2018-05-12")
+  'ess-r-versions-create 'ess-r-define-runners "ESS 18.09")
 
 (defvar ess-newest-R nil
   "Stores the newest version of R that has been found.  Used as a cache,
@@ -925,7 +925,7 @@ not issue messages."
     (ess-rep-regexp "\\(\\([][=,()]\\|<-\\) *\\)F\\>" "\\1FALSE"
                     'fixcase nil (not quietly))))
 (define-obsolete-function-alias 'R-fix-T-F 'ess-r-fix-T-F
-  "2018-07-25")
+  "ESS 18.09")
 
 (defvar ess--packages-cache nil
   "Cache var to store package names. Used by

--- a/lisp/ess-rutils.el
+++ b/lisp/ess-rutils.el
@@ -420,7 +420,7 @@ Options should be separated by value of `crm-default-separator'."
 (easy-menu-add-item inferior-ess-mode-menu nil ess-rutils-mode-menu "Utils")
 (add-hook 'inferior-ess-mode-hook 'ess-rutils-keys)
 
-(make-obsolete 'ess-rutils-rhtml-fn "overwrite .ess_help_start instead." "2018-06")
+(make-obsolete 'ess-rutils-rhtml-fn "overwrite .ess_help_start instead." "ESS 18.09")
 
 (provide 'ess-rutils)
 

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -620,7 +620,7 @@ ARG as the number of times to insert."
 
 (defun ess-disable-smart-S-assign (&rest _ignore)
   "Disable `ess-insert-assign'."
-  (declare (obsolete "Use ess-smart-S-assign-key instead." "2018-06-08"))
+  (declare (obsolete "Use ess-smart-S-assign-key instead." "ESS 18.09"))
   (setq ess-smart-S-assign-key nil))
 
 (defun ess-add-MM-keys ()
@@ -787,13 +787,13 @@ return it.  Otherwise, return `ess-help-topics-list'."
 (fset 'S-mode 's-mode)
 
 
-(define-obsolete-function-alias 'ess-toggle-S-assign-key #'ignore "2018-06-08")
-(define-obsolete-function-alias 'ess-smart-underscore 'ess-insert-assign "2018-06-08")
-(define-obsolete-function-alias 'ess-smart-S-assign 'ess-insert-assign "2018-06-21")
-(define-obsolete-function-alias 'ess-insert-S-assign 'ess-insert-assign "2018-07-02")
+(define-obsolete-function-alias 'ess-toggle-S-assign-key #'ignore "ESS 18.09")
+(define-obsolete-function-alias 'ess-smart-underscore 'ess-insert-assign "ESS 18.09")
+(define-obsolete-function-alias 'ess-smart-S-assign 'ess-insert-assign "ESS 18.09")
+(define-obsolete-function-alias 'ess-insert-S-assign 'ess-insert-assign "ESS 18.09")
 
-(define-obsolete-function-alias 'ess-toggle-underscore 'ess-disable-smart-S-assign "2018-06-08")
-(define-obsolete-function-alias 'ess-toggle-S-assign 'ess-disable-smart-S-assign "2018-06-08")
+(define-obsolete-function-alias 'ess-toggle-underscore 'ess-disable-smart-S-assign "ESS 18.09")
+(define-obsolete-function-alias 'ess-toggle-S-assign 'ess-disable-smart-S-assign "ESS 18.09")
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.[Ss]t\\'" . S-transcript-mode))

--- a/lisp/ess-sas-a.el
+++ b/lisp/ess-sas-a.el
@@ -473,7 +473,7 @@ current buffer if nil."
   (ess-sas--change-alist 'ess-kermit-remote-directory ess-kermit-remote-directory nil))
 
 (define-obsolete-function-alias
-  'ess-change-alist 'ess-sas--change-alist "2018-07-06")
+  'ess-change-alist 'ess-sas--change-alist "ESS 18.09")
 
 (defun ess-sas-data-view-fsview (&optional ess-sas-data)
   "Open a dataset for viewing with PROC FSVIEW."
@@ -1182,7 +1182,7 @@ Keep in mind that the maximum command line length in MS-DOS is
 
 (defvar ess-sas-created-runners)
 (define-obsolete-variable-alias
-  'ess-sas-versions-created 'ess-sas-created-runners "2018-05-12")
+  'ess-sas-versions-created 'ess-sas-created-runners "ESS 18.09")
 (defun ess-sas-define-runners ()
   "Generate the `M-x SASV' functions for starting other versions of SAS.
 See `ess-sas-versions' for strings that determine which functions are created.
@@ -1204,7 +1204,7 @@ be placed on the menubar upon ESS initialization."
     (setq ess-sas-created-runners
           (mapc (lambda (v) (ess-define-runner v "SAS")) versions))))
 (define-obsolete-function-alias
-  'ess-sas-create-versions 'ess-sas-define-runners "2018-05-12")
+  'ess-sas-create-versions 'ess-sas-define-runners "ESS 18.09")
 
 
 ;;; Section 3:  Key Definitions

--- a/lisp/ess-sp6-d.el
+++ b/lisp/ess-sp6-d.el
@@ -170,7 +170,7 @@ before ess-site is loaded) for it to take effect.")
 
 (defvar ess-s-created-runners)
 (define-obsolete-variable-alias
-  'ess-s-versions-created 'ess-s-created-runners "2018-05-12")
+  'ess-s-versions-created 'ess-s-created-runners "ESS 18.09")
 (defun ess-s-define-runners ()
   "Generate functions for starting other versions of S.
 See `ess-s-versions' for strings that determine which functions are created.
@@ -205,7 +205,7 @@ ESS initialization."
      (ess-sqpe-versions-create ess-SHOME-versions-64 "-64-bit")) ;; 64-bit
   (ess-s-define-runners))
 (define-obsolete-function-alias
-  'ess-s-versions-create 'ess-s-define-runners "2018-05-12")
+  'ess-s-versions-create 'ess-s-define-runners "ESS 18.09")
 
 
 

--- a/lisp/obsolete/ess-r-args.el
+++ b/lisp/obsolete/ess-r-args.el
@@ -179,25 +179,25 @@
 ;; These defvars were previously defcustoms in ess-custom
 (defvar ess-r-args-noargsmsg "No args found."
   "Message returned if \\[ess-r-args-get] cannot find a list of arguments.")
-(make-obsolete-variable 'ess-r-args-noargsmsg "Use `eldoc-mode' instead." "2018-05-22")
+(make-obsolete-variable 'ess-r-args-noargsmsg "Use `eldoc-mode' instead." "ESS 18.09")
 
 (defvar ess-r-args-show-prefix "ARGS: "
   "A prefix string that is shown before the arguments list.")
-(make-obsolete-variable 'ess-r-args-show-prefix "Use `eldoc-mode' instead." "2018-05-22")
+(make-obsolete-variable 'ess-r-args-show-prefix "Use `eldoc-mode' instead." "ESS 18.09")
 
 (defvar ess-r-args-show-as 'message
   "How ess-r-args-show should show the argument list. Possible values
 are: 'message' (the default) or 'tooltip'.")
-(make-obsolete-variable 'ess-r-args-show-as "Use `eldoc-mode' instead." "2018-05-22")
+(make-obsolete-variable 'ess-r-args-show-as "Use `eldoc-mode' instead." "ESS 18.09")
 
 (defvar ess-r-args-keep-silent ess-S-non-functions
   "List of functions names which should *not* trigger \\[ess-r-args-show];
 Defaults to `ess-S-non-functions'.")
-(make-obsolete-variable 'ess-r-args-keep-silent "Use `eldoc-mode' instead." "2018-05-22")
+(make-obsolete-variable 'ess-r-args-keep-silent "Use `eldoc-mode' instead." "ESS 18.09")
 
 (defvar ess-r-args-electric-paren nil
   "Non-nil means re-assign \"(\" to \\[ess-r-args-auto-show].")
-(make-obsolete-variable 'ess-r-args-electric-paren "Use `eldoc-mode' instead." "2018-05-22")
+(make-obsolete-variable 'ess-r-args-electric-paren "Use `eldoc-mode' instead." "ESS 18.09")
 
 (defun ess-r-args-current-function ()
   "Returns the name of the R function assuming point is currently
@@ -211,7 +211,7 @@ found."
       (let ((rfunname (buffer-substring-no-properties posend (point))))
         (if (posix-string-match "^[a-zA-Z0-9_\.]+$" rfunname)
             rfunname nil)))))
-(make-obsolete 'ess-r-args-current-function "See `eldoc-mode'" "2018-05-22")
+(make-obsolete 'ess-r-args-current-function "See `eldoc-mode'" "ESS 18.09")
 
 (defun ess-r-args-get (&optional function trim)
   "Returns string of arguments and their default values of R
@@ -231,7 +231,7 @@ buffer readjustments for multiline string)."
                (cadr (ess-function-arguments function))
                ", ")))
 
-(make-obsolete 'ess-r-args-get "See `eldoc-mode'" "2018-05-22")
+(make-obsolete 'ess-r-args-get "See `eldoc-mode'" "ESS 18.09")
 
 ;;;###autoload
 (defun ess-r-args-show (&optional function)
@@ -257,7 +257,7 @@ buffer readjustments for multiline string)."
           ;; lines of text
           (ess-tooltip-show-at-point args 0 30))
         ))))
-(make-obsolete 'ess-r-args-show "See `eldoc-mode'" "2018-05-22")
+(make-obsolete 'ess-r-args-show "See `eldoc-mode'" "ESS 18.09")
 
 ;;;###autoload
 (defun ess-r-args-auto-show ()
@@ -269,7 +269,7 @@ and their default values of an R function. Built on \\[ess-r-args-show]."
            ess-local-process-name ; has a process and it must still be running
            (ess-get-process ess-local-process-name))
       (ess-r-args-show)))
-(make-obsolete 'ess-r-args-auto-show "See `eldoc-mode'" "2018-05-22")
+(make-obsolete 'ess-r-args-auto-show "See `eldoc-mode'" "ESS 18.09")
 
 ;; MM: I would strongly discourage use of the following:
 ;;     it leads to clueless newbie-users  who indeed
@@ -286,7 +286,7 @@ ess-r-args-current-function if no argument given."
             (pointpos (point)))
         (insert args)
         (goto-char pointpos))))
-(make-obsolete 'ess-r-args-insert "See `eldoc-mode'" "2018-05-22")
+(make-obsolete 'ess-r-args-insert "See `eldoc-mode'" "ESS 18.09")
 
 
 ;; (defvar ess-r-object-tooltip-alist


### PR DESCRIPTION
ESS 18.09 will be the next release, update the symbols made obsolete since the 17.11 release