### PR TITLE
Cleanup documentation

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -6,7 +6,7 @@ Changes and New Features in development version:
 
 @item @ESS: Font-lock keywords are now generated lazily. That means you
 can now add or remove keywords from variables like @code{ess-R-keywords}
-in your Emacs config after loading ESS (i.e. in the @code{:config}
+in your Emacs configuration file after loading ESS (i.e. in the @code{:config}
 section for @code{use-package} users).
 
 @item @ESS{[R]}: Interaction with inferior process in non-R files within
@@ -59,7 +59,7 @@ keywords inherit from @code{ess-modifiers-face} (the face used for
 @item @ESS{[R]}: The package development minor mode now only activates
 within editing buffers by default, i.e. ones that inherit from
 @code{prog-mode} or @code{text-mode}. If you want to restore the old
-behaviour and activate the package mode in all buffers (that have a
+behavior and activate the package mode in all buffers (that have a
 @code{default-directory} that is part of a package path), set
 @code{ess-r-package-auto-activate} to @code{t}.
 
@@ -90,7 +90,7 @@ So, for example, R buffers will now show ESS[R] rather than ESS[S].
 @item @ESS{[R]}: @code{Makevars} files are now automatically opened
 with @code{makefile-mode}.
 
-@item New varaible @code{ess-write-to-dribble}.
+@item New variable @code{ess-write-to-dribble}.
 This allows users to disable the dribble (@code{*ESS*}) buffer if they wish.
 
 @item ESS now respects Emacs conventions for keybindings.
@@ -132,7 +132,7 @@ ess-disable-smart-S-assign.
 Customize new option @code{ess-assign-list} instead.
 
 @item @code{C-c C-=} is now bound to @code{ess-cycle-assignment} by default
-See the docstring for details. New user customization option
+See the documentation for details. New user customization option
 @code{ess-assign-list} controls what assignment operators are cycled
 through.
 
@@ -148,7 +148,7 @@ now do @code{(use-package ess :defer t)} to take advantage of this
 behavior.
 
 @item Commands that send the region to the inferior process now deal with rectangular regions.
-See the docstring of @code{ess-eval-region} for details. This only
+See the documentation of @code{ess-eval-region} for details. This only
 works on Emacs 25.1 and newer.
 
 @end itemize

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -59,12 +59,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun ess--help-get-bogus-buffer-substring (buffer &optional nr-first)
-  "Return non-nil if  BUFFER  looks like a bogus ESS help buffer.
-Return the pair (match-beg. match-end) which can be used in error message.
-NR-FIRST is the number of characters at the start of the buffer
-to examine when deciding if the buffer if bogus.  If nil, the
-first 150 characters of the buffer are searched."
-
+  "Return non-nil if BUFFER looks like a bogus ESS help buffer.
+Return the pair (match-beg. match-end) which can be used in error
+message. NR-FIRST is the number of characters at the start of the
+buffer to examine when deciding if the buffer if bogus. If nil,
+the first 150 characters of the buffer are searched."
   (if (not nr-first) (setq nr-first 150))
 
   (with-current-buffer buffer
@@ -108,13 +107,13 @@ first 150 characters of the buffer are searched."
 
 (defvar ess-help-type nil
   "Type of help file, help, index, vingettes etc.
-Local in ess-help buffers.")
+Local in `ess-help' buffers.")
 (make-variable-buffer-local 'ess-help-type)
 
 (defvar ess-help-object nil
   "Name of the object the help is displayed for.
 Is name of the package for package index.
-Local in ess-help buffers.")
+Local in `ess-help' buffers.")
 (make-variable-buffer-local 'ess-help-object)
 
 ;;;###autoload
@@ -177,7 +176,7 @@ If COMMAND is suplied, it is used instead of `inferior-ess-help-command'."
     (setq truncate-lines nil)))
 
 (defun ess--help-kill-bogus-buffer-maybe (buffer)
-  "Internal, try to kill bogus buffer with message. Return t if killed."
+  "Internal, try to kill bogus BUFFER with message. Return t if killed."
   (when ess-help-kill-bogus-buffers
     (let ((bog-mes  (ess--help-get-bogus-buffer-substring buffer)))
       (when bog-mes
@@ -535,17 +534,17 @@ For internal use.  Take into account variable `ess-help-own-frame'."
       (display-buffer buff action))))
 
 (defun ess-help-web-search ()
-  "Search the web for documentation"
+  "Search the web for documentation."
   (interactive)
   (ess-execute-dialect-specific ess-help-web-search-command "Search for: "))
 
 (defun ess-manual-lookup ()
-  "Search manual for topic"
+  "Search manual for topic."
   (interactive)
   (ess-execute-dialect-specific ess-manual-lookup-command ))
 
 (defun ess-reference-lookup ()
-  "Search manual for topic"
+  "Search manual for topic."
   (interactive)
   (ess-execute-dialect-specific ess-reference-lookup-command))
 
@@ -660,7 +659,7 @@ For internal use.  Take into account variable `ess-help-own-frame'."
     "-"
     ["Handy commands"		ess-handy-commands t]
     ["Describe ESS-help Mode"	ess-describe-help-mode t])
-  "Menu used in ess-help mode.")
+  "Menu used in `ess-help-mode'.")
 
 (defun ess-help-mode ()
 ;;; Largely ripped from more-mode.el,
@@ -710,10 +709,11 @@ Other keybindings are as follows:
 ;;*;; User commands defined in ESS help mode
 
 (defun ess-skip-to-help-section nil
-  "Jump to a section heading of a help buffer.  The section selected
-is determined by the command letter used to invoke the command, as
-indicated by `ess-help-sec-keys-alist'.  Use \\[ess-describe-sec-map]
-to see which keystrokes find which sections."
+  "Jump to a section heading of a help buffer.
+The section selected is determined by the command letter used to
+invoke the command, as indicated by `ess-help-sec-keys-alist'.
+Use \\[ess-describe-sec-map] to see which keystrokes find which
+sections."
   (interactive)
   (let ((old-point (point))
         (case-fold-search nil))
@@ -786,10 +786,11 @@ Keystroke    Section
     object))
 ;;;###autoload
 (defun ess-helpobjs-at-point (slist)
-  ;; Return a list (def obj fun) where OBJ is a name at point, FUN - name of
-  ;; the function call point is in. DEF is either OBJ or FUN (in that order)
-  ;; which has a a help file, i.e. it is a member of slist (string-list). nil
-  ;; otherwise
+  "Return a list (def obj fun).
+Obj is a name at point, fun is the name of the function call
+point is in, and def is either obj or fun (in that order) which
+has a a help file, i.e. it is a member of slist (string-list).
+nil otherwise."
   (let* ((obj (ess-helpobjs-at-point--read-obj))
          (unqualified-obj (and obj (ess-unqualify-symbol obj)))
          ;; FIXME: probably should use syntactic logic here
@@ -898,21 +899,21 @@ Note that we can't search SAS, Stata or XLispStat for additional information."
  ;; describe object at point
 
 (defvar ess-describe-object-at-point-commands nil
-  "Commands cycled by `ess-describe-object-at-point'. Dialect
-specific.")
+  "Commands cycled by `ess-describe-object-at-point'.
+Dialect specific.")
 (make-variable-buffer-local 'ess-describe-at-point-commands)
 
 (defvar ess--descr-o-a-p-commands nil)
 
 (defun ess-describe-object-at-point ()
-  "Get info for object at point, and display it in an electric buffer or tooltip.
+  "Get info for object at point, & display it in an electric buffer or tooltip.
 If region is active use it instead of the object at point.
 
 This is an electric command (`ess--execute-electric-command'),
 which means that you can use the last key to cycle through the
 action set (in this case `C-e').
 
-After invocation of this command all standard emacs commands,
+After invocation of this command all standard Emacs commands,
 except those containing 'window' in their names, remove the
 electric *ess-describe* buffer. Use `other-window' to switch to
 *ess-describe* window.
@@ -981,7 +982,7 @@ option for other dialects)."
  ; Bug Reporting
 ;;;###autoload
 (defun ess-submit-bug-report ()
-  "Submit a bug report on the ess-mode package."
+  "Submit a bug report to the ESS maintainers."
   (interactive)
   (require 'ess)
   (require 'reporter)

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -411,7 +411,7 @@ has been found, use `ess-gen-proc-buffer-name:directory'. See
       (ess-gen-proc-buffer-name:directory proc-name))))
 
 (defun inferior-ess-set-status (proc string &optional no-timestamp)
-  "Internal function to set the satus of the PROC
+  "Internal function to set the satus of the PROC.
 If no-timestamp, don't set the last-eval timestamp.
 Return the 'busy state."
   ;; todo: do it in one search, use starting position, use prog1
@@ -477,7 +477,7 @@ Return the 'busy state."
              string))))
 
 (defun inferior-ess-output-filter (proc string)
-  "Standard output filter for the inferior ESS process.
+  "Standard output filter for the inferior ESS process PROC.
 Ring Emacs bell if process output starts with an ASCII bell, and pass
 the rest to `comint-output-filter'.
 Taken from octave-mod.el."
@@ -611,7 +611,7 @@ the language dialect (e.g. \"R\")."
 
 ;;*;; General process handling code
 (defmacro with-ess-process-buffer (no-error &rest body)
-  "Execute BODY with current-buffer set to the process buffer of ess-current-process-name.
+  "Execute BODY in the process buffer of `ess-current-process-name'.
 If NO-ERROR is t don't trigger error when there is not current
 process.
 
@@ -626,7 +626,7 @@ Symbol *proc* is bound to the current process during the evaluation of BODY."
 
 (defmacro ess-with-current-buffer (buffer &rest body)
   "Like `with-current-buffer' but with transfer of some essential
-local ESS vars like `ess-local-process-name'"
+local ESS vars like `ess-local-process-name'."
   (declare (indent 1) (debug t))
   (let ((lpn (make-symbol "lpn"))
         (alist (make-symbol "alist")))
@@ -645,10 +645,11 @@ local ESS vars like `ess-local-process-name'"
       (2 font-lock-variable-name-face)))))
 
 (defun ess-get-process (&optional name use-another)
-  "Return the ESS process named by NAME.  If USE-ANOTHER is non-nil,
-and the process NAME is not running (anymore), try to connect to another if
-there is one.  By default (USE-ANOTHER is nil), the connection to another
-process happens interactively (when possible)."
+  "Return the ESS process named by NAME.
+If USE-ANOTHER is non-nil, and the process NAME is not
+running (anymore), try to connect to another if there is one. By
+default (USE-ANOTHER is nil), the connection to another process
+happens interactively (when possible)."
   (setq name (or name ess-local-process-name))
   (if (null name)           ; should almost never happen at this point
       (error "No ESS process is associated with this buffer now"))
@@ -732,22 +733,18 @@ process was killed."
               (process-live-p proc)))))
 
 (defun ess-process-get (propname)
-  "Return the variable PROPNAME (symbol) from the plist of the
-current ESS process."
+  "Return the variable PROPNAME (symbol) from the plist of the current ESS process."
   (process-get (get-process ess-local-process-name) propname))
 
 (defun ess-process-put (propname value)
-  "Set the variable PROPNAME (symbol) to VALUE in the plist of
-the current ESS process."
+  "Set the variable PROPNAME (symbol) to VALUE in the plist of the current ESS process."
   (process-put (get-process ess-local-process-name) propname value))
 
 (defun ess-start-process-specific (language dialect)
-  "Start an ESS process typically from a language-specific buffer, using
-LANGUAGE (and DIALECT)."
-
+  "Start an ESS process.
+Typically from a language-specific buffer, using LANGUAGE (and DIALECT)."
   (unless dialect
     (error "The value of `dialect' is nil"))
-
   (save-current-buffer
     (let ((dsymb (intern dialect)))
       (ess-write-to-dribble-buffer
@@ -953,8 +950,7 @@ If variable `ess-switch-to-end-of-proc-buffer' is t (the default)
  this function switches to the end of process buffer.
 
 If TOGGLE-EOB is given, the value of
-`ess-switch-to-end-of-proc-buffer' is toggled.
-"
+`ess-switch-to-end-of-proc-buffer' is toggled."
   (interactive "P")
   (let ((map (make-sparse-keymap))
         (EOB (if toggle-eob
@@ -1193,10 +1189,9 @@ hook from the current buffer.")
     (concat string "\n")))
 
 (defvar ess--dbg-del-empty-p t
-  "Internal variable to control removal of empty lines during the
-debugging.  Let-bind it to nil before calling
-`ess-send-string' or `ess-send-region' if no
-removal is necessary.")
+  "Internal variable to control removal of empty lines during the debugging.
+Let-bind it to nil before calling `ess-send-string' or
+`ess-send-region' if no removal is necessary.")
 
 (defun inferior-ess--interrupt-subjob-maybe (proc)
   "Internal. Interrupt the process if interruptable? process variable is non-nil.
@@ -1356,7 +1351,7 @@ This handles Tramp when working on a remote."
     (unless no-prompt-check
       (when (process-get proc 'busy)
         (ess-error
-         "ESS process not ready. Finish your command before trying again.")))
+         "ESS process not ready. Finish your command before trying again")))
     proc))
 
 (ess-defgeneric ess-command (cmd &optional out-buffer sleep no-prompt-check wait proc force-redisplay)
@@ -1423,8 +1418,8 @@ wrapping the code into:
 
 (defun ess-boolean-command (com &optional buf wait)
   "Like `ess-command' but expects COM to print TRUE or FALSE.
-If TRUE (or true) is found return non-nil otherwise
-nil. Example (ess-boolean-command \"2>1\n\")"
+If TRUE (or true) is found return non-nil otherwise nil.
+Example (ess-boolean-command \"2>1\n\")"
   (with-current-buffer (ess-command com buf nil nil wait)
     (goto-char (point-min))
     (let ((case-fold-search t))
@@ -1446,7 +1441,7 @@ nil. Example (ess-boolean-command \"2>1\n\")"
 ;;                    (lambda (proc2) (message "name: %s" (process-name proc2))))
 
 (defun ess-async-command (com &optional buf proc callback interrupt-callback )
-  "Asynchronous version of ess-command.
+  "Asynchronous version of `ess-command'.
 COM, BUF, WAIT and PROC are as in `ess-command'.
 
 CALLBACK is a function of two arguments (PROC STRING) to run
@@ -1458,15 +1453,14 @@ argument (PROC) to be called on interruption.
 NOTE: Currently this function should be used only for background
 jobs like caching. ESS tries to suppress any output from the
 asynchronous command, but long output of COM will most likely end
-up in user's main buffer.
-"
+up in user's main buffer."
   (let ((proc (or proc (get-process ess-local-process-name))))
     (if (not (and proc
                   (eq (process-status proc) 'run)))
         (error "Process %s is dead" ess-local-process-name)
       (if (or (process-get proc 'busy)
               (process-get proc 'running-async?))
-          (error "Process %s is busy or already running an async command." ess-local-process-name)
+          (error "Process %s is busy or already running an async command" ess-local-process-name)
         (when (eq interrupt-callback t)
           (setq interrupt-callback (lambda (proc))))
         (process-put proc 'callbacks (list (cons callback 'suppress-output)
@@ -1732,18 +1726,20 @@ Prefix arg VIS toggles visibility of ess-code as for `ess-eval-region'."
 ;;       (ess-eval-region (point) end vis "Eval sexp"))))
 
 (defun ess-eval-function-or-paragraph (vis)
-  "Send the current function if \\[point] is inside one, otherwise the current
-paragraph other to the inferior ESS process.
-Prefix arg VIS toggles visibility of ess-code as for `ess-eval-region'."
+  "Send the current function if \\[point] is inside one.
+Otherwise send the current paragraph to the inferior ESS process.
+Prefix arg VIS toggles visibility of ess-code as for
+`ess-eval-region'."
   (interactive "P")
   (let ((beg-end (ess-eval-function vis 'no-error)))
     (if (null beg-end) ; not a function
         (ess-eval-paragraph vis))))
 
 (defun ess-eval-function-or-paragraph-and-step (vis)
-  "Send the current function if \\[point] is inside one, otherwise the current
-paragraph other to the inferior ESS process.
-Prefix arg VIS toggles visibility of ess-code as for `ess-eval-region'."
+  "Send the current function if \\[point] is inside one.
+Otherwise send the current paragraph to the inferior ESS process.
+Prefix arg VIS toggles visibility of ess-code as for
+`ess-eval-region'."
   (interactive "P")
   (let ((beg-end (ignore-errors (ess-eval-function vis 'no-error)))) ;; ignore-errors is a hack, ess-eval-function gives stupid errors sometimes
     (if (null beg-end) ; not a function
@@ -1783,7 +1779,7 @@ active. Prefix arg VIS toggles visibility of ess-code as for
 
 (defun ess-eval-line (&optional vis)
   "Send the current line to the inferior ESS process.
-Arg has same meaning as for `ess-eval-region'."
+VIS has same meaning as for `ess-eval-region'."
   (interactive "P")
   (save-excursion
     (end-of-line)
@@ -1877,37 +1873,36 @@ for `ess-eval-region'."
 
 (defun ess-eval-buffer-and-go (vis)
   "Send the current buffer to the inferior S and switch to the process buffer.
-Arg has same meaning as for `ess-eval-region'."
+VIS has same meaning as for `ess-eval-region'."
   (interactive "P")
   (ess-eval-buffer vis)
   (ess-switch-to-ESS t))
 
 (defun ess-eval-function-and-go (vis)
-  "Send the current function to the inferior ESS process and switch to
-the process buffer. Arg has same meaning as for `ess-eval-region'."
+  "Send the current function, then switch to the inferior process buffer.
+VIS has same meaning as for `ess-eval-region'."
   (interactive "P")
   (ess-eval-function vis)
   (ess-switch-to-ESS t))
 
 (defun ess-eval-line-and-go (vis)
-  "Send the current line to the inferior ESS process and switch to the
-process buffer. Arg has same meaning as for `ess-eval-region'."
+  "Send the current line, then switch to the inferior process buffer.
+VIS has same meaning as for `ess-eval-region'."
   (interactive "P")
   (ess-eval-line vis)
   (ess-switch-to-ESS t))
 
 (defun ess-eval-paragraph-and-go (vis)
-  "Send the current paragraph to the inferior ESS process and switch to the
-process buffer. Arg has same meaning as for `ess-eval-region'."
+  "Send the current paragraph, then switch to the inferior process buffer.
+VIS has same meaning as for `ess-eval-region'."
   (interactive "P")
   (ess-eval-paragraph vis)
   (ess-switch-to-ESS t))
 
 (defun ess-eval-paragraph-and-step (vis)
-  "Send the current paragraph to the inferior ESS process and
-move forward to the first line after the paragraph.  If not
-inside a paragraph, evaluate next one. Arg has same meaning as
-for `ess-eval-region'."
+  "Evaluate the current paragraph and move point to the next line.
+If not inside a paragraph, evaluate the next one. VIS has same
+meaning as for `ess-eval-region'."
   (interactive "P")
   (let ((beg-end (ess-eval-paragraph vis)))
     (goto-char (cadr beg-end))
@@ -2019,7 +2014,7 @@ for `ess-eval-region'."
     (define-key map "\C-c\C-s" 'ess-execute-search)
     (define-key map "\C-c\C-x" 'ess-execute-objects)
     map)
-  "Keymap used in `ess-execute'")
+  "Keymap used in `ess-execute'.")
 
 ;;;###autoload
 (defun inferior-ess-mode ()
@@ -2045,9 +2040,10 @@ if errors occur. The ess-eval- commands do not do this.
 Customization: Entry to this mode runs the hooks on `comint-mode-hook' and
 `inferior-ess-mode-hook' (in that order).
 
-You can send text to the inferior ESS process from other buffers containing
-S source. The key bindings of these commands can be found by typing
-C-h m (help for mode) in the other buffers.
+You can send text to the inferior ESS process from other buffers
+containing source code. The key bindings of these commands can be
+found by typing \\[describe-mode].
+
     `ess-eval-region' sends the current region to the ESS process.
     `ess-eval-buffer' sends the current buffer to the ESS process.
     `ess-eval-function' sends the current function to the ESS process.
@@ -2203,8 +2199,7 @@ to continue it."
   "Move point to the begining of input skiping all continuation lines.
 If in the output field, goes to the begining of previous input
 field.
-Note: inferior-ess-secondary-prompt should match exactly.
-"
+Note: `inferior-ess-secondary-prompt' should match exactly."
   (goto-char (field-beginning))
   ;; move to the begining of non-output field
   (while (and (not (= (point) (point-min)))
@@ -2224,8 +2219,7 @@ Note: inferior-ess-secondary-prompt should match exactly.
   "Move point to the end of input skiping all continuation lines.
 If in the output field,  goes to the begining of previous input field.
 
-NOTE: to be used only with fields, see `comint-use-prompt-regexp'.
-" ;; this func is not used but might be useful some day
+NOTE: to be used only with fields, see `comint-use-prompt-regexp'." ;; this func is not used but might be useful some day
   (goto-char (field-end))
   (let ((pos (point))
         (secondary-prompt (concat "^" inferior-ess-secondary-prompt)))
@@ -2336,7 +2330,7 @@ A negative prefix argument gets the objects for that position
 
 (defun ess-execute-search (invert)
   "Send the `inferior-ess-search-list-command' command to the `ess-language' process.
- [search(..) in S]"
+[search(..) in S]"
   (interactive "P")
   (ess-execute inferior-ess-search-list-command  invert "S search list"))
 
@@ -2619,8 +2613,7 @@ keyword 'non-... or nil.
 To avoid truncation of long vectors, wrap your
 command (%s) like this, or a version with explicit options(max.print=1e6):
 
-local({ out <- try({%s}); print(out, max=1e6) })\n
-"
+local({ out <- try({%s}); print(out, max=1e6) })\n"
   (inferior-ess-force)
   (let* ((tbuffer (get-buffer-create
                    " *ess-get-words*")); initial space: disable-undo
@@ -2659,13 +2652,18 @@ I.e. if the filenames in DIR are not representative of the objects in DIR."
 
 (defun ess-object-names (obj &optional pos)
   "Return alist of S object names in directory (or object) OBJ.
-If OBJ is a directory name (begins with `/') returns a listing of that dir.
-   This may use the search list position POS if necessary.
-If OBJ is an object name, returns result of the command `inferior-ess-safe-names-command'.
-If POS is supplied return the result of the command in `inferior-ess-objects-command'
-If OBJ is nil or not a directory, POS must be supplied.
-In all cases, the value is an list of object names."
+If OBJ is a directory name (begins with `/') returns a listing of
+that dir. This may use the search list position POS if necessary.
 
+If OBJ is an object name, returns result of the command
+`inferior-ess-safe-names-command'.
+
+If POS is supplied return the result of the command in
+`inferior-ess-objects-command'
+
+If OBJ is nil or not a directory, POS must be supplied.
+
+In all cases, the value is an list of object names."
   (cond ((and (stringp obj)
               (string-match-p "ESSR" obj))
          nil)
@@ -2707,17 +2705,19 @@ In all cases, the value is an list of object names."
 ;;; SJE: Wed 29 Dec 2004 --- remove this function.
 ;;; rmh: Wed 5 Jan 2005 --- bring it back for use on Windows
 (defun ess-create-object-name-db ()
-  "Create a database of object names in standard S directories.  This
-database is saved in the file specified by `ess-object-name-db-file',
-and is loaded when `ess-mode' is loaded. It defines the variable
-`ess-object-name-db', which is used for completions.
+  "Create a database of object names in standard S directories.
+This database is saved in the file specified by
+`ess-object-name-db-file', and is loaded when `ess-mode' is
+loaded. It defines the variable `ess-object-name-db', which is
+used for completions.
 
-Before you call this function, modify the S search list so that it contains
-all the non-changing (i.e. system) S directories.  All positions of the search
-list except for position 1 are searched and stored in the database.
+Before you call this function, modify the S search list so that
+it contains all the non-changing (i.e. system) S directories. All
+positions of the search list except for position 1 are searched
+and stored in the database.
 
-After running this command, you should move ess-namedb.el to a directory in
-the `load-path'."
+After running this command, you should move ess-namedb.el to a
+directory in the `load-path'."
   (interactive)
   (setq ess-object-name-db nil)
   (let ((search-list (cdr (ess-search-list)))
@@ -2752,8 +2752,7 @@ the `load-path'."
     (setq ess-object-name-db temp-object-name-db)))
 
 (defun ess-resynch nil
-  "Reread all directories/objects in variable `ess-search-list' to
-form completions."
+  "Reread all directories/objects in variable `ess-search-list' to form completions."
   (interactive)
 
   (if (ess-make-buffer-current) nil
@@ -3054,15 +3053,13 @@ To be used in `ess-idle-timer-functions'."
 
 ;; search path
 (defun ess--mark-search-list-as-changed ()
-  "Internal. Marks all the search-list related variables as
-changed."
+  "Internal. Mark all the search-list related variables as changed."
   ;; other guys might track their own
   (ess-process-put 'sp-for-help-changed? t)
   (ess-process-put 'sp-for-ac-changed? t))
 
 (defun ess-cache-search-list ()
-  "To be used in `ess-idle-timer-functions', to set
-search path related variables."
+  "To be used in `ess-idle-timer-functions', to set search path related variables."
   (when (and ess-can-eval-in-background
              inferior-ess-search-list-command)
     (ess-when-new-input last-cache-search-list
@@ -3128,7 +3125,8 @@ search path related variables."
 
 
 (defun ess-display-temp-buffer (buff)
-  "Display the buffer BUFF using `temp-buffer-show-function' and respecting
+  "Display the buffer BUFF.
+Uses `temp-buffer-show-function' and respects
 `ess-display-buffer-reuse-frames'."
   (if (fboundp temp-buffer-show-function)
       (funcall temp-buffer-show-function buff))
@@ -3175,7 +3173,7 @@ if this is the case."
             (not (y-or-n-p
 
                   (format
-                   "The ESS object %s is newer than this file. Continue?"
+                   "The ESS object %s is newer than this file. Continue? "
                    objname)))
             (error "Aborted"))))))
 

--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -176,7 +176,7 @@ or \\[ess-internal-complete-object-name] otherwise."
   (ess-complete-object-name))
 
 (defun ess-complete-object-name-deprecated ()
-  "Gives a deprecated message "
+  "Gives a deprecated message."
   (interactive)
   (ess-complete-object-name)
   (message "C-c TAB is deprecated, completions has been moved to [M-TAB] (aka C-M-i)")
@@ -189,7 +189,7 @@ The object is compared against those objects known by
 `ess-get-object-list' and any additional characters up to ambiguity are
 inserted.  Completion only works on globally-known objects (including
 elements of attached data frames), and thus is most suitable for
-interactive command-line entry, and not so much for function editing
+interactive `command-line' entry, and not so much for function editing
 since local objects (e.g. argument names) aren't known.
 
 Use \\[ess-resynch] to re-read the names of the attached directories.
@@ -447,7 +447,7 @@ To be used instead of ESS' completion engine for R versions >= 2.7.0."
     (candidates . ess-ac-candidates)
     ;; (action  . ess-ac-action-args) ;; interfere with ac-fallback mechanism on RET (which is extremely annoing in inferior buffers)
     (document   . ess-ac-help))
-  "Combined ad-completion source for R function arguments and R objects")
+  "Combined ad-completion source for R function arguments and R objects.")
 
 (defun ess-ac-start ()
   (when (ess-process-live-p)
@@ -455,7 +455,7 @@ To be used instead of ESS' completion engine for R versions >= 2.7.0."
         (ess-symbol-start))))
 
 (defun ess-ac-candidates ()
-  "OBJECTS + ARGS"
+  "OBJECTS + ARGS."
   (let ((args (ess-ac-args)))
     ;; sort of intrusive but right
     (if (and ac-auto-start
@@ -476,10 +476,10 @@ To be used instead of ESS' completion engine for R versions >= 2.7.0."
     ;; (requires   . 2)
     (candidates . ess-ac-objects)
     (document   . ess-r-get-object-help-string))
-  "Auto-completion source for R objects")
+  "Auto-completion source for R objects.")
 
 (defun ess-ac-objects (&optional no-kill)
-  "Get all cached objects"
+  "Get all cached objects."
  (let ((aprf ac-prefix))
    (when (and aprf (ess-process-live-p))
      (unless no-kill ;; workaround
@@ -493,7 +493,7 @@ To be used instead of ESS' completion engine for R versions >= 2.7.0."
     (candidates . ess-ac-args)
     ;; (action     . ess-ac-action-args)
     (document   . ess-r-get-arg-help-string))
-  "Auto-completion source for R function arguments")
+  "Auto-completion source for R function arguments.")
 
 (defun ess-ac-args ()
   "Get the args of the function when inside parentheses."
@@ -511,3 +511,5 @@ To be used instead of ESS' completion engine for R versions >= 2.7.0."
   "getArgHelp('%s','%s')")
 
 (provide 'ess-r-completion)
+
+;;; ess-r-completion.el ends here

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -77,7 +77,6 @@
 (defvar ess-dev-map
   (let (ess-dev-map)
     (define-prefix-command 'ess-dev-map)
-    ;; Note: some of these comand are automatically redefined by those in
     (define-key ess-dev-map "\C-s" 'ess-r-set-evaluation-env)
     (define-key ess-dev-map "s" 'ess-r-set-evaluation-env)
     (define-key ess-dev-map "T" 'ess-toggle-tracebug)
@@ -451,8 +450,7 @@ before ess-site is loaded) for it to take effect.")
 ;;;*;;; Mode init
 
 (defvar ess-r-post-run-hook nil
-  "Functions run in process buffer after the initialization of R
-  process.")
+  "Functions run in process buffer after the initialization of R process.")
 (defalias 'ess-R-post-run-hook 'ess-r-post-run-hook)
 
 (defun ess-r-mode-p ()
@@ -621,16 +619,17 @@ Executed in process buffer."
 ;;*;; Miscellaneous
 
 (defun ess-R-arch-2-bit (arch)
-  "Translate R's architecture shortcuts/directory names to 'bits',
- i.e., \"32\" or \"64\" (for now)."
+  "Translate R's architecture shortcuts/directory names to 'bits'.
+ARCH \"32\" or \"64\" (for now)."
   (if (string= arch "i386")  "32"
     ;; else:
     "64"))
 
 (defun ess-rterm-arch-version (long-path &optional give-cons)
-  "Find an architecture-specific name for LONG-PATH, an absolute (long name) path
- to R on Windows. Returns either Name, a string, or a (Name . Path) cons, such as
- (\"R-2.12.1-64bit\"  .  \"C:/Program Files/R/R-2.12.1/bin/x64/Rterm.exe\")
+  "Find a name for LONG-PATH, an absolute path to R on Windows.
+Returns either Name, a string, or a (Name . Path) cons, such as
+
+(\"R-2.12.1-64bit\"  .  \"C:/Program Files/R/R-2.12.1/bin/x64/Rterm.exe\")
 
 \"R-x.y.z/bin/Rterm.exe\" will return \"R-x.y.z\", for R-2.11.x and older.
 \"R-x.y.z/bin/i386/Rterm.exe\" will return \"R-x.y.z-32bit\", for R-2.12.x and newer.
@@ -687,9 +686,9 @@ as `ess-r-created-runners' upon ESS initialization."
   'ess-r-versions-create 'ess-r-define-runners "2018-05-12")
 
 (defvar ess-newest-R nil
-  "Stores the newest version of R that has been found.  Used as a cache,
-within ess-find-newest-R.  Do not use this value directly, but
-instead call the function \\[ess-find-newest-R].")
+  "Stores the newest version of R that has been found.
+Used as a cache, within `ess-find-newest-R'. Do not use this value
+directly, but instead call the function \\[ess-find-newest-R].")
 
 
 (defcustom ess-prefer-higher-bit t
@@ -700,10 +699,10 @@ by the code on Windows for finding the newest version of R."
   :type 'boolean)
 
 (defun ess-rterm-prefer-higher-bit ()
-  "Optionally remove 32bit Rterms from being candidate for R-newest.
-Return the list of candidates for being R-newest.  Filtering is done
-iff `ess-prefer-higher-bit' is non-nil.
-This is used only by Windows when running `ess-find-newest-R'."
+  "Optionally remove 32bit Rterms from being candidate for `R-newest'.
+Return the list of candidates for being `R-newest'. Filtering is
+done iff `ess-prefer-higher-bit' is non-nil. This is used only by
+Windows when running `ess-find-newest-R'."
   (if ess-prefer-higher-bit
     ;; filter out 32 bit elements
     (let ((filtered
@@ -718,9 +717,10 @@ This is used only by Windows when running `ess-find-newest-R'."
 
 
 (defun ess-find-newest-R ()
-  "Find the newest version of R on the system.  Once the value is found,
-cache it in the variable `ess-newest-R' for future use as finding the
-newest version of R can be potentially time-consuming."
+  "Find the newest version of R on the system.
+Once the value is found, cache it in the variable `ess-newest-R'
+for future use as finding the newest version of R can be
+potentially time-consuming."
   (or ess-newest-R
       (progn (message "Finding all versions of R on your system...")
              ;;(sleep-for 3)
@@ -751,7 +751,7 @@ prompt for command line arguments."
   (interactive "P")
   (let ((rnewest (ess-find-newest-R)))
     (if (not rnewest)
-        (error "No version of R could be found.")
+        (error "No version of R could be found")
       ;; Else: we have a working version of R.
       ;; Have to be careful to avoid recursion...
       (message (concat "Newest version of R is " rnewest))
@@ -791,7 +791,7 @@ returned."
     (cons date rver)))
 
 (defun ess-current-R-version ()
-  "Get the version of R currently running in the ESS buffer as a string"
+  "Get the version of R currently running in the ESS buffer as a string."
   (ess-make-buffer-current)
   (car (ess-get-words-from-vector "as.character(.ess.Rversion)\n")))
 
@@ -836,11 +836,13 @@ If the value returned is nil, no valid newest version of R could be found."
 
 (defun ess-find-rterm (&optional ess-R-root-dir bin-Rterm-exe)
   "Find the full path of all occurences of Rterm.exe under the ESS-R-ROOT-DIR.
-If ESS-R-ROOT-DIR is nil, construct it by looking for an occurence of Rterm.exe
-in the exec-path.  If there are no occurences of Rterm.exe in the exec-path,
-then use `ess-program-files' (which evaluates to something like \"c:/progra~1/R/\"
-in English locales) which is the default location for the R distribution.
-If BIN-RTERM-EXE is nil, then use \"bin/Rterm.exe\"."
+If ESS-R-ROOT-DIR is nil, construct it by looking for an
+occurence of Rterm.exe in the `exec-path'. If there are no
+occurences of Rterm.exe in the `exec-path', then use
+`ess-program-files' (which evaluates to something like
+\"c:/progra~1/R/\" in English locales) which is the default
+location for the R distribution. If BIN-RTERM-EXE is nil, then
+use \"bin/Rterm.exe\"."
   (if (not ess-R-root-dir)
       (let ((Rpath (executable-find "Rterm")))
         (setq ess-R-root-dir
@@ -928,14 +930,15 @@ not issue messages."
   "2018-07-25")
 
 (defvar ess--packages-cache nil
-  "Cache var to store package names. Used by
-  `ess-r-install-library'.")
+  "Cache var to store package names.
+Used by `ess-r-install-library'.")
 
 (defvar ess--CRAN-mirror nil
   "CRAN mirror name cache.")
 
 (defun ess-r-install-library (&optional update pack)
-  "Prompt and install R package. With argument, update cached packages list."
+  "Prompt and install R package PACK.
+With argument UPDATE, update cached packages list."
   (interactive "P")
   (inferior-ess-r-force)
   (when (equal "@CRAN@" (car (ess-get-words-from-vector "getOption('repos')[['CRAN']]\n")))
@@ -955,14 +958,14 @@ not issue messages."
     (display-buffer (buffer-name (process-buffer (get-process ess-current-process-name))))))
 
 (defun ess-setRepositories ()
-  "Call setRepositories()"
+  "Call setRepositories()."
   (interactive)
   (if (not (string-match "^R" ess-dialect))
       (message "Sorry, not available for %s" ess-dialect)
     (ess-eval-linewise "setRepositories(FALSE)\n")))
 
 (defun ess-setCRANMiror (&optional mirror)
-  "Set cran mirror"
+  "Set cran MIRROR."
   (interactive)
   (let ((mirror-cmd "local({r <- getOption('repos'); r['CRAN'] <- '%s';options(repos=r)})\n"))
     (if mirror
@@ -994,7 +997,7 @@ not issue messages."
   (ess-eval-linewise (format "sos::findFn(\"%s\", maxPages=10)" cmd)))
 
 (defun ess-R-scan-for-library-call (string)
-  "Detect `library/require' calls in string and update tracking vars.
+  "Detect `library/require' call in STRING and update tracking vars.
 Placed into `ess-presend-filter-functions' for R dialects."
   (when (string-match-p "\\blibrary(\\|\\brequire(" string)
     (ess--mark-search-list-as-changed))
@@ -1006,7 +1009,7 @@ Placed into `ess-presend-filter-functions' for R dialects."
 Note that add-ons in R are called 'packages' and the name of this
 function has nothing to do with R package mechanism, but it
 rather serves a generic, dialect independent purpose. It is also
-similar to `load-library' emacs function."
+similar to `load-library' Emacs function."
   (interactive)
   (if (not (string-match "^R" ess-dialect))
       (message "Sorry, not available for %s" ess-dialect)
@@ -1198,8 +1201,8 @@ selected (see `ess-r-set-evaluation-env')."
 (defconst inferior-ess-r--page-regexp (format "^ *page *(%s)" ess-help-arg-regexp))
 
 (defvar ess-help-r--last-help-type nil
-  "Variable holding the last known help type. If it changes,
-we flush the cache.")
+  "Variable holding the last known help type.
+If it changes, we flush the cache.")
 
 (defun ess-help-r--check-last-help-type ()
   (let ((help-type (ess-string-command "getOption('help_type')\n")))
@@ -1248,7 +1251,7 @@ we flush the cache.")
            (ess-display-help-on-object help-?-match "%s\n")))))
 
 (defun ess-help-r--sanitize-topic (string)
-  ;; Enclose help topics into `` to avoid ?while ?if etc hangs
+  "Enclose help topic STRING into `` to avoid ?while ?if etc hangs."
   (if (string-match "\\([^:]*:+\\)\\(.*\\)$" string) ; treat foo::bar corectly
       (format "%s`%s`" (match-string 1 string) (match-string 2 string))
     (format "`%s`" string)))
@@ -1835,8 +1838,7 @@ Returns nil if line starts inside a string, t if in a comment."
                (ess-calculate-indent--continued)))))))
 
 (defun ess-calculate-indent--continued ()
-  "If a continuation line, return an indent of this line,
-otherwise nil."
+  "If a continuation line, return an indent of this line, otherwise nil."
   (save-excursion
     (let* ((start-line (line-number-at-pos))
            (prev-pos 0)
@@ -1941,8 +1943,9 @@ otherwise nil."
   "Backup of original code to cycle back to original state.")
 
 (defvar ess-fill--second-state nil
-  "Backup of code produce by very first cycling. If this is equal
-  to orig-state, no need to cycle back to original state.")
+  "Backup of code produce by very first cycling.
+If this is equal to orig-state, no need to cycle back to original
+state.")
 
 (defvar ess-fill--style-level nil
   "Filling style used in last cycle.")

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -216,7 +216,7 @@ Root is determined by locating `ess-r-package-root-file'."
          (pkg-info (cons pkg-name pkg-path)))
     (unless (and pkg-name pkg-path
                  (file-exists-p (expand-file-name ess-r-package-root-file pkg-path)))
-      (error "Not a valid package. No '%s' found in `%s'." ess-r-package-root-file pkg-path))
+      (error "Not a valid package. No '%s' found in `%s'" ess-r-package-root-file pkg-path))
     (message (format "%s selected and added to file-local variables" pkg-name))
     (save-excursion
       (add-file-local-variable 'ess-r-package--project-cache pkg-info))
@@ -329,7 +329,7 @@ With prefix ARG run with `valgrind = TRUE'."
 
 (defun ess-r-devtools-build (&optional arg)
   "Interface for `devtools::build()'.
-With prefix arg, build with 'vignettes = FALSE'."
+With prefix ARG, build with 'vignettes = FALSE'."
   (interactive "P")
   (ess-r-package-eval-linewise
    "devtools::build(%s)\n" "Building %s" arg
@@ -382,7 +382,7 @@ With prefix ARG ask for extra arguments."
 
 (defun ess-r-devtools-install-package (&optional arg)
   "Interface to `devtools::install()'.
-On prefix ARG (C-u), build the package first outside of current
+On prefix ARG \\[universal-argument], build the package first outside of current
 tree (local = FALSE). With double prefix ARG (C-u C-u) install
 quickly (quick = TRUE, upgrade_dependencies = FALSE)."
   (interactive "P")
@@ -440,7 +440,7 @@ When called with prefix ARG asks for additional arguments."
 
 (defcustom ess-r-package-auto-activate t
   "If non-nil, `ess-r-package-mode' is turned on within R packages.
-If `t' the minor mode auto-activates in R packages. See
+If 't' the minor mode auto-activates in R packages. See
 `ess-r-package-exclude-modes' if you wish to inhibit
 `ess-r-package-mode' in specific buffers."
   :group 'ess-r-package
@@ -467,8 +467,8 @@ The check is done with `derived-mode-p'."
   '(:eval (let ((pkg-name (ess-r-package-name)))
             (when pkg-name
               (format " [pkg:%s]" pkg-name))))
-  "Mode line for ESS developer. Set this variable to nil to
-disable the mode line entirely."
+  "Mode line for ESS developer.
+Set this variable to nil to disable the mode line entirely."
   :group 'ess-r-package
   :type 'sexp
   :risky t)
@@ -550,7 +550,7 @@ package mode. Use this function if state of the buffer such as
 
 ;;;*;;; Deprecated variables and functions
 (defun ess-developer (&optional val)
-  (error "As of ESS 16.04, `ess-developer' is deprecated. Use `ess-r-set-evaluation-env' instead."))
+  (error "As of ESS 16.04, `ess-developer' is deprecated. Use `ess-r-set-evaluation-env' instead"))
 
 (defalias 'ess-toggle-developer 'ess-developer)
 (define-obsolete-function-alias 'ess-r-devtools-check-package-buildwin 'ess-r-devtools-check-with-winbuilder)

--- a/lisp/ess-r-syntax.el
+++ b/lisp/ess-r-syntax.el
@@ -65,8 +65,8 @@
     t))
 
 (defun ess-goto-char (pos)
-  "Go to `pos' if it is non-nil.
-If `pos' is nil, return nil.  Otherwise return `pos' itself."
+  "Go to POS if it is non-nil.
+If POS is nil, return nil.  Otherwise return position itself."
   (when pos
     (goto-char pos)))
 
@@ -94,7 +94,7 @@ be advised"
                 (goto-char orig-point))))))
 
 (defmacro ess-while (test &rest body)
-  "Like (while) but return `t' when body gets executed once."
+  "Like `while' for TEST but return t when BODY gets executed once."
   (declare (indent 1)
            (debug (&rest form)))
   `(let (executed)
@@ -122,10 +122,9 @@ be advised"
      (progn ,@body)))
 
 (defmacro ess-any (&rest forms)
-  "Evaluates all arguments and return non-nil if one of the
-arguments is non-nil. This is useful to trigger
-side-effects. FORMS follows the same syntax as arguments to
-`(cond)'."
+  "Evaluate all arguments and return non-nil if one of the arguments is non-nil.
+This is useful to trigger side-effects. FORMS follows the same
+syntax as arguments to `cond'."
   (declare (indent 0) (debug nil))
   `(let ((forms (list ,@(mapcar (lambda (form) `(progn ,@form)) forms))))
      (cl-some 'identity (mapcar 'eval forms))))
@@ -145,7 +144,7 @@ side-effects. FORMS follows the same syntax as arguments to
   (ess-token-type (ess-refine-token token)))
 
 (defun ess-token-after (&optional token)
-  "Returns next token.
+  "Return next TOKEN.
 Cons cell containing the token type and string representation."
   (save-excursion
     (when token
@@ -153,7 +152,7 @@ Cons cell containing the token type and string representation."
     (ess-jump-token)))
 
 (defun ess-token-before (&optional token)
-  "Returns previous token.
+  "Return previous TOKEN.
 Cons cell containing the token type and string representation."
   (save-excursion
     (when token
@@ -255,9 +254,8 @@ Cons cell containing the token type and string representation."
 
 (defun ess-jump-token (&optional type string)
   "Consume a token forward.
-Returns a cons cell containing the token type and the token
-string content. Returns nil when the end of the buffer is
-reached."
+Return a cons cell containing the token type and the token string
+content. Return nil when the end of the buffer is reached."
   (ess-save-excursion-when-nil
     (ess-skip-blanks-forward t)
     (let* ((token-start (point))
@@ -729,7 +727,7 @@ reached."
 
 (defun backward-ess-r-sexp ()
   (interactive)
-  (error "todo"))
+  (error "Todo"))
 
 (defun ess-parser-tree-assoc (key tree)
   (let ((next tree)
@@ -751,7 +749,7 @@ reached."
 ;;*;; Point predicates
 
 (defun ess-inside-call-p (&optional call)
-  "Is point in a function or indexing call?"
+  "Return non-nil if point is in a function or indexing call."
   (let ((containing-sexp (or (bound-and-true-p containing-sexp)
                              (ess-containing-sexp-position))))
     (save-excursion
@@ -782,12 +780,12 @@ reached."
     (ess-climb-call-name call)))
 
 (defun ess-inside-prefixed-block-p (&optional call)
-  "Is point in a prefixed block? Prefixed blocks refer to the
-blocks following function declarations, control flow statements,
-etc.
+  "Return non-nil if point is in a prefixed block.
+Prefixed blocks refer to the blocks following function
+declarations, control flow statements, etc.
 
-If CALL not nil, check if the prefix corresponds to CALL. If nil,
-return the prefix."
+If CALL is not nil, check if the prefix corresponds to CALL. If
+nil, return the prefix."
   (save-excursion
     (ess-escape-prefixed-block call)))
 
@@ -797,8 +795,7 @@ return the prefix."
 ;;;*;;; Blanks, Characters, Comments and Delimiters
 
 (defun ess-skip-blanks-backward (&optional newlines)
-  "Skip blanks and newlines backward, taking end-of-line comments
-into account."
+  "Skip blanks and newlines backward, taking end-of-line comments into account."
   (ess-any ((ess-skip-blanks-backward-1))
            ((when newlines
               (ess-while (and (/= (point) (point-min))
@@ -812,8 +809,7 @@ into account."
        (/= 0 (skip-syntax-backward " "))))
 
 (defun ess-skip-blanks-forward (&optional newlines)
-  "Skip blanks and newlines forward, taking end-of-line comments
-into account."
+  "Skip blanks and newlines forward, taking end-of-line comments into account."
   (ess-any ((/= 0 (skip-syntax-forward " ")))
            ((ess-while (and newlines
                             (= (point) (ess-code-end-position))
@@ -938,9 +934,9 @@ position of the control flow function (if, for, while, etc)."
          (point))))
 
 (defun ess-climb-block-prefix (&optional call ignore-ifelse)
-  "Climb the prefix of a prefixed block. Prefixed blocks refer to
-the blocks following function declarations, control flow
-statements, etc.
+  "Climb the prefix of a prefixed block.
+Prefixed blocks refer to the blocks following function
+declarations, control flow statements, etc.
 
 Should be called either in front of a naked block or in front
 of the curly brackets of a braced block.
@@ -1028,8 +1024,8 @@ return the prefix."
     (ess-climb-object)))
 
 (defun ess-ahead-param-assign-p ()
-  "Are we looking at a function argument? To be called just
-before the `=' sign."
+  "Return non-nil if looking at a function argument.
+To be called just before the `=' sign."
   (ess-refined-token= (ess-token-before) "param-assign"))
 
 (defun ess-behind-arg-p ()

--- a/lisp/ess-r-xref.el
+++ b/lisp/ess-r-xref.el
@@ -88,7 +88,7 @@ srcrefs point to temporary locations."
   "Look in the source directory of the R package containing symbol SYMBOL for R-SRC-FILE."
   (let* ((env-name (ess-string-command (format ".ess_fn_pkg(\"%s\")\n" symbol)))
          (pkg (if (string-equal env-name "")
-                  (error "Can't find package for symbol %s." symbol)
+                  (error "Can't find package for symbol %s" symbol)
                 env-name))
          (dir (or (assoc-default pkg ess-r-xref-pkg-sources)
                   (cond ((stringp ess-r-package-library-paths)
@@ -101,7 +101,7 @@ srcrefs point to temporary locations."
          (file (when dir (expand-file-name r-src-file dir))))
     (when file
       (unless (file-readable-p file)
-        (error "Can't read %s." file))
+        (error "Can't read %s" file))
       ;; Cache package's source directory.
       (unless (assoc pkg ess-r-xref-pkg-sources)
         (push `(,pkg . ,dir) ess-r-xref-pkg-sources))

--- a/lisp/ess-rd.el
+++ b/lisp/ess-rd.el
@@ -24,6 +24,10 @@
 ;; obtain it by writing to the Free Software Foundation, Inc., 675 Mass
 ;; Ave, Cambridge, MA 02139, USA.
 
+
+;;; Commentary:
+;;
+
 ;;; Code:
 (require 'ess-custom)
 (require 'ess-utils)
@@ -218,10 +222,10 @@ All Rd mode abbrevs start with a grave accent (`).")
   "Menu used in Rd mode.")
 
 (defvar Rd-mode-hook nil
-  "*Hook to be run when Rd mode is entered.")
+  "Hook to be run when Rd mode is entered.")
 
 (defvar Rd-to-help-command "R CMD Rd2txt"
-  "*Shell command for converting R documentation source to help text.")
+  "Shell command for converting R documentation source to help text.")
 
 
 (defvar Rd-font-list
@@ -234,13 +238,11 @@ All Rd mode abbrevs start with a grave accent (`).")
     (?\C-q "\\eqn{"     "}")
     (?\C-u "\\url{"     "}")
     )
-  "List of ``fonts'' used by Rd-font.
-
-Each entry is a list.
-The first element is the key to activate the font.
-The second element is the string to insert before point, and the third
-element is the string to insert after point."
-  )
+  "List of \"fonts\" used by `Rd-font'.
+Each entry is a list. The first element is the key to activate
+the font. The second element is the string to insert before
+point, and the third element is the string to insert after
+point.")
 
 
 ;;;###autoload
@@ -273,8 +275,7 @@ following lines to your `.emacs' file:
 
   (add-hook 'Rd-mode-hook
             (lambda ()
-              (abbrev-mode 1)))
-"
+              (abbrev-mode 1)))"
 
   (interactive)
   (text-mode)
@@ -316,7 +317,7 @@ following lines to your `.emacs' file:
 
 ;; FIXME: The following should be moved to ess-utils.el, no? (MM thinks)
 (defun ess-point (position)
-  "Returns the value of point at certain positions."
+  "Return the value of point at a certain POSITION."
   (save-excursion
     (cond
      ((eq position 'bol)  (beginning-of-line))
@@ -324,7 +325,7 @@ following lines to your `.emacs' file:
      ((eq position 'boi)  (back-to-indentation))
      ((eq position 'bonl) (forward-line 1))
      ((eq position 'bopl) (forward-line -1))
-     (t (error "unknown buffer position requested: %s" position)))
+     (t (error "Unknown buffer position requested: %s" position)))
     (point)))
 
 (defun Rd-describe-major-mode ()
@@ -432,7 +433,7 @@ following lines to your `.emacs' file:
 
 (defun Rd-font (what)
   "Insert template for font command.
- WHAT determines the font to use, as specified by `Rd-font-list'."
+WHAT determines the font to use, as specified by `Rd-font-list'."
   (interactive "c")
   ;;TeX had : (Rd-update-style)
   (let* ((entry (assoc what Rd-font-list))
@@ -475,8 +476,7 @@ following lines to your `.emacs' file:
   "Preview the current Rd buffer contents as help.
 If optional VIA-SHELL is set, using `Rd-to-help-command'.
 If the current buffer is not associated with a file, create a
-temporary one in `temporary-file-directory'.
-"
+temporary one in `temporary-file-directory'."
   (interactive "P")
   (require 'ess-help)
   (let ((file buffer-file-name)
@@ -533,9 +533,8 @@ temporary one in `temporary-file-directory'.
      'Rd-indent-level))))
 
 
-;; Provide ourself
-(provide 'ess-rd)
 ;; Legacy feature
 (provide 'essddr)
+(provide 'ess-rd)
 
-;; ess-rd.el ends here
+;;; ess-rd.el ends here

--- a/lisp/ess-rdired.el
+++ b/lisp/ess-rdired.el
@@ -56,7 +56,7 @@
 
 ;; Most of the hardwork is done by the R routine .rdired.objects(),
 ;; which, when called, produces the list of objects in a tidy format.
-;; This function is stored within the lisp variable `ess-rdired-objects',
+;; This function is stored within the Lisp variable `ess-rdired-objects',
 ;; and can be altered to provide other information if you so need it.
 ;; (Martin Maechler suggested providing output from str() here.)
 
@@ -106,9 +106,9 @@
   d
   }
 }; cat('\n'); print(.rdired.objects(ls()))}\n"
-  "Function to call within R to print information on objects.  The last
-line of this string should be the instruction to call the
-function which prints the output for rdired.")
+  "Function to call within R to print information on objects.
+The last line of this string should be the instruction to call
+the function which prints the output for rdired.")
 
 (defvar ess-rdired-buffer "*R dired*"
   "Name of buffer for displaying R objects.")
@@ -154,7 +154,7 @@ function which prints the output for rdired.")
 list of current objects in the current environment, one-per-line.  You
 can then examine these objects, plot them, and so on.
 \\{ess-rdired-mode-map}"
-  ;; (kill-all-local-variables) 
+  ;; (kill-all-local-variables)
   (make-local-variable 'revert-buffer-function)
   (setq revert-buffer-function 'ess-rdired-revert-buffer)
   (use-local-map ess-rdired-mode-map)
@@ -241,14 +241,14 @@ Handle special case when object contains spaces."
                  nil "R view" )))
 
 (defun ess-rdired-get (name)
-  "Generate R code to get the value of the variable name.
+  "Generate R code to get the value of the variable NAME.
 This is complicated because some variables might have spaces in their names.
 Otherwise, we could just pass the variable name directly to *R*."
   (concat "get(" (ess-rdired-quote name) ")")
   )
 
 (defun ess-rdired-quote (name)
-  "Quote name if not already quoted."
+  "Quote NAME if not already quoted."
   (if (equal (substring name 0 1) "\"")
       name
     (concat "\"" name "\"")))
@@ -498,4 +498,4 @@ After switching to a new process, the buffer is updated."
 
 (provide 'ess-rdired)
 
-;;; ess-rdired.el ends here.
+;;; ess-rdired.el ends here

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -59,8 +59,7 @@
 
 ;; this *is* enabled now via ess-mode-hook in ./ess-site.el
 
-
-;;*;; Dependencies:
+;;; Code:
 
 (require 'ess-utils)
 (require 'ess-custom)
@@ -220,14 +219,14 @@ Use you regular key for `outline-show-entry' to reveal it.")
 ;;*;; Function definitions
 
 (defun ess-back-to-roxy ()
-  "Go to roxy prefix"
+  "Go to roxy prefix."
   (progn
     (end-of-line)
     (re-search-backward (concat ess-roxy-re " ?") (point-at-bol))
     (goto-char (match-end 0))))
 
 (defun ess-roxy-beg-of-entry ()
-  "Get point number at start of current entry, 0 if not in entry"
+  "Get point number at start of current entry, 0 if not in entry."
   (save-excursion
     (let (beg)
       (beginning-of-line)
@@ -240,7 +239,7 @@ Use you regular key for `outline-show-entry' to reveal it.")
       beg)))
 
 (defun ess-roxy-in-header-p ()
-  "true if point is the description / details field"
+  "True if point is the description / details field."
   (save-excursion
     (let ((res t)
           (cont (ess-roxy-entry-p)))
@@ -253,7 +252,7 @@ Use you regular key for `outline-show-entry' to reveal it.")
         )res)))
 
 (defun ess-roxy-beg-of-field ()
-  "Get point number at beginning of current field, 0 if not in entry"
+  "Get point number at beginning of current field, 0 if not in entry."
   (save-excursion
     (let (cont beg)
       (beginning-of-line)
@@ -273,7 +272,7 @@ Use you regular key for `outline-show-entry' to reveal it.")
       beg)))
 
 (defun ess-roxy-end-of-entry ()
-  " get point number at end of current entry, 0 if not in entry"
+  "Get point number at end of current entry, 0 if not in entry."
   (save-excursion
     (let ((end))
       (end-of-line)
@@ -287,7 +286,7 @@ Use you regular key for `outline-show-entry' to reveal it.")
       end)))
 
 (defun ess-roxy-end-of-field ()
-  "get point number at end of current field, 0 if not in entry"
+  "Get point number at end of current field, 0 if not in entry."
   (save-excursion
     (let ((end nil)
           (cont nil))
@@ -312,7 +311,7 @@ Use you regular key for `outline-show-entry' to reveal it.")
       end)))
 
 (defun ess-roxy-entry-p (&optional field)
-  "True if point is in a roxy entry"
+  "True if point is in a roxy entry."
   (and (save-excursion
          (beginning-of-line)
          (looking-at ess-roxy-re))
@@ -320,7 +319,7 @@ Use you regular key for `outline-show-entry' to reveal it.")
            (string= (ess-roxy-current-field) field))))
 
 (defun ess-roxy-narrow-to-field ()
-  "Go to to the start of current field"
+  "Go to to the start of current field."
   (interactive)
   (let ((beg (ess-roxy-beg-of-field))
         (end (ess-roxy-end-of-field)))
@@ -372,8 +371,9 @@ Use you regular key for `outline-show-entry' to reveal it.")
     (insert (make-string ess-indent-offset ? ))))
 
 (defun ess-roxy-goto-func-def ()
-  "put point at start of function either that the point is in or
-below the current roxygen entry, error otherwise"
+  "Put point at start of function.
+Go to the beginning of the current one or below the current
+roxygen entry, error otherwise"
   (if (ess-roxy-entry-p)
       (progn
         (ess-roxy-goto-end-of-entry)
@@ -382,16 +382,16 @@ below the current roxygen entry, error otherwise"
     (goto-char (car (ess-end-of-function)))))
 
 (defun ess-roxy-get-args-list-from-def ()
-  "get args list for current function"
+  "Get args list for current function."
   (save-excursion
     (ess-roxy-goto-func-def)
     (let ((args (ess-roxy-get-function-args)))
       (mapcar (lambda (x) (cons x '(""))) args))))
 
 (defun ess-roxy-insert-args (args &optional here)
-  "Insert an args list to the end of the roxygen entry for the
-function at point. if here is supplied start inputting
-`here'. Finish at end of line."
+  "Insert an ARGS list to the end of the current roxygen entry.
+If HERE is supplied start inputting `here'. Finish at end of
+line."
   (let* ((arg-des nil)
          (roxy-str (ess-roxy-guess-str)))
     (if (or (not here) (< here 1))
@@ -415,8 +415,8 @@ function at point. if here is supplied start inputting
               (fill-paragraph)))))))
 
 (defun ess-roxy-merge-args (fun ent)
-  "Take two args lists (alists) and return their union. Result
-holds all keys from both fun and ent but no duplicates and
+  "Take two args lists (alists) and return their union.
+The result holds all keys from both FUN and ENT but no duplicates and
 association from ent are preferred over entries from fun. Also,
 drop entries from ent that are not in fun and are associated with
 the empty string."
@@ -435,12 +435,11 @@ the empty string."
     (nreverse res-arg)))
 
 (defun ess-roxy-update-entry ()
-  "Update the entry at the point or the entry above the function
-which the point is in. Add a template empty roxygen documentation
-if no roxygen entry is available. The template can be customized
-via the variable `ess-roxy-template-alist'. The parameter
-descriptions can are filled if `ess-roxy-fill-param-p' is
-non-nil."
+  "Update the entry at point or the entry above the current function.
+Add a template empty roxygen documentation if no roxygen entry is
+available. The template can be customized via the variable
+`ess-roxy-template-alist'. The parameter descriptions can are
+filled if `ess-roxy-fill-param-p' is non-nil."
   (interactive)
   (save-excursion
     (let* ((args-fun (ess-roxy-get-args-list-from-def))
@@ -478,10 +477,9 @@ non-nil."
           (setq line-break "\n"))))))
 
 (defun ess-roxy-goto-end-of-entry ()
-  "Put point at the top of the entry at point or above the
-function at point. Return t if the point is left in a roxygen
-entry, otherwise nil. Error if point is not in function or
-roxygen entry."
+  "Put point at the top of the current entry or above the function at point.
+Return t if the point is left in a roxygen entry, otherwise nil.
+Error if point is not in function or roxygen entry."
   (if (not (ess-roxy-entry-p))
       (progn
         (goto-char (nth 0 (ess-end-of-function)))
@@ -493,8 +491,8 @@ roxygen entry."
     (forward-line) nil))
 
 (defun ess-roxy-goto-beg-of-entry ()
-  "put point at the top of the entry at point or above the
-function at point. Return t if the point is left in a roxygen
+  "Put point at the top of the entry at point or above the function at point.
+Return t if the point is left in a roxygen
 entry, otherwise nil. Error if point is not in function or
 roxygen entry."
   (if (not (ess-roxy-entry-p))
@@ -508,9 +506,9 @@ roxygen entry."
     (forward-line) nil))
 
 (defun ess-roxy-delete-args ()
-  "remove all args from the entry at point or above the function
-at point. Return 0 if no deletions were made other wise the point
-at where the last deletion ended"
+  "Remove all args from the entry at point or above the function at point.
+Return 0 if no deletions were made other wise the point at where
+the last deletion ended"
   (save-excursion
     (let* ((args nil)
            (cont t)
@@ -534,8 +532,7 @@ at where the last deletion ended"
       field-beg)))
 
 (defun ess-roxy-get-args-list-from-entry ()
-  "fill an args list from the entry above the function where the
-point is"
+  "Fill an args list from the entry above the function where the point is."
   (save-excursion
     (let* (args entry-beg field-beg field-end args-text arg-name desc)
       (if (ess-roxy-goto-end-of-entry)
@@ -575,7 +572,7 @@ region, otherwise prefix all lines with the roxy
 string. Convenient for editing example fields."
   (interactive "r")
   (unless (use-region-p)
-    (error "region is not active"))
+    (error "Region is not active"))
   (ess-roxy-roxy-region beg end (ess-roxy-entry-p)))
 
 (defun ess-roxy-roxy-region (beg end &optional on)
@@ -615,7 +612,7 @@ in a temporary buffer and return that buffer."
                ((string= "roxygen2" ess-roxy-package)
                 (concat "(function(P) { if(packageVersion('roxygen2') < '3.0.0') {"
                         R-old-roxy "} else {" R-new-roxy "} })"))
-               (t (error "need to hard code the roclet output call for roxygen package '%s'"
+               (t (error "Need to hard code the roclet output call for roxygen package '%s'"
                          ess-roxy-package))))
         )
     (if (= beg 0)
@@ -673,9 +670,10 @@ generate the text help page of the roxygen entry at point."
     (Rd-preview-help)))
 
 (defun ess-roxy-preview-Rd (&optional name-file)
-  "Use the connected R session and the roxygen package to
+  "Preview Rd for the roxygen entry at point.
+Use the connected R session and the roxygen package to
 generate the Rd code for the roxygen entry at point. If called
-with a non-nil `name-file' (e.g. universal argument C-u),
+with a non-nil NAME-FILE (\\[universal-argument]),
 also set the visited file name of the created buffer to
 facilitate saving that file."
   (interactive "P")
@@ -696,9 +694,9 @@ facilitate saving that file."
 
 
 (defun ess-roxy-guess-str (&optional not-here)
-  "guess the prefix used in the current roxygen block. If
-`not-here' is non-nil, guess the prefix for nearest roxygen
-block before the point"
+  "Guess the prefix used in the current roxygen block.
+If NOT-HERE is non-nil, guess the prefix for nearest roxygen
+block before the point."
   (save-excursion
     (if (ess-roxy-entry-p)
         (progn
@@ -711,7 +709,7 @@ block before the point"
       ess-roxy-str)))
 
 (defun ess-roxy-hide-block ()
-  "hide current roxygen comment block"
+  "Hide current roxygen comment block."
   (interactive)
   (save-excursion
     (let ((end-of-entry (ess-roxy-end-of-entry))
@@ -728,12 +726,12 @@ See `hs-show-block' and `ess-roxy-hide-block'."
      (ess-roxy-hide-block))))
 
 (defun ess-roxy-show-all ()
-  "Hide all Roxygen entries in current buffer. "
+  "Hide all Roxygen entries in current buffer."
   (interactive)
   (ess-roxy-hide-all t))
 
 (defun ess-roxy-hide-all (&optional show)
-  "Hide all Roxygen entries in current buffer. "
+  "Hide all Roxygen entries in current buffer."
   (interactive)
   (hs-life-goes-on
    (save-excursion
@@ -747,7 +745,7 @@ See `hs-show-block' and `ess-roxy-hide-block'."
          (forward-line 1))))))
 
 (defun ess-roxy-previous-entry ()
-  "Go to beginning of previous Roxygen entry. "
+  "Go to beginning of previous Roxygen entry."
   (interactive)
   (if (ess-roxy-entry-p)
       (progn
@@ -757,7 +755,7 @@ See `hs-show-block' and `ess-roxy-hide-block'."
   (goto-char (ess-roxy-beg-of-entry)))
 
 (defun ess-roxy-next-entry ()
-  "Go to beginning of next Roxygen entry. "
+  "Go to beginning of next Roxygen entry."
   (interactive)
   (if (ess-roxy-entry-p)
       (progn
@@ -767,8 +765,7 @@ See `hs-show-block' and `ess-roxy-hide-block'."
   (goto-char (ess-roxy-beg-of-entry)))
 
 (defun ess-roxy-get-function-args ()
-  "Return the arguments specified for the current function as a
-list of strings."
+  "Return the arguments specified for the current function as a list of strings."
   (save-excursion
     (let ((args-txt
            (progn
@@ -787,12 +784,12 @@ list of strings."
       (split-string args-txt ","))))
 
 (defun ess-roxy-match-paren ()
-  "Go to the matching parenthesis"
+  "Go to the matching parenthesis."
   (cond ((looking-at "\\s\(") (forward-list 1) (backward-char 1))
         ((looking-at "\\s\)") (forward-char 1) (backward-list 1))))
 
 (defun ess-roxy-complete-tag ()
-  "complete the tag at point"
+  "Complete the tag at point."
   (let ((bounds (ess-bounds-of-symbol)))
     (when (and bounds
                (save-excursion
@@ -802,7 +799,7 @@ list of strings."
             (append ess-roxy-tags-noparam ess-roxy-tags-param)))))
 
 (defun ess-roxy-tag-completion ()
-  "Completion data for emacs >= 24"
+  "Completion data for Emacs >= 24."
   (when (save-excursion (re-search-backward "@\\<\\(\\w*\\)" (point-at-bol) t))
     (let ((token (match-string-no-properties 1))
           (beg (match-beginning 1))
@@ -811,9 +808,9 @@ list of strings."
         (list beg end (append ess-roxy-tags-noparam ess-roxy-tags-param) :exclusive 'no)))))
 
 (defun ess-roxy-remove-roxy-re (string)
-  "Remove the `ess-roxy-str' before sending to R process. Useful
-  for sending code from example section.  This function is placed
-  in `ess-presend-filter-functions'."
+  "Remove `ess-roxy-str' from STRING before sending to R process.
+Useful for sending code from example section. This function is
+placed in `ess-presend-filter-functions'."
   ;; Only strip the prefix in the @examples field, and only when
   ;; STRING is entirely contained inside it. This allows better
   ;; behaviour for evaluation of regions.
@@ -863,14 +860,14 @@ list of strings."
          ,@body))))
 
 (defadvice ess-eval-line-and-step (around ess-eval-line-and-step-roxy)
-  "evaluate line but do not skip over comment (roxy) lines"
+  "Evaluate line but do not skip over comment (roxy) lines."
   (if (ess-roxy-entry-p)
       (let ((simple-next t))
         ad-do-it)
     ad-do-it))
 
 (defadvice ess-indent-command (around ess-roxy-toggle-hiding)
-  "hide this block if we are at the beginning of the line"
+  "Hide this block if we are at the beginning of the line."
   (if (and (= (point) (point-at-bol)) (ess-roxy-entry-p) 'ess-roxy-hide-show-p)
       (progn (ess-roxy-toggle-hiding))
     ad-do-it))
@@ -941,7 +938,7 @@ list of strings."
     ad-do-it)))
 
 (defadvice move-beginning-of-line (around ess-roxy-beginning-of-line)
-  "move to start"
+  "Move to start."
   (if (ess-roxy-entry-p)
       (let ((new-pos (save-excursion
                        (end-of-line)
@@ -954,7 +951,7 @@ list of strings."
     ad-do-it))
 
 (defadvice back-to-indentation (around ess-roxy-back-to-indentation)
-  "Handle back-to-indentation in roxygen doc"
+  "Handle `back-to-indentation' in roxygen doc."
   (if (ess-roxy-entry-p)
       (progn
         (end-of-line)

--- a/lisp/ess-rutils.el
+++ b/lisp/ess-rutils.el
@@ -129,8 +129,9 @@ Useful bindings to handle package loading and installing.
       nil)))
 
 (defun ess-rutils-repos-pkgs ()
-  "List available packages from the repositories as listed by
-getOptions(\"repos\") in the current R session."
+  "List available packages.
+Use the repositories as listed by getOptions(\"repos\") in the
+current R session."
   (interactive)
   (if (get-buffer ess-rutils-buf)
       (progn
@@ -229,10 +230,11 @@ User is asked for confirmation."
       (message "no packages flagged to install"))))
 
 (defun ess-rutils-update-pkgs (lib repos)
-  "Update packages in library LIB and repos REPOS. Defaults are the first
-element returned by .libPaths() for LIB, and the repository named CRAN
-returned by getOption(\"repos\") for REPOS. This also uses checkBuilt=TRUE
-to rebuild installed packages if needed."
+  "Update packages in library LIB and repos REPOS.
+Defaults are the first element returned by .libPaths() for LIB,
+and the repository named CRAN returned by getOption(\"repos\")
+for REPOS. This also uses checkBuilt=TRUE to rebuild installed
+packages if needed."
   (interactive "DPath to library to update: \nsrepos: ")
   (if (string= "" lib)
       (setq lib
@@ -305,11 +307,12 @@ the 'R_HOME' directory on a remote server (defaults to NULL)."
     (kill-buffer tmpbuf)))
 
 (defun ess-rutils-rsitesearch (string)
-  "Search the R archives for STRING, using default criteria, and show results
-using `browse-url'.  If called with a prefix, options are offered (with
-completion) for matches per page, sections of the archives to search,
-displaying results in long or short formats, and sorting by any given field.
-Options should be separated by value of `crm-default-separator'."
+  "Search the R archives for STRING, and show results using `browse-url'.
+If called with a prefix, options are offered (with completion)
+for matches per page, sections of the archives to search,
+displaying results in long or short formats, and sorting by any
+given field. Options should be separated by value of
+`crm-default-separator'."
   (interactive "sSearch string: ")
   (let ((site "http://search.r-project.org/cgi-bin/namazu.cgi?query=")
         (okstring (replace-regexp-in-string " +" "+" string)))

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -102,8 +102,8 @@ Currently only R is supported."
   :group 'ess)
 
 (defvar ess-tracebug-indicator " TB"
-  "String to be displayed in mode-line alongside the process
-  name. Indicates that ess-tracebug-mode is turned on. ")
+  "String to be displayed in mode-line alongside the process name.
+Indicates that ess-tracebug-mode is turned on.")
 
 ;; (defvar ess--tracebug-p nil
 ;;   "Non nil if ess-tracebug is turned on for current process.
@@ -139,14 +139,13 @@ Currently only R is supported."
 
 
 (defcustom ess-tracebug-prefix nil
-  "*Key to be used as prefix for all ess-tracebug commands.
+  "*Key to be used as prefix for all `ess-tracebug' commands.
 Set this to a key cominbation you don't use often, like:
 
  (setq ess-tracebug-prefix \"\\M-t\")
 
 The postfix keys are defined in `ess-tracebug-map':
-\\{ess-tracebug-map}
-"
+\\{ess-tracebug-map}"
   :type '(choice (const nil) (string))
   :group 'ess-tracebug)
 
@@ -156,8 +155,7 @@ The postfix keys are defined in `ess-tracebug-map':
 
 (defcustom ess-tracebug-search-path nil
   "List of directories to search for source files.
-Elements should be directory names, not file names of directories.
-"
+Elements should be directory names, not file names of directories."
   :type '(choice (const :tag "Unset" nil)
                  (repeat :tag "Directory list" (string :tag "Directory")))
   :group 'ess-debug)
@@ -166,7 +164,7 @@ Elements should be directory names, not file names of directories.
   "Name of the watch buffer.")
 
 (defcustom ess-watch-height-threshold nil
-  "Minimum height for splitting *R* windwow sensibly to make space for watch window.
+  "Minimum height for splitting *R* window sensibly to make space for watch window.
 See `split-height-threshold' for a detailed description.
 
 If nil, the value of `split-height-threshold' is used."
@@ -174,7 +172,7 @@ If nil, the value of `split-height-threshold' is used."
   :type '(choice (const nil) (integer)))
 
 (defcustom ess-watch-width-threshold nil
-  "Minimum width for splitting *R* windwow sensibly to make space for watch window.
+  "Minimum width for splitting *R* window sensibly to make space for watch window.
 See `split-width-threshold' for a detailed description.
 
 If nil, the value of `split-width-threshold' is used."
@@ -206,7 +204,8 @@ subprocess to keep the source code references.
 
 If this variable is t, you won't be able to execute blocks which
 don't form a valid R expression. That is, if your expression
-spreads multiple paragraphs, and you call C-c C-c on first
+spreads multiple paragraphs, and you call
+\\[ess-eval-region-or-function-or-paragraph-and-step] on first
 paragraph, R will report an error."
   :group 'ess-tracebug
   :type '(choice (const nil) (const function) (const function-and-buffer) (const t)))
@@ -214,13 +213,13 @@ paragraph, R will report an error."
 (define-obsolete-variable-alias 'ess-tracebug-inject-source-p 'ess-inject-source "ESS v13.09")
 
 (defcustom ess-tracebug-enter-hook nil
-  "List of functions to call on entry to ess-tracebug mode.
+  "List of functions to call on entry to `ess-tracebug' mode.
 Use `add-hook' to insert append your functions to this list."
   :group 'ess-tracebug
   :type 'hook)
 
 (defcustom ess-tracebug-exit-hook nil
-  "List of functions to call on exit of ess-tracebug mode.
+  "List of functions to call on exit of `ess-tracebug' mode.
 Use `add-hook' to insert append your functions to this list."
   :group 'ess-tracebug
   :type 'hook)
@@ -229,7 +228,7 @@ Use `add-hook' to insert append your functions to this list."
 
 (defvar ess--tracebug-eval-index 0
   "This is used by to track source references in evaluation with source.
-For example, each time ess-eval-function is called the evaluated
+For example, each time `ess-eval-function' is called the evaluated
 region is marked.  When debugger enteres the code it desplayes
 this reference number. Ess-debug finds this number in the
 referenced buffer.")
@@ -254,6 +253,7 @@ applications, like org-babel,  that call ess evaluation functions
 from temporary buffers.")
 
 (defun ess-tracebug-p ()
+  "Return non-nil if tracebug is running."
   (ess-process-get 'tracebug))
 
 (defun ess-make-source-refd-command (beg end visibly process)
@@ -397,9 +397,7 @@ by `ess-inject-source' variable."
 * Navigation to errors (general emacs functionality):
 
  C-x `, M-g n   . `next-error'
- M-g p          . `previous-error'
-
-")
+ M-g p          . `previous-error'")
 
 
 ;; * Input Ring:
@@ -409,12 +407,13 @@ by `ess-inject-source' variable."
 
 
 (defun ess-tracebug-show-help (&optional ev)
+  "Show help for `ess-tracebug'."
   (interactive)
   (describe-variable 'ess-tracebug-help))
 
 (defun ess-tracebug--propertize (dummy bitmap face &optional string )
-  "If window-system propertize DUMMY with fringe BITMAP and FACE,
-else propertize  line-prefix and margin  with STRING and  FACE"
+  "If `window-system' propertize DUMMY with fringe BITMAP and FACE.
+Otherwise, propertize line-prefix and margin with STRING and FACE"
   (unless string
     (setq string dummy))
   (if window-system
@@ -427,15 +426,15 @@ else propertize  line-prefix and margin  with STRING and  FACE"
 
 
 (defun ess-tracebug (&optional arg)
-  "Toggle ess-tracebug mode.
-With ARG, turn ess-tracebug mode on if and only if ARG is
+  "Toggle `ess-tracebug' mode.
+With ARG, turn `ess-tracebug' mode on if and only if ARG is
 positive.
 
 This mode adds to ESS the interactive debugging, breakpoint and
-error navigation functionality.  Strictly speaking ess-tracebug
+error navigation functionality.  Strictly speaking `ess-tracebug'
 is not a minor mode. It integrates globally into ESS and iESS.
 
-Note: Currently, ess-tracebug does not detect some of R's debug
+Note: Currently, `ess-tracebug' does not detect some of R's debug
 related messages in non-English locales. To set your R messages
 to English add the following line to your .Rprofile init file:
 
@@ -546,7 +545,7 @@ Local in iESS buffers with `ess-tracebug' mode enabled.")
 Local in iESS buffers.")
 
 (defvar ess--busy-count 0
-  "Used to compute the busy indicator")
+  "Used to compute the busy indicator.")
 (make-variable-buffer-local 'ess--busy-count)
 
 ;; (unless (boundp 'ess--busy-slash)
@@ -571,7 +570,7 @@ can use `ess--busy-slash', `ess--busy-B',`ess--busy-stars',
   :type '(repeat string))
 
 (defvar ess--busy-timer nil
-  "Timer used for busy process indication")
+  "Timer used for busy process indication.")
 
 (defcustom inferior-ess-replace-long+ t
   "Determines if ESS replaces long + sequences in output.
@@ -605,7 +604,7 @@ ESS internal code assumes default R prompts.")
 
 
 (defun ess--tb-start ()
-  "Start traceback session "
+  "Start traceback session."
   (with-current-buffer (process-buffer (get-process ess-local-process-name))
     (unless ess-error-regexp-alist
       (error "Can not activate the traceback for %s dialect" ess-dialect))
@@ -643,7 +642,7 @@ ESS internal code assumes default R prompts.")
       (defalias 'ess-parse-errors (symbol-function 'next-error)))))
 
 (defun ess--tb-stop ()
-  "Stop ess traceback session in the current ess process"
+  "Stop ess traceback session in the current ess process."
   (with-current-buffer (process-buffer (get-process ess-current-process-name))
     ;; restore original definitions
     (when (equal ess-dialect "R")
@@ -663,13 +662,13 @@ ESS internal code assumes default R prompts.")
     (setq mode-line-buffer-identification (propertized-buffer-identification "%12b"))))
 
 (defvar ess--dbg-forward-ring (make-ring 10)
-  "Ring of markers to the positions of the user inputs
- when the  debugger or traceback events are initiated.  It is used in
- `ess--dbg-goto-input-point'.")
+  "Ring of markers to the positions of user inputs when the
+debugger or traceback events are initiated. It is used in
+`ess--dbg-goto-input-point'.")
 
 (defvar ess--dbg-backward-ring (make-ring 10)
   "Ring of markers to the positions from which `ess--dbg-goto-input-point' is called.
- See the also `ess--dbg-goto-debug-point'")
+See the also `ess--dbg-goto-debug-point'")
 
 ;; (setq ess-R--tb-regexp-alist '(R R2 R3 R-recover))
 ;;(pop compilation-error-regexp-alist-alist)
@@ -682,8 +681,7 @@ for `next-error' and `previous-error' respectively.
 
 You can bind 'no-select' versions of this commands:
 \(define-key compilation-minor-mode-map [(?n)] 'next-error-no-select\)
-\(define-key compilation-minor-mode-map [(?p)] 'previous-error-no-select\)
-"
+\(define-key compilation-minor-mode-map [(?p)] 'previous-error-no-select\)"
   (interactive)
   (if (null ess-traceback-command)
       (error "Not implemented for dialect %s" ess-dialect)
@@ -828,8 +826,7 @@ have the form (DISP SYMB ACTION) where DISP is the string to be
 displayed in the mode line when the action is in place. SYMB is
 the symbolic name of an action. ACTION is the string giving the
 actual expression to be assigned to 'error' user option. See R's
-help ?options for more details.
-"
+help ?options for more details."
   :type '(alist :key-type string
                 :value-type (group string string))
   :group 'ess-debug)
@@ -857,9 +854,9 @@ help ?options for more details.
 
 (defvar ess--dbg-current-debug-position (make-marker)
   "Marker to the current debugged line.
- It always point to the beginning of the currently debugged line
+It always point to the beginning of the currently debugged line
 and is used by overlay-arrow.
-In no-windowed emacs an `overlay-arrow' is displayed at this position.")
+In no-windowed Emacs an `overlay-arrow' is displayed at this position.")
 
 (unless  window-system
   (add-to-list 'overlay-arrow-variable-list 'ess--dbg-current-debug-position))
@@ -880,11 +877,10 @@ In no-windowed emacs an `overlay-arrow' is displayed at this position.")
 
 
 (defcustom ess-debug-blink-interval .2
-  "Time in seconds to blink the background
- of the current debug line on exceptional events.
- Currently two exceptional events are defined 'ref-not-found'
- and 'same-ref'. Blinking colors for these events can be
- customized by corresponding faces."
+  "Time in seconds to blink the background of the debug line.
+Currently two events are defined 'ref-not-found' and 'same-ref'.
+Blinking colors for these events can be customized by
+corresponding faces."
   :group 'ess-debug
   :type 'float)
 
@@ -949,25 +945,25 @@ by default."
   "Keymap used to define commands for single key input mode.
 This commands are triggered by `ess-electric-selection' .
 
-\\{ess-electric-selection-map}
-")
+\\{ess-electric-selection-map}")
 
 (ess-if-verbose-write "\n<- debug-vars done")
 
 ;;;_ + debug functions
 (defun ess-debug-set-error-action (spec)
-  "Set the on-error action. The ACTION should be  one
-of components of `ess-debug-error-action-alist' (a cons!)."
+  "Set the on-error action.
+The SPEC should be one of the components of
+`ess-debug-error-action-alist'."
   (let ((proc (get-process ess-local-process-name)))
     (if spec
         (with-current-buffer (process-buffer proc)
           (process-put proc 'on-error-action (car spec))
           (ess-command (format "options(error= %s )\n" (nth 2 spec))))
-      (error "Unknown action."))))
+      (error "Unknown action"))))
 
 (defun ess-debug-toggle-error-action ()
   "Toggle the 'on-error' action.
-The action list is in `ess-debug-error-action-alist'. "
+The action list is in `ess-debug-error-action-alist'."
   (interactive)
   (ess-force-buffer-current)
   (let* ((alist ess-debug-error-action-alist)
@@ -1022,8 +1018,7 @@ The input-event-S-ring is a virtual object which consists of two
 rings `ess--dbg-forward-ring' and `ess--dbg-backward-ring' which
 are joint at their tops.
 
-See the more info at http://code.google.com/p/ess-tracebug/#Work-Flow
-"
+See the more info at http://code.google.com/p/ess-tracebug/#Work-Flow"
   (interactive)
   (let* ((ev last-command-event)
          (com-char  (event-basic-type ev))
@@ -1052,7 +1047,7 @@ See the more info at http://code.google.com/p/ess-tracebug/#Work-Flow
     (push ev unread-command-events)))
 
 (defun ess-debug-goto-debug-point ()
-  "Returns to the debugging position.
+  "Return to the debugging position.
 Jump to markers stored in `ess--dbg-backward-ring'. If debug
 session is active, first jump to current debug line.
 
@@ -1082,16 +1077,16 @@ of the ring."
     (push ev unread-command-events)))
 
 (defun ess-debug-insert-in-forward-ring ()
+  "Insert `point-marker' into the forward-ring."
   (interactive)
-  "Inserts point-marker into the forward-ring."
   (ring-insert ess--dbg-forward-ring (point-marker))
   (message "Point inserted into the forward-ring"))
 
 (defvar ess-debug-indicator " DB"
-  "String to be displayed in mode-line alongside the process
-  name. Indicates that ess-debug-mode is turned on. When the
-  debugger is in active state this string is shown in upper case
-  and highlighted.")
+  "String to be displayed in mode-line alongside the process name.
+Indicates that ess-debug-mode is turned on. When the debugger is
+in active state this string is shown in upper case and
+highlighted.")
 
 (defvar-local ess--dbg-mode-line-debug
   '(:eval (let ((proc (get-process ess-local-process-name)))
@@ -1113,7 +1108,7 @@ of the ring."
 (put 'ess--dbg-mode-line-error-action 'risky-local-variable t)
 
 (defun ess--dbg-remove-empty-lines (string)
-  "Remove empty lines (which interfere with evals) during debug.
+  "Remove empty lines from STRING (which interfere with evals) during debug.
 This function is placed in `ess-presend-filter-functions'."
   ;; the process here is an ugly reliance on dynamic scope
   (if (and ess--dbg-del-empty-p (ess-process-get 'dbg-active))
@@ -1182,7 +1177,7 @@ Kill the *ess.dbg.[R_name]* buffer."
 
 
 (defun ess--make-busy-timer-function (process)
-  "Display the spiner of prompt if ess-process is busy."
+  "Display the spiner of prompt if PROCESS is busy."
   `(lambda ()
      (let ((pb ,process))
        (when (eq (process-status pb) 'run) ;; only when the process is alive
@@ -1248,7 +1243,7 @@ Kill the *ess.dbg.[R_name]* buffer."
   (message (format "Error in inferior: %s" msg)))
 
 (defun ess-mpi:eval (expr &optional callback)
-  "Evaluate EXP as emacs expression.
+  "Evaluate EXP as Emacs expression.
 If present, the CALLBACK string is passed through `format' with
 returned value from EXPR and then sent to the subprocess."
   (let ((result (eval (read expr))))
@@ -1409,11 +1404,11 @@ prompts."
             (erase-buffer)))))))
 
 (defun inferior-ess-tracebug-output-filter (proc string)
-  "Standard output filter for the inferior ESS process when
-`ess-debug' is active. Call `inferior-ess-output-filter'. Check
-for debug reg-expressions (see `ess--dbg-regexp-debug',...), when
-found puts iESS in the debugging state. If in debugging state,
-mirrors the output into *ess.dbg* buffer."
+  "Standard output filter for the inferior ESS process when `ess-debug' is active.
+Call `inferior-ess-output-filter'. Check for debug
+reg-expressions (see `ess--dbg-regexp-debug',...), when found
+puts iESS in the debugging state. If in debugging state, mirrors
+the output into *ess.dbg* buffer."
   (let* ((is-iess (member major-mode (list 'inferior-ess-mode 'ess-watch-mode)))
          (pbuf (process-buffer proc))
          (abuf (ess--accumulation-buffer proc))
@@ -1549,12 +1544,11 @@ mirrors the output into *ess.dbg* buffer."
   :keymap ess-debug-minor-mode-map)
 
 (defun ess--dbg-goto-last-ref-and-mark (dbuff &optional other-window)
-  "Open the most recent debug reference, and set all the
-necessary marks and overlays.
-
-It's called from `inferior-ess-tracebug-output-filter'.  DBUFF must be
-the *ess.dbg* buffer associated with the process. If OTHER-WINDOW
-is non nil, attempt to open the location in a different window."
+  "Open the most recent debug reference, and set all the necessary marks and overlays.
+It's called from `inferior-ess-tracebug-output-filter'. DBUFF
+must be the *ess.dbg* buffer associated with the process. If
+OTHER-WINDOW is non nil, attempt to open the location in a
+different window."
   (interactive)
   (let (t-debug-position ref)
     (with-current-buffer dbuff
@@ -1586,7 +1580,7 @@ is non nil, attempt to open the location in a different window."
           (message "Reference %s not found" (car ref)))))))
 
 (defun ess--dbg-goto-ref (other-window file line &optional col)
-  "Opens the reference given by FILE, LINE and COL,
+  "Opens the reference given by FILE, LINE and COL.
 Try to open in a different window if OTHER-WINDOW is nil.  Return
 the buffer if found, or nil otherwise be found.
 `ess--dbg-find-buffer' is used to find the FILE and open the
@@ -1719,11 +1713,10 @@ next message, default to (point).  BOUND is the limiting position
 of the search.  REG is the regular expression to search with.  nF
 - sub-expression of REG giving the 'file'; defaults to 1.  nL -
 giving the 'line'; defaults to 2.  nC - sub-expr giving the
-'column'; defaults to 3.
-"
+'column'; defaults to 3."
   (interactive "p")
   (unless ess--dbg-buf-p
-    (error "Not in *ess.dbg* buffer."))
+    (error "Not in *ess.dbg* buffer"))
   (setq nF (or nF 1)
         nL (or nL 2)
         nC (or nC 3))
@@ -1735,9 +1728,8 @@ giving the 'line'; defaults to 2.  nC - sub-expr giving the
     nil))
 
 (defun ess--dbg-next-ref-function (n &optional reset)
-  "Advance to the next reference and visit the location
-given by the reference.  This is the value of
-`next-error-function' in *ess.dbg* buffers."
+  "Advance to the next reference and visit the location given by the reference.
+This is the value of `next-error-function' in *ess.dbg* buffers."
   (interactive "p")
   (if reset
       (set-marker ess--dbg-current-ref ess--dbg-last-ref-marker))
@@ -1832,7 +1824,7 @@ triggered the command."
 
 (defun ess-debug-command-digit (&optional ev)
   "Digit commands in selection mode.
-If suplied ev must be a proper key event or a string representing the digit."
+If supplied, EV must be a proper key event or a string representing the digit."
   (interactive)
   (ess-force-buffer-current)
   (unless (ess--dbg-is-recover-p)
@@ -2041,7 +2033,7 @@ List format is identical to that of `ess-bp-type-spec-alist'."
 
 
 (defun ess-bp-get-bp-specs (type &optional condition no-error)
-  "get specs for TYPE "
+  "Get specs for TYPE."
   (let ((spec-alist (cond
                      ((eq type 'conditional)
                       (let ((tl (copy-sequence  ess-bp-conditional-spec)))
@@ -2065,7 +2057,7 @@ List format is identical to that of `ess-bp-type-spec-alist'."
 
 (defun ess-bp-create (type &optional condition no-error)
   "Set breakpoint for the current line.
- Returns the begging position of the hidden text."
+Returns the beginning position of the hidden text."
   (let* ((bp-specs (ess-bp-get-bp-specs type condition no-error))
          (init-pos (point-marker))
          (fringe-bitmap (nth 3 bp-specs))
@@ -2108,7 +2100,7 @@ List format is identical to that of `ess-bp-type-spec-alist'."
       insertion-pos)))
 
 (defun ess-bp-recreate-all ()
-  "internal function to recreate all bp"
+  "Internal function to recreate all bp."
   (save-excursion
     (save-restriction
       (with-silent-modifications
@@ -2174,11 +2166,12 @@ List format is identical to that of `ess-bp-type-spec-alist'."
 
 
 (defun ess-bp-get-bp-position-nearby ()
-  "Return the cons (beg . end) of breakpoint limit points
-closest to the current position.  Only currently visible region of the
-buffer is searched.  This command is intended for use in
-interactive commands like `ess-bp-toggle-state' and `ess-bp-kill'.
-Use `ess-bp-previous-position' in programs."
+  "Get nearby break points.
+Return the cons (beg . end) of breakpoint limit points closest to
+the current position. Only currently visible region of the buffer
+is searched. This command is intended for use in interactive
+commands like `ess-bp-toggle-state' and `ess-bp-kill'. Use
+`ess-bp-previous-position' in programs."
   (interactive)
   (let*  ((pos-end (if (get-char-property (1- (point)) 'ess-bp)
                        (point)
@@ -2204,8 +2197,9 @@ Use `ess-bp-previous-position' in programs."
 
 
 (defun ess-bp-previous-position ()
-  "Returns the cons (beg . end) of breakpoint limit points closest
-to the current position, nil if not found. "
+  "Get previous breakpoints.
+Return the cons (beg . end) of breakpoint limit points closest
+to the current position, nil if not found."
   (let* ( (pos-end (if (get-char-property (1- (point)) 'ess-bp)
                        (point)
                      (previous-single-property-change (point) 'ess-bp ))))
@@ -2213,6 +2207,7 @@ to the current position, nil if not found. "
         (cons (previous-single-property-change pos-end 'ess-bp) pos-end))))
 
 (defun ess-bp-set ()
+  "Set a breakpoint."
   (interactive)
   (let* ((pos (ess-bp-get-bp-position-nearby))
          (same-line (and pos
@@ -2261,7 +2256,7 @@ to the current position, nil if not found. "
   (indent-for-tab-command))
 
 (defun ess-bp-kill (&optional interactive?)
-  "Remove the breakpoint nearby"
+  "Remove the breakpoint nearby."
   (interactive "p")
   (let ((pos (ess-bp-get-bp-position-nearby))
         (init-pos (make-marker)))
@@ -2346,7 +2341,7 @@ If there is no active R session, this command triggers an error."
 
 
 (defun ess-bp-make-visible ()
-  "Makes bp text visible."
+  "Make bp text visible."
   (interactive)
   (let ((pos (ess-bp-get-bp-position-nearby)))
     (set-text-properties (car pos) (cdr pos) (list 'display nil))))
@@ -2390,14 +2385,14 @@ If there is no active R session, this command triggers an error."
       [#b00001100] nil nil '(top t)))
 
 (defun ess-tracebug--set-left-margin ()
-  "Set the margin on non-X displays"
+  "Set the margin on non-X displays."
   (unless window-system
     (when (= left-margin-width 0)
       (setq left-margin-width 1)
       (set-window-buffer (selected-window) (current-buffer)))))
 
 (defun ess-watch-mode ()
-  "Major mode in ess-watch window.
+  "Major mode in `ess-watch' window.
 \\{ess-watch-mode-map}"
   (let ((cur-block (max 1 (ess-watch-block-at-point)))
         (dummy-string
@@ -2422,12 +2417,11 @@ If there is no active R session, this command triggers an error."
       )))
 
 (defun ess-watch ()
-  "Run ess-watch mode on R objects.
+  "Run `ess-watch' mode on R objects.
 This is the trigger function.  See documentation of
 `ess-watch-mode' for more information.
 
-\\{ess-watch-mode-map}
-"
+\\{ess-watch-mode-map}"
   (interactive)
   (ess-force-buffer-current)
   (let ((wbuf (get-buffer-create ess-watch-buffer))
@@ -2494,7 +2488,7 @@ respectively."
 
 
 (defun ess-watch-revert-buffer (ignore noconfirm)
-  "Update the watch buffer
+  "Update the watch buffer.
 Arguments IGNORE and NOCONFIRM currently not used."
   (ess-watch)
   (message "Watch reverted"))
@@ -2520,10 +2514,10 @@ Arguments IGNORE and NOCONFIRM currently not used."
 (defvar ess-watch-help nil
   "Keymap for the *R watch* buffer.
 
-\\{ess-watch-mode-map}
-")
+\\{ess-watch-mode-map}")
 
 (defun ess-watch-help ()
+  "Help on `ess-watch'."
   (interactive)
   (describe-variable 'ess-watch-help))
 
@@ -2547,7 +2541,7 @@ Arguments IGNORE and NOCONFIRM currently not used."
       (list start-pos end-pos))))
 
 (defun ess-watch-block-at-point ()
-  "return the current block's order count, 0 if no block was found."
+  "Return the current block's order count, 0 if no block was found."
   (save-excursion
     (let ((cur-point (point))
           (count 0))
@@ -2557,7 +2551,7 @@ Arguments IGNORE and NOCONFIRM currently not used."
       count)))
 
 (defun ess-watch-set-current (nr)
-  "Move the overlay over the block with count NR in current watch buffer"
+  "Move the overlay over the block with count NR in current watch buffer."
   (goto-char (point-min))
   (re-search-forward ess-watch-start-expression nil t nr)
   (goto-char (match-end 0))
@@ -2565,7 +2559,7 @@ Arguments IGNORE and NOCONFIRM currently not used."
 
 
 (defun ess-watch--make-alist ()
-  "Create an association list of expression from current buffer (better be a watch buffer).
+  "Create an alist of expressions from the current watch buffer.
 Each element of assoc list is of the form (pos name expr) where
 pos is an unique integer identifying watch blocks by position,
 name is a string giving the name of expression block, expr is a
@@ -2623,7 +2617,7 @@ buffer."
 ;;;_  + MOTION
 (defun ess-watch-next-block (&optional n)
   "Move the overlay over the next block.
-Optional N if supplied gives the number of steps forward backward-char."
+Optional N if supplied gives the number of steps forward `backward-char'."
   (interactive "P")
   (setq n (prefix-numeric-value n))
   (goto-char (overlay-end ess-watch-current-block-overlay))
@@ -2646,7 +2640,7 @@ Optional N if supplied gives the number of backward steps."
 
 ;;;_  + BLOCK MANIPULATION and EDITING
 (defun ess-watch-rename ()
-  "Rename the currently selected watch block. "
+  "Rename the currently selected watch block."
   (interactive)
   (end-of-line)
   (unless (re-search-backward ess-watch-start-block nil t)
@@ -2672,7 +2666,7 @@ Optional N if supplied gives the number of backward steps."
     (ess-watch-refresh-buffer-visibly (current-buffer))))
 
 (defun ess-watch-edit-expression ()
-  "Edit in the minibuffer the R expression from the current watch block. "
+  "Edit in the minibuffer the R expression from the current watch block."
   (interactive)
   (end-of-line)
   (unless (re-search-backward ess-watch-start-block nil 1)
@@ -2695,7 +2689,7 @@ Optional N if supplied gives the number of backward steps."
     (ess-watch-refresh-buffer-visibly (current-buffer))))
 
 (defun ess-watch-add ()
-  "Ask for new R expression and name and append it to the end of the list of watch expressions"
+  "Ask for new R expression and name and append it to the end of the list of watch expressions."
   (interactive)
   (let (nr expr name)
     (goto-char (point-max))
@@ -2709,7 +2703,7 @@ Optional N if supplied gives the number of backward steps."
     (ess-watch--install-.ess_watch_expressions)))
 
 (defun ess-watch-insert ()
-  "Ask for new R expression and name and insert it in front of current watch block"
+  "Ask for new R expression and name and insert it in front of current watch block."
   (interactive)
   (let (nr expr name)
     (setq nr (number-to-string (ess-watch-block-at-point)))
@@ -2754,7 +2748,7 @@ Optional N if supplied gives the number of backward steps."
       (setq buffer-read-only t))))
 
 (defun ess-watch-kill ()
-  "Kill the current block"
+  "Kill the current block."
   (interactive)
   (setq buffer-read-only nil)
   (apply 'delete-region (ess-watch-block-limits-at-point))
@@ -2762,7 +2756,7 @@ Optional N if supplied gives the number of backward steps."
 
 ;;;_ + Debug/Undebug at point
 (defun ess--dbg-get-signatures (method)
-  "Get signatures for the method METHOD"
+  "Get signatures for the method METHOD."
   (let ((tbuffer (get-buffer-create " *ess-command-output*")); initial space: disable-undo
         signatures curr-point)
     (save-excursion
@@ -2875,7 +2869,7 @@ for signature and trace it with browser tracer."
 ;;;_ * Kludges and Fixes
 ;;; delete-char and delete-backward-car do not delete whole intangible text
 (defadvice delete-char (around ess-delete-backward-char-intangible activate)
-  "When about to delete a char that's intangible, delete the whole intangible region
+  "When deleting an intangible char, delete the whole intangible region.
 Only do this when #chars is 1"
   (if (and (eq major-mode 'ess-mode)
            (= (ad-get-arg 0) 1)
@@ -2887,8 +2881,8 @@ Only do this when #chars is 1"
     ad-do-it))
 
 (defadvice delete-backward-char (around ess-delete-backward-char-intangible activate)
-  "When about to delete a char that's intangible, delete the whole intangible region
-Only do this when called interactively and  #chars is 1"
+  "When deleting an intangible char, delete the whole intangible region.
+Only do this when called interactively and #chars is 1"
   (if (and (eq major-mode 'ess-mode)
            (= (ad-get-arg 0) 1)
            (> (point) (point-min))

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -24,6 +24,10 @@
 ;; A copy of the GNU General Public License is available at
 ;; http://www.r-project.org/Licenses/
 
+
+;;; Commentary:
+;; Various utilities for ESS.
+
 ;;; Code:
 
 (eval-when-compile
@@ -49,7 +53,7 @@
     (if load-file-name
         (file-truename load-file-name)
       (locate-library "ess-utils") )))
-  "Directory containing ess-site.el(c) and other ESS lisp files.")
+  "Directory containing ess-site.el(c) and other ESS Lisp files.")
 
 (defvar ess-etc-directory nil
   "Location of the ESS etc/ directory.
@@ -96,16 +100,15 @@ Used in noweb modes.")
     (forward-line (1- line))))
 
 (defun ess-line-end-position (&optional N)
-  "return the 'point' at the end of N lines. N defaults to 1, i.e., current line."
+  "Return the 'point' at the end of N lines. N defaults to 1, i.e., current line."
   (save-excursion
     (end-of-line N)
     (point)))
 
 (defun ess-search-except (regexp &optional except backward)
-  "Search for a regexp, store as match 1, optionally ignore
-strings that match exceptions."
+  "Search for a REGEXP and store as match 1.
+Optionally ignore strings that match exceptions."
   (interactive)
-
   (let ((continue t) (exit nil))
 
     (while continue
@@ -144,18 +147,18 @@ Return t if buffer was modified, nil otherwise."
     ess-temp-return-value))
 
 (defun ess-get-file-or-buffer (file-or-buffer)
-  "Return file-or-buffer if it is a buffer; otherwise return the buffer
-associated with the file which must be qualified by it's path; if the
-buffer does not exist, return nil."
+  "Return FILE-OR-BUFFER if it is a buffer.
+Otherwise return the buffer associated with the file which must
+be qualified by it's path; if the buffer does not exist, return
+nil."
   (interactive)
-
   (if file-or-buffer
       (if (bufferp file-or-buffer) file-or-buffer
         (find-buffer-visiting file-or-buffer))))
 
 (defun ess-set-local-variables (alist &optional file-or-buffer)
-  "Set local variables from ALIST in current buffer; if file-or-buffer
-is specified, perform action in that buffer."
+  "Set local variables from ALIST in current buffer.
+If FILE-OR-BUFFER is specified, perform action in that buffer."
   (interactive)
   (if file-or-buffer (set-buffer (ess-get-file-or-buffer file-or-buffer)))
 
@@ -165,7 +168,7 @@ is specified, perform action in that buffer."
           alist))
 
 (defun ess-return-list (ess-arg)
-  "Given an item, if it is a list return it, else return item in a list."
+  "If ESS-ARG is a list return it, else return ESS-ARG in a list."
   (if (listp ess-arg) ess-arg (list ess-arg)))
 
 ;; Copyright (C) 1994 Simon Marshall.
@@ -192,7 +195,7 @@ This function will work even if LIST is unsorted.  See also `ess-uniq-list'."
   (ess-uniq items 'delete))
 
 (defun ess-flatten-list (&rest list)
-  "Take the arguments and flatten them into one long list.
+  "Take the arguments and flatten them into one long LIST.
 Drops 'nil' entries."
   ;; Taken from lpr.el
   ;; `lpr-flatten-list' is defined here (copied from "message.el" and
@@ -310,7 +313,7 @@ Search for the executables in ESS-EXEC-DIR (which defaults to
     ess-tmp-exec))
 
 (defun ess-drop-non-directories (file-strings)
-  "Drop all entries that do not \"look like\" directories."
+  "Drop all entries in FILE-STRINGS that do not \"look like\" directories."
   (ess-flatten-list (mapcar 'file-name-directory file-strings)))
 
 (defun ess--parent-dir (path n)
@@ -345,8 +348,7 @@ Variable  *proc*  is bound  to  the  current process  during  the
 evaluation of BODY.
 
 Should be used in `ess-idle-timer-functions' which call the
-process to avoid excessive requests.
-"
+process to avoid excessive requests."
   (declare (indent 1) (debug t))
   `(with-ess-process-buffer 'no-error
      (let ((le (process-get *proc* 'last-eval))
@@ -358,7 +360,7 @@ process to avoid excessive requests.
            out)))))
 
 (defmacro ess-execute-dialect-specific (command &optional prompt &rest args)
-  "Execute dialect specific command.
+  "Execute dialect specific COMMAND.
 
 -- If command is nil issue warning 'Not available for dialect X'
 -- If command is a elisp function, execute it with ARGS
@@ -371,8 +373,7 @@ When PROMPT is non-nil ask the user for a string value and
 prepend the response to ARGS.
 
 If prompt is a string just pass it to `read-string'. If a list, pass it
-to `ess-completing-read'.
-"
+to `ess-completing-read'."
   `(if (null ,command)
        (message "Not implemented for dialect %s" ess-dialect)
      (let* ((com  (if (symbolp ,command)
@@ -400,8 +401,7 @@ to `ess-completing-read'.
               (error "Argument COMMAND must be either a function or a string"))))))
 
 (defcustom ess-idle-timer-interval 1
-  "Number of idle seconds to wait before running function in
-  `ess-idle-timer-functions'."
+  "Number of idle seconds to wait before running function in `ess-idle-timer-functions'."
   :type '(integer)
   :group 'ess)
 
@@ -419,11 +419,10 @@ Most likely you will need a local hook. Then you should specify
 the LOCAL argument to `add-hook' and initialise it in
 `ess-mode-hook' or `ess-post-run-hook', or one of the more
 specialised hooks `ess-r-post-run-hook',`ess-stata-post-run-hook'
-etc.
-")
+etc.")
 
 (defun ess--idle-timer-function nil
-  "Internal function executed by `ess--idle-timer'"
+  "Internal function executed by `ess--idle-timer'."
   ;; (while-no-input
   (run-hooks 'ess-idle-timer-functions))
 
@@ -448,7 +447,7 @@ etc.
 ;;;*;;; Font Lock
 
 (defun ess--fl-keywords-values ()
-  "Return a cons (STANDARD-VALUE . CUSTOM-VALUE) of ess-font-lock-keywords."
+  "Return a cons (STANDARD-VALUE . CUSTOM-VALUE) of `ess-font-lock-keywords'."
   (let ((sym (if (derived-mode-p 'ess-mode)
                  ess-font-lock-keywords
                ;; also in transcript mode
@@ -643,8 +642,7 @@ supplementary arguments passed to the commands.
 
 EXIT-FORM should be supplied for a more refined control of the
 read-even loop. The loop is exited when EXIT-FORM evaluates to
-t. See examples in the tracebug code.
-"
+t. See examples in the tracebug code."
   ;;VS[09-06-2013]: check: it seems that set-temporary-overlay-map is designed
   ;;for this type of things; see also repeat.el package.
   `(let* ((ev last-command-event)
@@ -694,7 +692,7 @@ Invoke this command with C-u C-u C-y."
     ))
 
 (defun ess-yank (&optional ARG)
-  "With double prefix (C-u C-u) call `ess-yank-cleaned-commands"
+  "With double prefix (C-u C-u) call `ess-yank-cleaned-commands."
   (interactive "*P")
   (if (equal '(16) ARG)
       (ess-yank-cleaned-commands)
@@ -714,7 +712,7 @@ and ask the subprocess to build the tags. Otherwise use imenu
 regexp and call find .. | etags .. in a shell command. You must
 have 'find' and 'etags' programs installed.
 
-Use M-. to navigate to a tag. M-x `visit-tags-table' to
+Use M-. to navigate to a tag. \\[visit-tags-table] to
 append/replace the currently used tag table.
 
 If prefix is given, force tag generation based on imenu. Might be
@@ -771,8 +769,7 @@ Otherwise try a list of fixed known viewers."
 (defun ess-get-pdf-viewer ()
   "Get external PDF viewer to be used from ESS.
 Use `ess-pdf-viewer-pref' when that is executably found by \\[executable-find].
-Otherwise try a list of fixed known viewers.
-"
+Otherwise try a list of fixed known viewers."
   (let ((viewer (or ess-pdf-viewer-pref
                     ;; (and (stringp ess-pdf-viewer-pref)         ; -> ./ess-custom.el
                     ;;      (executable-find ess-pdf-viewer-pref))
@@ -1031,7 +1028,7 @@ we simply do not break it (instead of breaking after the first word)."
   (cadr (syntax-ppss)))
 
 (defun ess-code-end-position ()
-  "Like (line-end-position) but stops at comments"
+  "Like (line-end-position) but stops at comments."
   (save-excursion
     (goto-char (1+ (line-end-position)))
     (forward-comment -1)
@@ -1049,7 +1046,7 @@ we simply do not break it (instead of breaking after the first word)."
 
 (defvar ess-r-symbol-pattern
   "\\(\\sw\\|\\s_\\)"
-  "The regular expression for matching an R symbol")
+  "The regular expression for matching an R symbol.")
 
 (defvar ess-r-name-pattern
   (concat "\\(" ess-r-symbol-pattern "+\\|\\(`\\).+`\\)")
@@ -1253,7 +1250,7 @@ it cannot find a function beginning."
         (if no-error
             (setq  done t  beg nil)
           ;; else [default]:
-          (error "Point is not in a function according to 'ess-function-pattern'.")))
+          (error "Point is not in a function according to 'ess-function-pattern'")))
       (unless done
         (setq beg (point))
         (ess-write-to-dribble-buffer
@@ -1274,7 +1271,7 @@ it cannot find a function beginning."
 
 (defun ess-end-of-function (&optional beginning no-error)
   "Leave the point at the end of the current ESS function.
-Optional argument for location of beginning.  Return '(beg end)."
+Optional argument for location of BEGINNING.  Return '(beg end)."
   (interactive)
   (if beginning
       (goto-char beginning)
@@ -1330,7 +1327,7 @@ symbols (like aaa$bbb and aaa@bbb in R)."
   (car (ess-bounds-of-symbol)))
 
 (defun ess-arg-start ()
-  "Get initial position for args completion"
+  "Get initial position for args completion."
   (when (not (ess-inside-string-p))
     (when (ess--fn-name-start)
       (if (looking-back "[(,]+[ \t\n]*" nil)
@@ -1357,7 +1354,7 @@ POS defaults to `point'."
 
 (defun ess-inside-brackets-p (&optional pos curly?)
   "Return t if position POS is inside brackets.
-POS defaults to point if no value is given. If curly? is non nil
+POS defaults to point if no value is given. If CURLY?? is non nil
 also return t if inside curly brackets."
   (save-excursion
     (let ((ppss (syntax-ppss pos))
@@ -1384,17 +1381,18 @@ also return t if inside curly brackets."
 ;; simple alternative to ess-read-object-name-default of ./ess-inf.el :
 ;; is "wrongly" returning   "p1"  for word "p1.part2" :
 (defun ess-extract-word-name ()
-  "Get the word you're on (cheap algorithm). Use `ess-read-object-name-default'
-for a better but slower version."
+  "Get the word you're on (cheap algorithm).
+Use `ess-read-object-name-default' for a better but slower
+version."
   (save-excursion
     (re-search-forward "\\<\\w+\\>" nil t)
     (buffer-substring (match-beginning 0) (match-end 0))))
 
 (defun ess-rep-regexp (regexp to-string &optional fixedcase literal verbose)
   "Instead of (replace-regexp..) -- do NOT replace in strings or comments.
- If FIXEDCASE is non-nil, do *not* alter case of replacement text.
- If LITERAL   is non-nil, do *not* treat `\\' as special.
- If VERBOSE   is non-nil, (message ..) about replacements."
+If FIXEDCASE is non-nil, do *not* alter case of replacement text.
+If LITERAL   is non-nil, do *not* treat `\\' as special.
+If VERBOSE   is non-nil, (message ..) about replacements."
   (let ((case-fold-search (and case-fold-search
                                (not fixedcase))); t  <==> ignore case in search
         (ppt (point)); previous point
@@ -1428,8 +1426,8 @@ from the beginning of the buffer."
       (query-replace-regexp regexp to-string nil))))
 
 (defun ess-space-around (word &optional from verbose)
-  "Replace-regexp .. ensuring space around all occurences of WORD,
- starting from FROM {defaults to (point)}."
+  "Replace-regexp .. ensuring space around all occurences of WORD.
+Start at from FROM, which defaults to point."
   (interactive "d\nP"); Defaults: point and prefix (C-u)
   (save-excursion
     (goto-char from)
@@ -1442,8 +1440,8 @@ from the beginning of the buffer."
   )
 
 (defun ess-time-string (&optional clock)
-  "Returns a string for use as a timestamp. + hr:min if CLOCK is non-nil,
- like \"13 Mar 1992\".  Redefine to taste."
+  "Return a string for use as a timestamp, like \"13 Mar 1992\".
+Include hr:min if CLOCK is non-nil. Redefine to taste."
   (format-time-string (concat "%e %b %Y" (if clock ", %H:%M"))))
 
 (defun ess-replace-in-string (str regexp newtext &optional literal)
@@ -1516,21 +1514,21 @@ Otherwise treat \\ in NEWTEXT string as special:
 
 (defvar ess-nuke-trailing-whitespace-p nil;disabled by default  'ask
   "*[Dis]activates (ess-nuke-trailing-whitespace).
- Disabled if `nil'; if `t', it works unconditionally, otherwise,
- the user is queried.
- Note that setting the default to `t' may not be a good idea when you edit
- binary files!")
+Disabled if nil; if t, it works unconditionally, otherwise,
+the user is queried.
+Note that setting the default to t may not be a good idea when you edit
+binary files!")
 
 ;;; MM: Newer Emacsen now have  delete-trailing-whitespace
 ;;; --  but no customization like  nuke-trailing-whitespace-p ..
 (defun ess-nuke-trailing-whitespace ()
   "Nuke all trailing whitespace in the buffer.
 Whitespace in this case is just spaces or tabs.
-This is a useful function to put on write-file-hooks.
+This is a useful function to put on `write-file-hooks'.
 
-If the variable `ess-nuke-trailing-whitespace-p' is `nil', this function is
-disabled.  If `t', unreservedly strip trailing whitespace.
-If not `nil' and not `t', query for each instance."
+If the variable `ess-nuke-trailing-whitespace-p' is nil, this function is
+disabled.  If t, unreservedly strip trailing whitespace.
+If not nil and not t, query for each instance."
   (interactive)
   (let ((bname (buffer-name)))
     (cond ((or
@@ -1594,7 +1592,7 @@ not contain chunks.")
   "Default intensity for adjusting faces.")
 
 (defun ess-adjust-face-background (start end &optional intensity)
-  "Adjust face background between BEG and END.
+  "Adjust face background between START and END.
 On dark background, lighten.  Oposite on light."
   (let* ((intensity (or intensity ess-adjust-face-intensity))
          (color (color-lighten-name
@@ -1632,7 +1630,7 @@ Adds the `ess-face-adjusted' property so we only adjust face once."
            (overlays-at pos)))
 
 (defun ess-sleep ()
-  "Put emacs to sleep for `ess-sleep-for-shell' seconds (floats work)."
+  "Put Emacs to sleep for `ess-sleep-for-shell' seconds (floats work)."
   (sleep-for ess-sleep-for-shell))
 
 (defun ess-setq-vars-local (alist &optional buf)

--- a/lisp/ess.el
+++ b/lisp/ess.el
@@ -143,7 +143,7 @@
     (define-key ess-extra-map "w" 'ess-execute-screen-options)
     (define-key ess-extra-map "/" 'ess-set-working-directory)
     ess-extra-map)
-  "ESS extra map")
+  "ESS extra map.")
 
 (easy-menu-define
   ess-mode-menu ess-mode-map
@@ -329,7 +329,7 @@ indentation style. At present, predefined style are `BSD', `GNU', `K&R', `C++',
 `CLB' (quoted from C language style)."
   (setq alist (or alist
                   (buffer-local-value 'ess-local-customize-alist (current-buffer))
-                  (error "Customise alist is not specified, nor  ess-local-customize-alist is set.")))
+                  (error "Customise alist is not specified, nor  ess-local-customize-alist is set")))
   (unless is-derived
     (kill-all-local-variables)) ;; NOTICE THIS! *** NOTICE THIS! *** NOTICE THIS! ***
   (ess-setq-vars-local alist)
@@ -386,7 +386,7 @@ indentation style. At present, predefined style are `BSD', `GNU', `K&R', `C++',
 (defun ess--get-mode-line-indicator ()
   "Get `ess--mode-line-process-indicator' from process buffer.
 Internal function to be used for dynamic mode-line dysplay in
-ess-mode."
+`ess-mode'."
   (if ess-local-process-name
       (let* ((proc (get-process ess-local-process-name))
              (buff (when proc (process-buffer proc))))
@@ -414,16 +414,16 @@ Currently works only for R."
 ;;;*;;; Motion / manipulation commands
 
 (defun ess-goto-beginning-of-function-or-para ()
-  "If inside a function go to the beginning of it, otherwise go to the beginning
-  of paragraph."
+  "If inside a function go to the beginning of it.
+Otherwise go to the beginning of paragraph."
   (interactive)
   (or (ess-beginning-of-function 'no-error)
       (backward-paragraph))
   (point))
 
 (defun ess-goto-end-of-function-or-para ()
-  "If inside a function go to end of it, otherwise go to the end
-  of paragraph."
+  "If inside a function go to end of it.
+Otherwise go to the end of paragraph."
   (interactive)
   (or (ess-end-of-function nil 'no-error)
       (forward-paragraph))
@@ -454,6 +454,7 @@ current function."
 (define-obsolete-function-alias 'ess-narrow-to-defun 'ess-narrow-to-defun-or-para "15.09")
 
 (defun ess-newline-and-indent ()
+  "Like `newline-and-indent' but accounts for roxygen comments."
   (interactive)
   (cond ((and (fboundp 'ess-roxy-newline-and-indent)
               (string= ess-dialect "R"))
@@ -462,6 +463,7 @@ current function."
          (newline-and-indent))))
 
 (defun ess-indent-new-comment-line ()
+  "Like `indent-new-comment-line' but accounts for roxygen comments."
   (interactive)
   (cond ((and (fboundp 'ess-roxy-indent-new-comment-line)
               (string= ess-dialect "R"))
@@ -473,10 +475,10 @@ current function."
 ;;;*;;; Formatting / indentation
 
 (defun ess-set-style (&optional style quiet)
-  "Set up the `ess-mode' style variables from the `ess-style' variable
-or if STYLE argument is given, use that.  It makes the ESS indentation
-style variables buffer local."
-
+  "Set up the `ess-mode' style variables from the `ess-style' variable.
+If STYLE argument is given, use that instead. It makes the ESS
+indentation style variables buffer local. When non-nil, QUIET
+suppresses messaging."
   (interactive)
   (let ((ess-styles (mapcar 'symbol-name (mapcar 'car ess-style-alist))))
     (unless style
@@ -536,9 +538,9 @@ of the expression are preserved."
       (funcall indent-line-function))))
 
 (defun ess-indent-or-complete ()
-  "When region is selected indent the region, otherwise, if
-`ess-tab-complete-in-script' is non-nil, try to indent, if code
-is already indented, complete instead.
+  "When region is selected indent the region.
+Otherwise, if `ess-tab-complete-in-script' is non-nil, try to
+indent, if code is already indented, complete instead.
 
 The default of `ess-tab-complete-in-script' is nil.  Also see
 `ess-first-tab-never-complete'."
@@ -615,7 +617,7 @@ generate the source buffer."
       (if (y-or-n-p                     ; Approved
            (format "Directory %s does not exist. Create it? " dirname))
           (make-directory (directory-file-name dirname))
-        (error "Directory %s does not exist." dirname)))
+        (error "Directory %s does not exist" dirname)))
 
     ;; Three options:
     ;;  (1) Pop to an existing buffer containing the file in question
@@ -642,7 +644,7 @@ generate the source buffer."
   (let ((complete-dump-command (format inferior-ess-dump-command
                                        object filename)))
     (if (file-writable-p filename) nil
-      (error "Can't dump %s as %f is not writeable." object filename))
+      (error "Can't dump %s as %f is not writeable" object filename))
 
     (:override
      ;; Make sure we start fresh
@@ -730,6 +732,7 @@ Function defined using `ess-define-runner'."
                      (SAS))))))))
 
 (defun ess-version ()
+  "Return a string with ESS version information."
   (interactive)
   (message (format "ess-version: %s (loaded from %s)"
                    (ess-version-string)


### PR DESCRIPTION
Fix some typos and make M-x checkdoc a little happier.

This commit only touches documentation.