### PR TITLE
Fix dribble buffer writing

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -3138,8 +3138,7 @@ See also `ess-verbose'."
   :type 'boolean)
 
 (defvar ess-dribble-buffer "*ESS*"
-  "Name of buffer for temporary use for setting default variable values.
-Used for recording status of the program, mainly for debugging.")
+  "Buffer or name of buffer for printing debugging information.")
 
 (defvar ess-customize-alist nil
   "Variable settings to use for proper behavior.

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -1014,7 +1014,7 @@ option for other dialects)."
        (insert "This bug report will be sent to the ESS bugs email list\n")
        (insert "Press C-c C-c when you are ready to send your message.\n")
        (insert "-------------------------------------------------------\n\n")
-       (insert (with-current-buffer "*ESS*"
+       (insert (with-current-buffer ess-dribble-buffer
                  (goto-char (point-max))
                  (forward-line -100)
                  (buffer-substring-no-properties (point) (point-max))))

--- a/lisp/ess-sp6w-d.el
+++ b/lisp/ess-sp6w-d.el
@@ -504,7 +504,7 @@ Sqpe.  `ESS-SHOME-VERSIONS' is normally taken from
 functions are created.  This works by creating a temp buffer where the
 template function `Sqpe+template' is edited by replacing the string
 'Sqpe+template' by the version name.  The list of functions actually
-created appears in the *ESS* buffer.  If `X64' is not nil, then
+created appears in the `ess-dribble-buffer'.  If `X64' is not nil, then
 modify the function name to show \"-64bit\" in its name.
 
 The result `ess-sqpe-versions-created' will store a list of the new

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -1556,22 +1556,16 @@ If not nil and not t, query for each instance."
 
 ;;*;; Debugging tools
 
-(defvar ess-dribble-buffer)
 (defun ess-write-to-dribble-buffer (text)
-  "Write TEXT to dribble ('*ESS*') buffer."
-  (unless (or ess-verbose ess-write-to-dribble)
-    (unless (buffer-live-p ess-dribble-buffer)
-      ;; ESS dribble buffer must be re-created.
-      (setq ess-dribble-buffer (get-buffer-create "*ESS*")))
-    (let (deactivate-mark)
-      (with-current-buffer ess-dribble-buffer
-        (goto-char (point-max))
-        (insert-before-markers text)))))
+  "Write TEXT to `ess-dribble-buffer'."
+  (when (or ess-verbose ess-write-to-dribble)
+    (with-current-buffer (get-buffer-create ess-dribble-buffer)
+      (goto-char (point-max))
+      (insert-before-markers text))))
 
-;; Shortcut to render "dribbling" statements less cluttering:
 (defun ess-if-verbose-write (text)
-  "Write TEXT to dribble buffer ('*ESS*') only *if* `ess-verbose'."
-  (if ess-verbose (ess-write-to-dribble-buffer text)))
+  "Write TEXT to `ess-dribble-buffer' only if `ess-verbose' is non-nil."
+  (when ess-verbose (ess-write-to-dribble-buffer text)))
 
 
 (defun ess-kill-last-line ()


### PR DESCRIPTION
This fixes ESS creating and writing to the dribble buffer even when
ess-write-to-dribble-buffer was nil.