### PR TITLE
More fixes for the byte compiler

### DIFF
--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -47,7 +47,7 @@
 (require 'ess-trns)
 (when (>= emacs-major-version 25) (require 'ess-r-xref)) ;; Xref API was added in Emacs 25.1
 ;; TODO: Remove when we drop support for Emacs 24:
-(declare-function ess-r-xref-backend "exx-r-xref")
+(declare-function ess-r-xref-backend "ess-r-xref")
 (when (>= emacs-major-version 26) (require 'ess-r-flymake)) ; Flymake rewrite in Emacs 26
 
 ;; TODO: Refactor so as to not rely on dynamic scoping.  After that
@@ -540,6 +540,21 @@ will be prompted to enter arguments interactively."
 
 ;;;###autoload
 (defalias 'R #'run-ess-r)
+
+(defun inferior-ess-r--adjust-startup-directory (dir dialect)
+  "Adjust startup directory DIR if DIALECT is R.
+If in a package project, prefer the tests directory but only if
+the package directory was selected in the first place."
+  (if (string= dialect "R")
+      (let* ((project-dir (cdr (ess-r-package-project)))
+             (tests-dir (expand-file-name (file-name-as-directory "tests")
+                                          project-dir)))
+        (if (and project-dir
+                 (string= project-dir dir)
+                 (string= default-directory tests-dir))
+            tests-dir
+          dir))
+    dir))
 
 (defun R-initialize-on-start (&optional proc string)
   "This function is run after the first R prompt.

--- a/lisp/ess-rd.el
+++ b/lisp/ess-rd.el
@@ -37,6 +37,8 @@
 (defvar ess-help-r-sec-regex)
 (defvar ess-help-r-sec-keys-alist)
 
+(defvar ess-r-customize-alist)
+
 (defvar essddr-version "0.9-1"
   "Current version of ess-rd.el.")
 

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -422,9 +422,10 @@ and ensure space before subsequent text."
 (defun ess-dump-to-src (&optional dont-query verbose)
   "Make the changes in an S - dump() file to improve human readability."
   (interactive "P")
+  (ess-mode)
   (ess-replace-regexp-dump-to-src  "^\"\\([a-z.][a-z.0-9]*\\)\" *<-\n"
                                    "\n\\1 <- "
-                                   dont-query verbose 'ensure-ess))
+                                   dont-query verbose))
 
 (defun ess-num-var-round (&optional dont-query verbose)
   "Is VERY useful for dump(.)'ed numeric variables; ROUND some of them by


### PR DESCRIPTION
- Move inferior-ess-r--adjust-startup-directory to ess-r-mode.
- Declare a variable for Rd-mode
- Move ess-function-arguments to ess-inf since it requires several
  functions from there
- Remove option 'ensure-mode' from ess-replace-regexp-dump-to-src so
  byte compiler doesn't complain about ess-mode being undefined
- Fixes a type in declare-function (not that the byte compiler
  complains about this)