### PR TITLE
Only fontify `in` keyword inside `for ()`

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,10 @@
 Changes and New Features in development version:
 @itemize @bullet
 
+@item @ESS{[R]}: The @code{in} keyword is now only fontified when
+inside a @code{for} construct. This avoids spurious fontification,
+especially in the output buffer where `in` is a commond English word.
+
 @item @ESS{[R]}: Fixed fontification toggling of certain syntactic
 elements such as @code{%op%} operators and backquoted function
 definitions.

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2734,33 +2734,6 @@ See `ess-R-modifiers' for the list of modifiers.")
 When this keyword is on, function names on the left hand side of
 <- are highlighted with `font-lock-function-name-face'.")
 
-(defvar ess-r--non-fn-kwds
-  '("in" "else" "break" "next" "repeat"))
-
-(defvar-local ess-r--keyword-regexp nil)
-(defun ess-r--find-fl-keyword (limit)
-  "Search for R keyword and set the match data.
-To be used as part of `font-lock-defaults' keywords."
-  (unless ess-r--keyword-regexp
-    (let (fn-kwds non-fn-kwds)
-      (dolist (kw ess-R-keywords)
-        (if (member kw ess-r--non-fn-kwds)
-            (push kw non-fn-kwds)
-          (push kw fn-kwds)))
-      (setq ess-r--keyword-regexp
-            (concat "\\("
-                    (regexp-opt non-fn-kwds 'words)
-                    "\\)\\|\\("
-                    (regexp-opt fn-kwds 'words)
-                    "\\)"))))
-  (let (out)
-    (while (and (not out)
-                (re-search-forward ess-r--keyword-regexp limit t))
-      (setq out (or (match-beginning 1)
-                    ;; fn-kwds matched; check if they are followed by an open paren
-                    (looking-at-p "\\s-*("))))
-    out))
-
 (defvar ess-R-fl-keyword:keywords
   '(ess-r--find-fl-keyword . ess-keyword-face)
   "Font lock keyword for `ess-R-keywords'.")

--- a/lisp/ess-r-syntax.el
+++ b/lisp/ess-r-syntax.el
@@ -54,6 +54,9 @@
         (progn (up-list N) t))
     (error nil)))
 
+(defun ess-backward-up-list (&optional N)
+  (ess-up-list (- (or N 1))))
+
 (defun ess-forward-char (&optional N)
   (unless (= (point) (point-max))
     (forward-char (or N 1))

--- a/test/ess-r-tests-utils.el
+++ b/test/ess-r-tests-utils.el
@@ -200,8 +200,8 @@ split arbitrary."
       (forward-char point))
     (get-char-property (point) 'face)))
 
-(defun insert-fontified (arg)
-  (insert arg)
+(defun insert-fontified (&rest args)
+  (apply #'insert args)
   (font-lock-default-fontify-buffer))
 
 

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -217,9 +217,17 @@
 (ert-deftest inferior-ess-r-fontification ()
   (with-r-running nil
     (with-ess-process-buffer nil
+      ;; Function-like keywords
       (should (eq major-mode 'inferior-ess-mode))
       (insert-fontified "for")
       (should (not (face-at -1)))
       (insert-fontified "(")
-      (should (eq (face-at -2) 'ess-keyword-face)))))
-
+      (should (eq (face-at -2) 'ess-keyword-face))
+      ;; `in` keyword
+      (insert-fontified "foo in bar)")
+      (search-backward "in")
+      (should (eq (face-at-point) 'ess-keyword-face))
+      (erase-buffer)
+      (insert-fontified "for foo in bar")
+      (search-backward "in")
+      (should (not (face-at-point))))))

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -57,13 +57,31 @@ withRestarts¶() invokeRestart¶() recover¶() browser¶()
 message¶() warning¶() signalCondition¶() withCallingHandlers¶()
 
 
-### 3 Simple keywords are always fontified ---------------------------
+### 3a Simple keywords are always fontified --------------------------
 
-¶in ¶else ¶break ¶next ¶repeat
+¶else ¶break ¶next ¶repeat
 
 ##! (should (eq (face-at-point) 'ess-keyword-face))
 
-¶in ¶else ¶break ¶next ¶repeat
+¶else ¶break ¶next ¶repeat
+
+
+### 3b `in` is fontified inside `for ()` -----------------------------
+
+for (foo ¶in bar) {}
+
+##! (should (eq (face-at-point) 'ess-keyword-face))
+
+for (foo ¶in bar) {}
+
+
+### 3c `in` is not fontified outside `for ()` ------------------------
+
+for foo ¶in bar {}
+
+##! (should (not (face-at-point)))
+
+for foo ¶in bar {}
 
 
 ### 4 Search list modifiers are not fontified if not in function position
@@ -149,20 +167,16 @@ foobar ¶foobaz()
 
 ### 10 Can remove bare keywords from `ess-R-keywords' ----------------
 
-¶in else
+¶for (foo ¶in bar) NULL
 
 ##! (let ((ess-R-keywords '("in")))
-##>   (ess-r-mode)
-##>   (font-lock-ensure))
-##> (should (eq (face-at-point) 'ess-keyword-face))
-##> (forward-word)
-##> (forward-char)
+##!   (ess-r-mode)
+##!   (font-lock-ensure))
+##! (if (looking-at "for")
+##!     (should (not (face-at-point)))
+##!   (should (eq (face-at-point) 'ess-keyword-face)))
 
-in ¶else
-
-##> (should (not (face-at-point)))
-
-in ¶else
+¶for (foo ¶in bar) NULL
 
 
 ### 11 Can disable backquoted function definition fontification ------


### PR DESCRIPTION
This change completes the set of spurious fontification fixes for this release cycle. It prevents fontification of `in` outside of `for ()` constructs:

```r
for x in y    # `in` not highlighted
for (x in y)  # `in` highlighted
```

Unfortunately only `in` is fixed because other keywords like `next` or `break` can't be fixed without robust detection/matching of complete expressions:

```r
for (x in x) if (x) break
```

Still fixing spurious `in` fontification is a good improvement as it is very common in certain sorts of process outputs, like R CMD check.

This is a non-trivial change and we're close to the release but the fontification stuff is now very well covered by unit tests (I added a few more for inferior buffers). Also fontification is hit-or-miss so once it works chances are it works robustly, and we can all test it for a few days to be sure.

I moved the keyword fontifier to the R mode file because that's the most fitting place for it and this way we can use functions defined in ess-r-syntax without compilation warnings.