### PR TITLE
Fix insert assign

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -123,12 +123,19 @@ will need to update their customization to
 @code{inferior-ess-R-program}. These variables are treated as risky
 variables.
 
-@item @code{ess-smart-S-assign} changed name to @code{ess-insert-S-assign}.
-By default, it provides similar functionality. Since many users
-dislike this functionality, it is easier to disable; set
-@code{ess-smart-S-assign-key} to nil. The following functions have
-been made obsolete and will be removed in the next release of ESS:
-ess-smart-S-assign, ess-toggle-S-assign, ess-toggle-S-assign-key,
+@item @code{ess-smart-S-assign} was renamed to @code{ess-insert-assign}.
+It provides similar functionality but for any keybinding, not just `_`.
+For instance if you bind it to `;`, repeated invokations cycle through
+between assignment and inserting `;`.
+
+The variable @code{ess-smart-S-assign-key} is now deprecated. If you
+would like to continue using `_` for insterting assign in future
+releases, please bind @code{ess-insert-assign} in @code{ess-mode-map}
+the normal way.
+
+In addition the following functions have been made obsolete and will be
+removed in the next release of ESS: ess-smart-S-assign,
+ess-toggle-S-assign, ess-toggle-S-assign-key,
 ess-disable-smart-S-assign.
 
 @item The option ess-S-assign has been removed.

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -557,12 +557,14 @@ buffer or end chunks etc.")
 (defcustom ess-smart-S-assign-key "_"
   "Key used by `ess-smart-S-assign'.
 Should be nil or a \"simple\" key, in other words no key
-modifiers.
+modifiers. Can only be changed before ESS is loaded.
 
-You may change this to nil at any time. However, if you change it
-to another string, it must be set before ESS is loaded."
+This variable is deprecated and will be removed in the future.
+Please bind `ess-insert-assign' in `ess-mode-map' to your key of
+choice with `define-key' or similar."
   :group 'ess-S
   :type '(choice (const :tag "Nothing" :value nil) string))
+(make-obsolete-variable 'ess-smart-S-assign-key nil "ESS 18.09")
 
 (defcustom ess-assign-list (cons (if (boundp 'ess-S-assign) ess-S-assign " <- ")
                                  '(" <<- " " = " " -> " " ->> "))

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -557,7 +557,7 @@ buffer or end chunks etc.")
 (defcustom ess-smart-S-assign-key "_"
   "Key used by `ess-smart-S-assign'.
 Should be nil or a \"simple\" key, in other words no key
-modifiers. Can only be changed before ESS is loaded.
+modifiers.
 
 This variable is deprecated and will be removed in the future.
 Please bind `ess-insert-assign' in `ess-mode-map' to your key of

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1946,7 +1946,7 @@ meaning as for `ess-eval-region'."
     (define-key map "\C-c\C-e"   'ess-extra-map)
     (define-key map "\C-c\C-t"   'ess-dev-map)
     (when ess-smart-S-assign-key
-      (define-key map ess-smart-S-assign-key 'ess-insert-assign))
+      (define-key map ess-smart-S-assign-key 'ess-smart-S-assign))
     map)
   "Keymap for `inferior-ess' mode.")
 

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -605,8 +605,7 @@ If the character before point is the first element of
 `ess-smart-S-assign-key' is nil, do `self-insert-command' using
 ARG as the number of times to insert."
   (interactive "p")
-  (if (and ess-smart-S-assign-key
-           (string= ess-language "S"))
+  (if (string= ess-language "S")
       (let* ((assign (car ess-assign-list))
              (event (event-basic-type last-input-event))
              (char (ignore-errors (format "%c" event))))

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -618,6 +618,16 @@ ARG as the number of times to insert."
               (t (insert assign))))
     (funcall #'self-insert-command arg)))
 
+(defun ess-smart-S-assign (arg)
+  "Insert `ess-smart-S-assign-key'.
+Please use `ess-insert-assign'."
+  (interactive "p")
+  (if ess-smart-S-assign-key
+      (ess-insert-assign arg)
+    (self-insert-command arg)))
+
+(make-obsolete 'ess-smart-S-assign 'ess-insert-assign "ESS 18.09")
+
 (defun ess-disable-smart-S-assign (&rest _ignore)
   "Disable `ess-insert-assign'."
   (declare (obsolete "Use ess-smart-S-assign-key instead." "ESS 18.09"))
@@ -789,7 +799,6 @@ return it.  Otherwise, return `ess-help-topics-list'."
 
 (define-obsolete-function-alias 'ess-toggle-S-assign-key #'ignore "ESS 18.09")
 (define-obsolete-function-alias 'ess-smart-underscore 'ess-insert-assign "ESS 18.09")
-(define-obsolete-function-alias 'ess-smart-S-assign 'ess-insert-assign "ESS 18.09")
 (define-obsolete-function-alias 'ess-insert-S-assign 'ess-insert-assign "ESS 18.09")
 
 (define-obsolete-function-alias 'ess-toggle-underscore 'ess-disable-smart-S-assign "ESS 18.09")

--- a/lisp/ess.el
+++ b/lisp/ess.el
@@ -122,7 +122,7 @@
     (define-key map "\C-c\C-e"   'ess-extra-map)
     (define-key map "\C-c\C-t"   'ess-dev-map)
     (when ess-smart-S-assign-key
-      (define-key map ess-smart-S-assign-key 'ess-insert-assign))
+      (define-key map ess-smart-S-assign-key 'ess-smart-S-assign))
     (define-key map (kbd "C-c C-=") 'ess-cycle-assignment)
     map)
   "Keymap for `ess-mode'.")

--- a/test/ess-literate-tests.el
+++ b/test/ess-literate-tests.el
@@ -298,6 +298,7 @@
 (defun elt--unalias-key (key)
   "Call command that corresponds to KEY.
 Insert KEY if there's no command."
+  (setq last-input-event (aref key 0))
   (let ((cmd (key-binding key)))
     (if (eq cmd 'self-insert-command)
         (insert key)

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -204,6 +204,7 @@
    (string= " <- "
             (ess-r-test-with-temp-text ""
               (progn
+                (setq last-input-event ?_)
                 (call-interactively 'ess-insert-S-assign)
                 (buffer-substring (point-min) (point-max)))))))
 

--- a/test/generate-literate-cases
+++ b/test/generate-literate-cases
@@ -18,4 +18,4 @@
 (mapc (lambda (file)
         (elt-do 'regenerate (expand-file-name file ess-literate-path)))
       '("elt.R" "roxy.R" "code-fill.R" "misc.R" "syntax.R" "tokens.R"
-        "fontification.R"))
+        "fontification.R" "keybindings.R"))

--- a/test/literate/keybindings.R
+++ b/test/literate/keybindings.R
@@ -1,0 +1,105 @@
+
+##### Assignment
+
+### 1 Smart assign key -----------------------------------------------
+
+foo¶
+
+##! "_"
+
+foo <- ¶
+
+##> "_"
+
+foo_¶
+
+##> "_"
+
+foo_ <- ¶
+
+
+### 2 Unbinding smart key --------------------------------------------
+
+foo¶
+
+##! (define-key ess-mode-map "_" nil)
+##! "_"
+
+foo_¶
+
+##> (define-key ess-mode-map "_" #'ess-insert-assign) ; Reset
+##> "_"
+
+foo_ <- ¶
+
+
+### 3a Binding `ess-insert-assign` to simple key ---------------------
+
+foo¶
+
+##! (define-key ess-mode-map ";" #'ess-insert-assign)
+##! ";"
+
+foo <- ¶
+
+##> ";"
+
+foo;¶
+
+##> ";"
+
+foo; <- ¶
+
+
+### 3b Binding `ess-insert-assign` to simple key with nil smart key --
+
+foo¶
+
+##! (setq ess-smart-S-assign-key nil)
+##! ";"
+
+foo <- ¶
+
+##> ";"
+
+foo;¶
+
+##> (define-key ess-mode-map ";" nil) ; Reset
+##> ";"
+
+foo;;¶
+
+
+### 3c Binding `ess-insert-assign` to complex key --------------------
+
+foo¶
+
+##! (let ((map (make-sparse-keymap)))
+##!   (define-key map (kbd "M--") #'ess-insert-assign)
+##!   (use-local-map map))
+##! "M--"
+
+foo <- ¶
+
+##> "M--"
+
+foo-¶
+
+
+### 4 `ess-insert-assign` uses `ess-assign-list` ---------------------
+
+foo¶
+
+##! (setq-local ess-assign-list '(" <~ "))
+##! "_"
+
+foo <~ ¶
+
+##> "_"
+
+foo_¶
+
+##> "_"
+
+foo_ <~ ¶
+

--- a/test/literate/keybindings.R
+++ b/test/literate/keybindings.R
@@ -1,7 +1,7 @@
 
 ##### Assignment
 
-### 1 Smart assign key -----------------------------------------------
+### 1a Smart assign key ----------------------------------------------
 
 foo¶
 
@@ -18,6 +18,25 @@ foo_¶
 foo_ <- ¶
 
 
+### 1b Can set `ess-smart-S-assign` to nil at any time ---------------
+
+foo¶
+
+##! (setq ess-smart-S-assign-key nil)
+##! "_"
+
+foo_¶
+
+##> "_"
+
+foo__¶
+
+##> (setq ess-smart-S-assign-key "_") ; Reset
+##> "_"
+
+foo__ <- ¶
+
+
 ### 2 Unbinding smart key --------------------------------------------
 
 foo¶
@@ -27,7 +46,7 @@ foo¶
 
 foo_¶
 
-##> (define-key ess-mode-map "_" #'ess-insert-assign) ; Reset
+##> (define-key ess-mode-map "_" #'ess-smart-S-assign) ; Reset
 ##> "_"
 
 foo_ <- ¶
@@ -65,6 +84,7 @@ foo <- ¶
 foo;¶
 
 ##> (define-key ess-mode-map ";" nil) ; Reset
+##> (setq ess-smart-S-assign-key "_") ; Reset
 ##> ";"
 
 foo;;¶

--- a/test/run-tests
+++ b/test/run-tests
@@ -40,7 +40,8 @@
   (elt-deftest test-ess-r-misc () "misc.R")
   (elt-deftest test-ess-r-syntax () "syntax.R")
   (elt-deftest test-ess-r-tokens () "tokens.R")
-  (elt-deftest test-ess-r-fontification () "fontification.R"))
+  (elt-deftest test-ess-r-fontification () "fontification.R")
+  (elt-deftest test-ess-r-fontification () "keybindings.R"))
 
 ;; run tests
 (ert-run-tests-batch-and-exit t)


### PR DESCRIPTION
Closes #660 and closes #659.

*   Fixes this sequence of commands:

    ```lisp
    (setq ess-smart-S-assign-key nil)
    (define-key ";" ess-mode-map #'ess-insert-assign)
    ```

    The flip side is that the smart key cannot be set to nil at any time to be disabled, it has to be set before loading ESS. But since we agreed to deprecate the smart key at the next release, it's important to avoid any interference between the smart key and `ess-insert-assign`.

*   Announces soft-deprecation of the smart key.