### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ version:
 	@echo "********************* VERSIONS **************************"
 	@echo $(shell $(EMACS) --version | sed -n 1p)
 	@echo ESS $(ESSVERSION)
-	@echo git HEAD $(shell git rev-parse --short HEAD)
 	@echo "*********************************************************"
 
 .PHONY: lisp
@@ -51,6 +50,8 @@ tarballs: $(ESSDIR)
 	@echo "**********************************************************"
 	@echo "** Making distribution of ESS for (pre)release $(ESSVERSION) from $(ESSDIR)/"
 	@echo "** Creating .tgz file **"
+	cd doc/ ; $(MAKE) pdf
+	cd doc/ ; $(MAKE) html
 	test -f $(ESSDIR).tgz && rm -rf $(ESSDIR).tgz || true
 	$(GNUTAR) hcvofz $(ESSDIR).tgz $(ESSDIR)
 	@echo "** Creating .zip file **"

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -33,14 +33,15 @@ ESSINFONODE3='                        (S/S+/R, SAS, BUGS, Stata, XLisp-Stat).'
 PDFs = ess.pdf readme.pdf refcard/refcard.pdf
 TXTs = ../README ../ANNOUNCE ../NEWS ../ONEWS
 
-all  : info text html pdf
-docs : info text html
+# Don't build pdf/html by default
+all  : info text
 info : info/ess.info
 text : $(TXTs)
 html : html/ess.html html/readme.html html/news.html
 pdf  : $(PDFs)
 
-ess.pdf : $(TEXISRC); $(TEXI2PDF) ess.texi
+ess.pdf : $(TEXISRC)
+	$(TEXI2PDF) ess.texi
 
 readme.pdf : $(TEXISRC); $(TEXI2PDF) readme.texi
 


### PR DESCRIPTION
- Remove "version" target as it fails when git isn't present

- New variables BUILD_PDF_DOCS and BUILD_HTML_DOCS control whether
  pdf/html documentation gets built (off by default), which enables
  "make all" without texlive

Closes #146