### PR TITLE
ess-julia: expand file path for include calls

### DIFF
--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -311,7 +311,7 @@ to look up any doc strings."
     (ess-help-web-search-command   . "https://docs.julialang.org/en/latest/search/?q=%s")
     (ess-manual-lookup-command     . 'ess-julia-manual-lookup-function)
     ;; (ess-reference-lookup-command       . 'ess-julia-reference-lookup-function)
-    (ess-load-command              . "include(\"%s\")\n")
+    (ess-load-command              . "include(expanduser(\"%s\"))\n")
     (ess-funargs-command           . "ESS.fun_args(\"%s\")\n")
     (ess-dump-error-re             . "in \\w* at \\(.*\\):[0-9]+")
     (ess-error-regexp              . "\\(^\\s-*at\\s-*\\(?3:.*\\):\\(?2:[0-9]+\\)\\)")


### PR DESCRIPTION
julia's include doesn't do tilde expansion, so `include(~/path/to/lib)' will end up
being pwd() + ~/path/to/lib which isn't somone wants