### PR TITLE
Use project instead of projectile for inferior buffer names

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -17,6 +17,14 @@ Users can change it to 'frame, 'window, or an integer. See the
 docstring for details. @code{ess-auto-width-visible} controls
 visibility.
 
+@item Options for 'ess-gen-proc-buffer-name-function' have been renamed.
+ess-gen-proc-buffer-name:projectile-or-simple was renamed to
+ess-gen-proc-buffer-name:project-or-simple and
+ess-gen-proc-buffer-name:projectile-or-directory was renamed to
+ess-gen-proc-buffer-name:project-or-directory. As the name suggests,
+these now rely on project.el (included with Emacs) rather than
+projectile.el, which is a third-party package.
+
 @end itemize
 
 Changes and New Features in 18.10:

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1554,30 +1554,35 @@ process buffer."
   :group 'ess
   :type 'boolean)
 
-(defcustom ess-gen-proc-buffer-name-function 'ess-gen-proc-buffer-name:projectile-or-simple
-  "Function used for generation of the buffer name of the newly created ESS process.
+(defcustom ess-gen-proc-buffer-name-function 'ess-gen-proc-buffer-name:project-or-simple
+  "Function used for generation of the buffer name of the new ESS processes.
 It should accept one argument PROC-NAME, a string specifying
 internal process name (R, R:2, etc).
 
 Provided default options are:
 
-  `ess-gen-proc-buffer-name:simple'    -- *proc*
-  `ess-gen-proc-buffer-name:directory' -- *proc:dir*
-  `ess-gen-proc-buffer-name:abbr-long-directory' -- *proc:abbr-long-dir*
-  `ess-gen-proc-buffer-name:projectile-or-simple'    -- *proc:projectile-root* or *proc*.
-  `ess-gen-proc-buffer-name:projectile-or-directory' -- *proc:projectile-root* or *proc:dir*.
+`ess-gen-proc-buffer-name:simple'
+ *proc*
 
-Strategies based on projectile default to built-in strategies if
-projectile.el is not loaded or there is no project root in the
-current directory.
-"
+`ess-gen-proc-buffer-name:directory'
+  *proc:dir*
+`ess-gen-proc-buffer-name:abbr-long-directory'
+  *proc:abbr-long-dir*
+`ess-gen-proc-buffer-name:project-or-simple'
+  *proc:project-root* or *proc*
+`ess-gen-proc-buffer-name:project-or-directory'
+  *proc:project-root* or *proc:dir*
+
+Strategies based on projects default to built-in strategies if
+there is no project root in the current directory."
   :group 'ess
   :type '(choice (const :tag "*proc*"     ess-gen-proc-buffer-name:simple)
                  (const :tag "*proc:dir*" ess-gen-proc-buffer-name:directory)
                  (const :tag "*proc:abbr-long-dir*" ess-gen-proc-buffer-name:abbr-long-directory)
-                 (const :tag "*proc:projectile-root* or *proc*"     ess-gen-proc-buffer-name:projectile-or-simple)
-                 (const :tag "*proc:projectile-root* or *proc:dir*" ess-gen-proc-buffer-name:projectile-or-directory)
-                 function))
+                 (const :tag "*proc:project-root* or *proc*"     ess-gen-proc-buffer-name:project-or-simple)
+                 (const :tag "*proc:project-root* or *proc:dir*" ess-gen-proc-buffer-name:project-or-directory)
+                 function)
+  :package-version '(ess . "19.04"))
 
 
 (defcustom ess-kermit-command "gkermit -T"

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -95,14 +95,14 @@ all source dirs recursively within the current package.")
 
 (defun ess-r-package-project (&optional dir)
   "Return the current package as an Emacs project instance.
-A project instance is a cons cell of the project name as symbol
+A project instance is a cons cell of the project type as symbol
 and the project path as string. If DIR is provided, the package
 is searched from that directory instead of `default-directory'."
   (if (car ess-r-package--project-cache)
       ess-r-package--project-cache
     (let* ((pkg-path (ess-r-package--find-package-path (or dir default-directory)))
            (project (when pkg-path
-                      (cons (ess-r-package--find-package-name pkg-path) pkg-path))))
+                      (cons 'ess-r-package pkg-path))))
       ;; Cache info for better performance on remotes
       (setq-local ess-r-package--project-cache (or project (list nil)))
       (when (car project)

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -29,7 +29,8 @@
 ;; see apropriate documentation section of ESS user manual
 
 ;;; Code:
-
+(require 'cl-lib)
+(require 'project)
 (require 'ess-custom)
 (require 'ess-inf)
 (require 'ess-utils)
@@ -107,6 +108,10 @@ is searched from that directory instead of `default-directory'."
       (setq-local ess-r-package--project-cache (or project (list nil)))
       (when (car project)
         (cons 'r-package (cdr project))))))
+
+(cl-defmethod project-roots ((project (head ess-r-package)))
+  "Return the project root for ESS R packages"
+  (list (cdr project)))
 
 (defun ess-r-package-name (&optional dir)
   "Return the name of the current package as a string."


### PR DESCRIPTION
project.el is included with Emacs 25.1 and newer.

This will fail travis until I merge #716 since it uses some Emacs 25+ lisp. I'll rebase this after merging that, just dropping the PR here so I don't forget.