### PR TITLE
ess-utils: Enable lexical binding

### DIFF
--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -434,7 +434,7 @@ packages are installed."
   (interactive (list 'interactive))
   (cl-case command
     (interactive (company-begin-backend 'company-R-library))
-    (prefix (and (member (car (ess--fn-name-start 'symbol))
+    (prefix (and (member (car (ess--fn-name-start))
                          '("library" "require"))
                  (let ((start (ess-symbol-start)))
                    (and start (buffer-substring start (point))))))


### PR DESCRIPTION
I'm not sure how familiar you are with lexical-binding but it has some nice benefits over the default dynamic bindings. This is a nice [blog post](https://nullprogram.com/blog/2016/12/11/) that summarizes the advantages as:

- It allows the compiler to catch more mistakes.
- It eliminates a class of bugs related to dynamic scope: Local variables are exposed to manipulation by callees.
- Lexical scope has better performance.

I'd like to eventually turn it on for all ESS files. This gets the ball rolling for using it with `ess-utils.el`.