### PR TITLE
Simplify ess-eval-* logic

### DIFF
--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -92,11 +92,60 @@ Used in noweb modes.")
 
 ;;*;; elisp tools
 
+(defun ess-next-code-line (&optional arg skip-to-eob)
+  "Move ARG lines of code forward (backward if ARG is negative).
+Skips past all empty and comment lines. Default for ARG is 1.
+Don't skip the last empty and comment lines in the buffer unless
+SKIP-TO-EOB is non-nil. On success, return 0. Otherwise, go as
+far as possible and return -1."
+  (interactive "p")
+  (or arg (setq arg 1))
+  (beginning-of-line)
+  (let ((pos (point))
+        (n 0)
+        (inc (if (> arg 0) 1 -1)))
+    (while (and (/= arg 0) (= n 0))
+      (setq n (forward-line inc)); n=0 is success
+      (if (not (fboundp 'comment-beginning))
+          (while (and (= n 0)
+                      (looking-at "\\s-*\\($\\|\\s<\\)"))
+            (setq n (forward-line inc)))
+        (comment-beginning)
+        (beginning-of-line)
+        (forward-comment (* inc (buffer-size))) ;; as suggested in info file
+        )
+      (if (or skip-to-eob
+              (not (looking-at ess-no-skip-regexp))) ;; don't go to eob or whatever
+          (setq arg (- arg inc))
+        (goto-char pos)
+        (setq arg 0)
+        (forward-line 1));; stop at next empty line
+      (setq pos (point)))
+    (goto-char pos)
+    n))
+
 (defun ess-goto-line (line)
   (save-restriction
     (widen)
     (goto-char (point-min))
     (forward-line (1- line))))
+
+(defun ess-skip-thing (thing)
+  "Leave point at the end of THING.
+THING can be 'function, 'paragraph, or 'line."
+  (cond
+   ((eql thing 'line) (goto-char (line-end-position)))
+   ((eql thing 'paragraph) (forward-paragraph))
+   ((eql thing 'function) (goto-char (cadr (ess-end-of-function nil 'no-error))))))
+
+(defun ess-step-line (&optional skip)
+  "Step forward to the \"next\" line.
+Depending on `ess-eval-empty', step one line or to the next code
+line. When given, SKIP gets passed to `ess-skip-thing'."
+  (when skip (ess-skip-thing skip))
+  (if ess-eval-empty
+      (forward-line 1)
+    (ess-next-code-line)))
 
 (defun ess-line-end-position (&optional N)
   "Return the 'point' at the end of N lines. N defaults to 1, i.e., current line."

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -224,6 +224,44 @@
                 (call-interactively 'ess-insert-S-assign)
                 (buffer-substring (point-min) (point-max)))))))
 
+(ert-deftest ess-skip-thing ()
+  (should (eql 18
+               (ess-r-test-with-temp-text "x <- function(x){\n mean(x)\n }\n \n \n x(3)\n "
+                 (progn
+                   (goto-char (point-min))
+                   (ess-skip-thing 'line)
+                   (point)))))
+  (should (eql 30
+               (ess-r-test-with-temp-text "x <- function(x){\n mean(x)\n }\n \n \n x(3)\n "
+                 (progn
+                   (goto-char (point-min))
+                   (ess-skip-thing 'function)
+                   (point)))))
+  (should (eql 31
+               (ess-r-test-with-temp-text "x <- function(x){\n mean(x)\n }\n \n \n x(3)\n "
+                 (progn
+                   (goto-char (point-min))
+                   (ess-skip-thing 'paragraph)
+                   (point)))))
+  (should-error (ess-r-test-with-temp-text "mean(1:10)"
+                  (progn
+                    (goto-char (point-min))
+                    (ess-skip-thing 'function)))))
+
+(ert-deftest ess-step-line ()
+  (should (eql 5
+               (ess-r-test-with-temp-text "1+1\n#2+2\n#3+3\n4+4"
+                 (let ((ess-eval-empty t))
+                   (goto-char (point-min))
+                   (ess-step-line)
+                   (point)))))
+  (should (eql 15
+               (ess-r-test-with-temp-text "1+1\n#2+2\n#3+3\n4+4"
+                 (let (ess-eval-empty)
+                   (goto-char (point-min))
+                   (ess-step-line)
+                   (point))))))
+
 (ert-deftest ess-Rout-file ()
   (let ((buf (find-file-noselect "fixtures/file.Rout")))
     (with-current-buffer buf


### PR DESCRIPTION
Now all the ess-eval-* functions will have the same behavior.

This is inspired by, but does not fix, bug report #720.