### PR TITLE
Silence all byte compile warnings, forever

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: emacs-lisp
 env:
+  # When there's a new major Emacs release, also update
+  # byte-compile-error-on-warn to the new release, below
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis
@@ -34,5 +36,11 @@ before_script:
 script:
 - emacs --version
 - R --version
-- make all
+- cd lisp; make julia-mode.elc
+- cd ..
+- make -k all "EMACSBATCH = 
+  emacs -batch -no-site-file -no-init-file 
+  --eval \"(put 'if-let 'byte-obsolete-info nil)\" 
+  --eval \"(put 'when-let 'byte-obsolete-info nil)\" 
+  --eval \"(setq byte-compile-error-on-warn (= emacs-major-version 26))\""
 - make test

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -54,6 +54,10 @@
 (declare-function tramp-dissect-file-name "tramp")
 (declare-function tramp-tramp-file-p "tramp")
 
+(declare-function ess-skip-blanks-backward "ess-r-syntax")
+(declare-function ess-skip-blanks-forward "ess-r-syntax")
+(declare-function ess-mode "ess")
+
 ;; TODO: refactor and remove file-local variable
 ;; byte-compile-warnings. See ess-r-mode.el also
 (defvar proc)

--- a/lisp/ess-noweb-font-lock-mode.el
+++ b/lisp/ess-noweb-font-lock-mode.el
@@ -241,7 +241,6 @@ Each chunk is fontified in accordance with its own mode."
   (save-excursion
     (font-lock-set-defaults)
     ;; (setq old-beginning-of-syntax font-lock-beginning-of-syntax-function)
-    (setq syntax-begin-function #'ess-noweb-start-of-syntax)
     (setq font-lock-keywords
           ;;         (append font-lock-keywords
           ;;                 '(("\\(\\[\\[\\)\\([^]]*\\]*\\)\\(\\]\\]\\|\\$\\)"

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -843,13 +843,13 @@ and y-offsets for the toolbar from point."
     (setq frame-left (if (not (consp fx))
                          fx
                        (if (eq (car fx) '-)
-                           (- (x-display-pixel-width) (car (cdr fx)) fw)
+                           (- (display-pixel-width) (car (cdr fx)) fw)
                          (car (cdr fx)))))
 
     (setq frame-top (if (not (consp fy))
                         fy
                       (if (eq (car fy) '-)
-                          (- (x-display-pixel-height) (car (cdr fy)) fh)
+                          (- (display-pixel-height) (car (cdr fy)) fh)
                         (car (cdr fy)))))
 
     ;; calculate the offset from point, use xo and yo to adjust to preference


### PR DESCRIPTION
Closes #506 

This fixes up some of the last compiler warnings, ignoring the ridiculous situation about `if-let` in 25.3-26.1-27.0.50 (see the commit log for details).

Travis will now error when the byte compile issues a warning on Emacs 26. The plan is to have a clean compile on whatever the latest Emacs major release is (I put a note in the travis build script to remind us about that when we update it).