### PR TITLE
Make ESS respect 'display-buffer-alist'

### DIFF
--- a/doc/ess.texi
+++ b/doc/ess.texi
@@ -573,11 +573,28 @@ It is not normally necessary to pass arguments to the iESS program; in
 particular do not pass the @samp{-e} option to @code{Splus}, since ESS
 provides its own command history mechanism.
 
-By default, the new process will be displayed in the same window in the
-current frame.  If you wish your iESS process to appear in a separate
-frame, customize the variable @code{inferior-ess-own-frame}.
-Alternatively, change @code{inferior-ess-same-window} if you wish the
-process to appear within another window of the current frame.
+To control where buffer containing the process is displayed, customize
+@code{display-buffer-alist}, @xref{Window Choice,,, emacs}. For
+example, to ensure Help buffers always appear at the right side of the
+current frame and inferior R buffers always appear at the bottom of
+the current frame, you could add this to your Emacs initialization
+file:
+
+@example
+(add-to-list 'display-buffer-alist
+             '("*Help"
+               (display-buffer-reuse-window display-buffer-in-side-window)
+               (side . right)
+               (window-width . 0.33)
+               (reusable-frames . nil)))
+
+(add-to-list 'display-buffer-alist
+             '("*R"
+               (display-buffer-reuse-window display-buffer-at-bottom)
+               (window-height . 0.5)
+               (reusable-frames . nil)))
+@end example
+
 
 @vindex ess-auto-width
 @vindex ess-auto-width-visible

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -17,6 +17,31 @@ Users can change it to 'frame, 'window, or an integer. See the
 docstring for details. @code{ess-auto-width-visible} controls
 visibility.
 
+@item ESS now respects @code{display-buffer-alist}.
+Users can now use @code{display-buffer-alist} to manage how and where
+windows appear. For example, to ensure help buffers always appear at
+the right side of the current frame and inferior R buffers always
+appear at the bottom, you could add something like the following to
+your Emacs file:
+
+@example
+(add-to-list 'display-buffer-alist
+             '("*Help"
+               (display-buffer-reuse-window display-buffer-in-side-window)
+               (side . right)
+               (window-width . 0.33)
+               (reusable-frames . nil)))
+
+(add-to-list 'display-buffer-alist
+             '("*R"
+               (display-buffer-reuse-window display-buffer-at-bottom)
+               (window-height . 0.5)
+               (reusable-frames . nil)))
+@end example
+
+See the documentation of @code{display-buffer-alist},
+@code{display-buffer}, and @xref{Window Choice,,, emacs} for details.
+
 @item Options for 'ess-gen-proc-buffer-name-function' have been renamed.
 ess-gen-proc-buffer-name:projectile-or-simple was renamed to
 ess-gen-proc-buffer-name:project-or-simple and
@@ -29,6 +54,19 @@ projectile.el, which is a third-party package.
 This includes old versions of S+, ARC, OMG, VST, and XLS.
 
 @end itemize
+
+The following have been made obsolete, see their documentation for more detail:
+
+@itemize @bullet
+
+@item User options for controlling display of buffers.
+This includes @code{ess-show-buffer-action},
+@code{inferior-ess-same-window}, @code{inferior-ess-own-frame}, and
+@code{inferior-ess-frame-alist}. See above about ESS respecting
+@code{display-buffer-alist}.
+
+@end itemize
+
 
 Changes and New Features in 18.10-1:
 @itemize @bullet

--- a/lisp/ess-bugs-l.el
+++ b/lisp/ess-bugs-l.el
@@ -271,7 +271,7 @@ add path to the command name."
 (defun ess-bugs-shell ()
   "Create a buffer with BUGS running as a subprocess."
   (interactive)
-  (switch-to-buffer (concat "*" ess-bugs-shell-buffer-name "*"))
+  (pop-to-buffer-same-window (concat "*" ess-bugs-shell-buffer-name "*"))
   (make-comint ess-bugs-shell-buffer-name ess-bugs-shell-command nil
                ess-bugs-default-bins ess-bugs-shell-default-output-file-root)
   (comint-mode)

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1614,26 +1614,18 @@ by `ess-function-template'."
 
  ; ess-inf: variables for inferior-ess.
 
-(defcustom inferior-ess-own-frame nil
+(defvar inferior-ess-own-frame nil
   "Non-nil means that inferior ESS buffers should start in their own frame.
-The parameters of this frame are stored in `inferior-ess-frame-alist'."
-  :group 'ess-proc
-  :type 'boolean)
+This variable is deprecated.
+please add an entry to `display-buffer-alist' instead. See Info
+node `(ess)Customizing startup'. For example:
 
-(defcustom inferior-ess-frame-alist default-frame-alist
-  "Alist of frame parameters used to create new frames for iESS buffers.
-This defaults to `default-frame-alist' and is used only when
-the variable `inferior-ess-own-frame' is non-nil."
-  :group 'ess-proc
-  :type 'alist)
-
-(defcustom inferior-ess-same-window t
-  "Non-nil indicates new inferior ESS process appears in current window.
-Otherwise, the new inferior ESS buffer is shown in another window in the
-current frame.  This variable is ignored if `inferior-ess-own-frame' is
-non-nil."
-  :group 'ess-proc
-  :type 'boolean)
+\(add-to-list 'display-buffer-alist
+             '(\"*R\"
+  (display-buffer-reuse-window display-buffer-pop-up-frame)))")
+(make-obsolete-variable 'inferior-ess-own-frame 'display-buffer-alist "ESS 19.04")
+(make-obsolete-variable 'inferior-ess-frame-alist "It is ignored. Use `display-buffer-alist' and `pop-up-frame-alist' instead." "ESS 19.04")
+(make-obsolete-variable 'inferior-ess-same-window 'display-buffer-alist "ESS 19.04")
 
 (defcustom inferior-ess-jit-lock-chunk-size 10000
   "Default for (buffer local) `jit-lock-chunk-size' in inferior ESS buffers."

--- a/lisp/ess-dde.el
+++ b/lisp/ess-dde.el
@@ -164,7 +164,7 @@ file into an emacs buffer and displays it."
     (sleep-for sleep)
     (if (not bufname)
         (find-file filename)
-      (switch-to-buffer bufname))
+      (pop-to-buffer-same-window bufname))
     (revert-buffer t t) ;; this allows the user to reuse the BUF name
     ))
 

--- a/lisp/ess-mouse.el
+++ b/lisp/ess-mouse.el
@@ -189,13 +189,13 @@ the string one more time by embedding it in a \"page()\" command."
           (if (not value-returned)
               nil
             (sleep-for 2)
-            (switch-to-buffer (car (buffer-list)))))
+            (pop-to-buffer-same-window (car (buffer-list)))))
       (ess-make-buffer-current)
-      (switch-to-buffer commands-buffer)
+      (pop-to-buffer-same-window commands-buffer)
       (ess-setq-vars-local (eval ess-mouse-customize-alist) (current-buffer))
       (setq ess-local-process-name lproc-name)
       (ess-command (concat scommand "\n") commands-buffer)
-      (if (not value-returned) (switch-to-buffer (nth 1 (buffer-list)))))
+      (if (not value-returned) (pop-to-buffer-same-window (nth 1 (buffer-list)))))
     (if (not value-returned)
         nil
       (if ess-microsoft-p                      ;; there ought to be a filter

--- a/lisp/ess-noweb-mode.el
+++ b/lisp/ess-noweb-mode.el
@@ -1413,12 +1413,12 @@ ess-noweb-set-doc-mode) before calling this function"
 
 (defun ess-noweb-log (s)
   (let ((b (current-buffer)))
-    (switch-to-buffer (get-buffer-create "*noweb-log*"))
+    (pop-to-buffer-same-window (get-buffer-create "*noweb-log*"))
     (goto-char (point-max))
     (setq buffer-read-only nil)
     (insert s)
     (setq buffer-read-only t)
-    (switch-to-buffer b)))
+    (pop-to-buffer-same-window b)))
 
 
 

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -269,7 +269,7 @@ arguments, or expressions which return R arguments."
     (message msg pkg-name)
     (with-ess-process-buffer nil
       (setq ess-r-package--project-cache ess-r-package--project-cache))
-    (ess-show-buffer (ess-get-process-buffer))
+    (display-buffer (ess-get-process-buffer))
     (ess-eval-linewise (format command (concat pkg-path args)))))
 
 (defun ess-r-command--build-args (ix &optional actions)
@@ -415,7 +415,7 @@ re-installation when called with a prefix ARG."
                   (ess-r-command--build-args 0 '((read-string "Arguments: " "force = TRUE")))
                 "")))
     (inferior-ess-r-force)
-    (ess-show-buffer (ess-get-process-buffer))
+    (display-buffer (ess-get-process-buffer))
     (message "Installing %s from github" repo)
     (ess-eval-linewise (format command repo args))))
 

--- a/lisp/ess-swv.el
+++ b/lisp/ess-swv.el
@@ -149,8 +149,8 @@ set this command to \"%s(%s)\"."
               (ess-eval-linewise (concat Sw-cmd "\n") nil nil nil t)
               (message "Finished %s()ing %S" cmd rnw-file))
           (ess-execute Sw-cmd 'buffer nil nil)
-          (switch-to-buffer rnw-buf)
-          (ess-show-buffer (buffer-name sbuffer) nil))))))
+          (pop-to-buffer-same-window rnw-buf)
+          (display-buffer (buffer-name sbuffer)))))))
 
 (defcustom ess-swv-processor 'sweave
   "Processor to use for weaving and tangling.

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -87,7 +87,6 @@
 (declare-function ess-process-live-p "ess-inf")
 (declare-function ess-process-put "ess-inf")
 (declare-function ess-send-string "ess-inf")
-(declare-function ess-show-buffer "ess-inf")
 (declare-function ess-switch-to-ESS "ess-inf")
 (declare-function ess-wait-for-process "ess-inf")
 (declare-function inferior-ess-run-callback "ess-inf")
@@ -1039,7 +1038,7 @@ See the more info at https://code.google.com/p/ess-tracebug/#Work-Flow"
       (ring-insert ess--dbg-backward-ring (point-marker)) ;; insert in backward ring ;;todo: check if the marker to this (close by?) position is already in the ring
       (setq input-point (ring-ref ess--dbg-forward-ring 0)))
     (when (marker-buffer input-point) ;; todo: give a message here if buff is not found
-      (switch-to-buffer (marker-buffer input-point))
+      (pop-to-buffer-same-window (marker-buffer input-point))
       (when (marker-position input-point)
         (goto-char (marker-position input-point))))
     (while  (eq (event-basic-type  (event-basic-type (setq ev (read-event)))) com-char)
@@ -1051,7 +1050,7 @@ See the more info at https://code.google.com/p/ess-tracebug/#Work-Flow"
         ;; get it from forward-ring
         (setq input-point (ring-ref ess--dbg-forward-ring ring-el)) )
       (when (marker-buffer input-point)
-        (switch-to-buffer (marker-buffer input-point))
+        (pop-to-buffer-same-window (marker-buffer input-point))
         (when (marker-position input-point)
           (goto-char (marker-position input-point)))))
     (push ev unread-command-events)))
@@ -1070,10 +1069,10 @@ of the ring."
          (ring-el 0))
     (if (ess--dbg-is-active-p)
         (progn
-          (switch-to-buffer (marker-buffer ess--dbg-current-debug-position))
+          (pop-to-buffer-same-window (marker-buffer ess--dbg-current-debug-position))
           (goto-char (marker-position ess--dbg-current-debug-position ))
           (back-to-indentation))
-      (switch-to-buffer (marker-buffer debug-point))
+      (pop-to-buffer-same-window (marker-buffer debug-point))
       (goto-char (marker-position debug-point)))
     (while  (eq (event-basic-type (setq ev (read-event))) com-char)
       (if (memq 'shift (event-modifiers ev))
@@ -1081,7 +1080,7 @@ of the ring."
         (setq ring-el (1+ ring-el)))
       (setq debug-point (ring-ref ess--dbg-backward-ring ring-el))
       (when (marker-buffer debug-point)
-        (switch-to-buffer (marker-buffer debug-point))
+        (pop-to-buffer-same-window (marker-buffer debug-point))
         (when (marker-position debug-point)
           (goto-char (marker-position debug-point)))))
     (push ev unread-command-events)))
@@ -1353,7 +1352,7 @@ prompts."
           (goto-char (point-min))
           (let ((case-fold-search nil))
             (when (re-search-forward "Error\\(:\\| +in\\)" nil t)
-              (ess-show-buffer (process-buffer proc))))
+              (display-buffer (process-buffer proc))))
           (goto-char (point-min))
           ;; First long + + in the output mirrors the sent input by the user and
           ;; is unnecessary in nowait case. A single + can be a continuation in
@@ -1529,7 +1528,7 @@ the output into *ess.dbg* buffer."
        (ess--debug-keys-message-string))
       (unless match-jump
         ;; no source reference, simply show the inferiro
-        (ess-show-buffer pbuf)))
+        (display-buffer pbuf)))
 
     (when match-selection ;(and (not was-in-recover) match-selection)
       (ess-electric-selection t))))
@@ -1599,19 +1598,19 @@ associated buffer. If FILE is nil return nil."
         (lpn ess-local-process-name))
     (when mrk
       (let ((buf (marker-buffer mrk)))
-	    (if (not other-window)
-	        (switch-to-buffer buf)
-	      (let ((this-frame (window-frame (get-buffer-window (current-buffer)))))
-	        (display-buffer buf)
-	        ;; simple save-frame-excursion
-	        (unless (eq this-frame (window-frame (get-buffer-window buf t)))
-	          (ess-select-frame-set-input-focus this-frame))))
-	    ;; set or re-set to lpn as this is the process with debug session on
-	    (with-current-buffer buf
-	      (setq ess-local-process-name lpn)
-	      (goto-char mrk)
+	(if (not other-window)
+	    (pop-to-buffer-same-window buf)
+	  (let ((this-frame (window-frame (get-buffer-window (current-buffer)))))
+	    (display-buffer buf)
+	    ;; simple save-frame-excursion
+	    (unless (eq this-frame (window-frame (get-buffer-window buf t)))
+	      (ess-select-frame-set-input-focus this-frame))))
+	;; set or re-set to lpn as this is the process with debug session on
+	(with-current-buffer buf
+	  (setq ess-local-process-name lpn)
+	  (goto-char mrk)
           (set-window-point (get-buffer-window buf) mrk))
-	    buf))))
+	buf))))
 
 ;; temporary, hopefully org folks implement something similar
 (defvar org-babel-tangled-file nil)
@@ -1751,7 +1750,7 @@ This is the value of `next-error-function' in *ess.dbg* buffers."
           (set-marker ess--dbg-current-ref (line-end-position))
           (set-marker overlay-arrow-position (line-beginning-position))
           (setq dbuff (ess--dbg-find-buffer  (car loc)))
-          (switch-to-buffer dbuff)
+          (pop-to-buffer-same-window dbuff)
           (save-restriction
             (widen)
             (goto-char 1)


### PR DESCRIPTION
Now users can configure 'display-buffer-alist' to customize where and
how ESS's various buffers are displayed. This also deprecates the
existing ESS-specific framework we have in favor of offloading that
responsibility to Emacs. The docstrings of inferior-ess-same-window and
inferior-ess-own-frame were modified to include instructions on how to
take advantage of 'display-buffer-alist'.

This doesn't touch the `ess-help` display stuff, but we might also think about deprecating those variables (e.g. `ess-help-own-frame` and friends) and relying on `display-buffer` framework.

I think the only user-visible change this has if they haven't customized anything is that M-x R will now open a new window if the frame only has one window, just like we already do if you do e.g. C-c C-c in an R-mode buffer.

Closes #687 