### PR TITLE
list all functions in module

### DIFF
--- a/etc/ess-julia.jl
+++ b/etc/ess-julia.jl
@@ -76,9 +76,9 @@ end
 # add                           Function
 # free                          Function
 function components(m::Module)
-    for v in sort(names(m))
+    for v in sort(names(m, all=true, imported=true))
         s = string(v)
-        if isdefined(m,v)
+        if !startswith(s, "#") && isdefined(m,v)
             println(rpad(s, 30), summary(Core.eval(m,v)))
         end
     end


### PR DESCRIPTION
update julia completion to list all the imported functions in module, like 
the REPL does. Filters out what I assume are compiler generated symbols
starting with "#", seems to work for now

#745 