### PR TITLE
Home directory installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ ess-[1-9]*.[0-9][0-9]-[0-9]
 ess-[1-9]*.[0-9][0-9]-[0-9][-.]???
 lisp/julia-mode.el
 lisp/ess-autoloads.el
+lisp/dist
 tmp*
 .DS_Store
 ._.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ doc/ess.*
 doc/info/ess.info
 doc/readme.*
 doc/refcard/refcard.*
+doc/*.log
 *history
 *NEWS
 *VERSION
@@ -31,3 +32,4 @@ lisp/ess-autoloads.el
 tmp*
 .DS_Store
 ._.DS_Store
+Makeconf.local

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,6 @@ before_script:
 script:
 - emacs --version
 - R --version
+- cp Makeconf.local.template Makeconf.local
 - make all
 - make test

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,7 @@
+To install from source
+
+cp Makeconf.local.template Makeconf.local
+
+and set variables in Makeconf.local as necessary.  Then
+
+make install

--- a/Makeconf
+++ b/Makeconf
@@ -4,6 +4,15 @@
 ## 1. Edit Section 1 and 2 below
 ## 2. Execute: gmake install
 
+## To install ESS for yourself:
+## 1. cat > Makeconf.local -<<EOF
+##    PREFIX=/home/<user>/.local
+##    SITELISP=/home/<user>/.emacs.d/elpa
+##    INFODIR=$(LISPDIR)
+##    ETCDIR=$(LISPDIR)/etc
+##    EOF
+## 2. Execute: gmake install
+
 ## Section 1
 ## Installation variables for your emacs variant
 ##
@@ -17,14 +26,14 @@
 ## PREFIX(DESTDIR) Directory prepended to SITELISP, INFODIR, DOCDIR & ETCDIR
 ##                 Specify either PREFIX or DESTDIR to over-ride /usr
 DESTDIR=/usr
-PREFIX=$(DESTDIR)
+PREFIX ?= $(DESTDIR)
 
 ##__ GNU Emacs __
 EMACS ?= emacs
-SITELISP=$(PREFIX)/share/emacs/site-lisp
+SITELISP ?= $(PREFIX)/share/emacs/site-lisp
 LISPDIR=$(SITELISP)/ess
-INFODIR=$(PREFIX)/share/info
-ETCDIR =$(PREFIX)/share/emacs/etc/ess
+INFODIR ?= $(PREFIX)/share/info
+ETCDIR  ?= $(PREFIX)/share/emacs/etc/ess
 
 ##__ XEmacs __
 #EMACS=$(PREFIX)/bin/xemacs
@@ -50,7 +59,7 @@ ETCDIR =$(PREFIX)/share/emacs/etc/ess
 # ETCDIR=$(PREFIX)/ess-mode/etc
 
 ## the following command is the same for recent versions of both Emacs and XEmacs
-EMACSBATCH = $(EMACS) -batch -no-site-file -no-init-file
+EMACSBATCH = $(EMACS) -Q --batch
 
 ## Section 2
 ## Installation variables for your unix variant

--- a/Makeconf
+++ b/Makeconf
@@ -1,18 +1,5 @@
 ####======= Common Declarations for *all* ESS -*-Makefile-*-s ==========
 
-## To install ESS for all users on your unix system:
-## 1. Edit Section 1 and 2 below
-## 2. Execute: gmake install
-
-## To install ESS for yourself:
-## 1. cat > Makeconf.local -<<EOF
-##    PREFIX=/home/<user>/.local
-##    SITELISP=/home/<user>/.emacs.d/elpa
-##    INFODIR=$(LISPDIR)
-##    ETCDIR=$(LISPDIR)/etc
-##    EOF
-## 2. Execute: gmake install
-
 ## Section 1
 ## Installation variables for your emacs variant
 ##
@@ -25,38 +12,12 @@
 ## ETCDIR          Destination of script and icon files
 ## PREFIX(DESTDIR) Directory prepended to SITELISP, INFODIR, DOCDIR & ETCDIR
 ##                 Specify either PREFIX or DESTDIR to over-ride /usr
-DESTDIR=/usr
-PREFIX ?= $(DESTDIR)
-
-##__ GNU Emacs __
-EMACS ?= emacs
-SITELISP ?= $(PREFIX)/share/emacs/site-lisp
+PREFIX=$$HOME/.local
+EMACS=emacs
+SITELISP=$$HOME/.emacs.d/elpa
 LISPDIR=$(SITELISP)/ess
-INFODIR ?= $(PREFIX)/share/info
-ETCDIR  ?= $(PREFIX)/share/emacs/etc/ess
-
-##__ XEmacs __
-#EMACS=$(PREFIX)/bin/xemacs
-#SITELISP=$(PREFIX)/share/xemacs/site-packages/lisp
-#LISPDIR=$(SITELISP)/ess
-#INFODIR=$(PREFIX)/share/xemacs/site-packages/info
-#ETCDIR =$(PREFIX)/share/xemacs/site-packages/etc/ess
-
-##__ GNU Emacs __  for Mac OS X with NeXTstep (Cocoa or GNUstep)
-# PREFIX=/Applications/Emacs.app/Contents/Resources
-# EMACS=/Applications/Emacs.app/Contents/MacOS/Emacs
-# SITELISP=$(PREFIX)/site-lisp
-# LISPDIR=$(SITELISP)/ess
-# INFODIR=/usr/local/info
-# ETCDIR =$(PREFIX)/etc/ess
-
-##__ Aquamacs __  (donated by Dan Knoepfle, Mar 26, 2011)
-# PREFIX=/Applications/Aquamacs.app/Contents/Resources/lisp/aquamacs/edit-modes
-# EMACS=/Applications/Aquamacs.app/Contents/MacOS/Aquamacs
-# SITELISP=/Applications/Aquamacs.app/Contents/Resources/lisp
-# LISPDIR=$(PREFIX)/ess-mode/lisp
-# INFODIR=/Applications/Aquamacs.app/Contents/Resources/info
-# ETCDIR=$(PREFIX)/ess-mode/etc
+INFODIR=$(LISPDIR)
+ETCDIR=$(LISPDIR)/etc
 
 ## the following command is the same for recent versions of both Emacs and XEmacs
 EMACSBATCH = $(EMACS) -Q --batch

--- a/Makeconf.local.template
+++ b/Makeconf.local.template
@@ -1,0 +1,2 @@
+## overrides variables from Makeconf here, e.g.,
+# SITELISP=$$HOME/.emacs.d/lisp

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 ## Top Level Makefile
 
 ## Before making changes here, please take a look at Makeconf
+LOCAL_CONF := $(strip $(wildcard ./Makeconf.local))
+ifneq ($(LOCAL_CONF),)
+	include ./Makeconf.local
+endif
 include ./Makeconf
 
 ## 'all' is the default target, i.e. 'make' and 'make all' are the same.
@@ -32,6 +36,7 @@ etc: version
 .PHONY: test
 test: version
 	cd test; $(EMACS) --script run-tests
+	cd lisp; $(MAKE) test-install
 
 generate-indent-cases:
 	cd test; $(EMACS) --script generate-indent-cases

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ etc: version
 .PHONY: test
 test: version
 	cd test; $(EMACS) --script run-tests
-	cd lisp; $(MAKE) test-install
+	cd lisp; $(MAKE) install-dry
 
 generate-indent-cases:
 	cd test; $(EMACS) --script generate-indent-cases

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 ## Top Level Makefile
 
-## Before making changes here, please take a look at Makeconf
-LOCAL_CONF := $(strip $(wildcard ./Makeconf.local))
-ifneq ($(LOCAL_CONF),)
-	include ./Makeconf.local
-endif
 include ./Makeconf
+LOCAL_CONF := $(strip $(wildcard ./Makeconf.local))
+ifeq ($(LOCAL_CONF),)
+$(error "No ./Makeconf.local found.  Please read INSTALL")
+else
+include ./Makeconf.local
+endif
 
 ## 'all' is the default target, i.e. 'make' and 'make all' are the same.
 .PHONY: all install uninstall

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,6 +2,10 @@
 ###
 
 ## Before making changes here, please take a look at Makeconf
+LOCAL_CONF := $(strip $(wildcard ../Makeconf.local))
+ifneq ($(LOCAL_CONF),)
+	include ../Makeconf.local
+endif
 include ../Makeconf
 
 # program to convert .texi{nfo} to .html

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,12 +1,13 @@
 ### Makefile - for DOCUMENTATION (./doc) of ESS distribution.
 ###
 
-## Before making changes here, please take a look at Makeconf
-LOCAL_CONF := $(strip $(wildcard ../Makeconf.local))
-ifneq ($(LOCAL_CONF),)
-	include ../Makeconf.local
-endif
 include ../Makeconf
+LOCAL_CONF := $(strip $(wildcard ../Makeconf.local))
+ifeq ($(LOCAL_CONF),)
+$(error "No ../Makeconf.local found.  Please read INSTALL")
+else
+include ../Makeconf.local
+endif
 
 # program to convert .texi{nfo} to .html
 #MM: use makeinfo (i.e. MAKEHTML from above) which is more

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -2,6 +2,10 @@
 ###
 
 ## Before making changes here, please take a look at Makeconf
+LOCAL_CONF := $(strip $(wildcard ../Makeconf.local))
+ifneq ($(LOCAL_CONF),)
+	include ../Makeconf.local
+endif
 include ../Makeconf
 
 # In ../Makefile we already construct the  ESSR-VERSION  file :

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -1,12 +1,13 @@
 ### Makefile - for scripts and icons (./etc) of ESS distribution.
 ###
 
-## Before making changes here, please take a look at Makeconf
-LOCAL_CONF := $(strip $(wildcard ../Makeconf.local))
-ifneq ($(LOCAL_CONF),)
-	include ../Makeconf.local
-endif
 include ../Makeconf
+LOCAL_CONF := $(strip $(wildcard ../Makeconf.local))
+ifeq ($(LOCAL_CONF),)
+$(error "No ../Makeconf.local found.  Please read INSTALL")
+else
+include ../Makeconf.local
+endif
 
 # In ../Makefile we already construct the  ESSR-VERSION  file :
 # ESSR_VERSION = $(shell cat ESSR-VERSION)

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -28,7 +28,6 @@ NOWEAVE=noweave
 COMPILE = $(EMACSBATCH) --directory . -f batch-byte-compile
 
 ELS = $(wildcard *.el obsolete/*.el)
-ELS := $(filter-out ess-autoloads.el, $(ELS))
 ELC = $(ELS:.el=.elc)
 
 PKBUILD:=2.3
@@ -52,35 +51,20 @@ dist/package.out:
 	$(INSTALLDIR) dist/recipes
 	if [ ! -s "dist/recipes/ess" ] ; then \
 	  cd dist/recipes ; curl -sLOk https://raw.githubusercontent.com/melpa/melpa/master/recipes/ess ; fi
-	$(EMACSBATCH) -L dist/package-build-$(PKBUILD) \
-	--eval "(require 'package-build)" \
-	--eval "(setq debug-on-error t)" \
-	--eval "(setq package-user-dir (expand-file-name \"dist\"))" \
-	--eval "(package-initialize)" \
-	--eval "(add-to-list 'package-archives '(\"melpa\" . \"http://melpa.org/packages/\"))" \
-	--eval "(package-refresh-contents)" \
-	--eval "(setq rcp (package-recipe-lookup \"ess\"))" \
-	--eval "(unless (file-exists-p package-build-archive-dir) \
-	           (make-directory package-build-archive-dir))" \
-	--eval "(unless (zerop (length \"$(TRAVIS_PULL_REQUEST_SLUG)\")) \
-	          (oset rcp :repo \"$(TRAVIS_PULL_REQUEST_SLUG)\") \
-	          (oset rcp :branch \"$(TRAVIS_PULL_REQUEST_BRANCH)\") \
-	          (oset rcp :commit \"$(TRAVIS_PULL_REQUEST_SHA)\"))" \
-	--eval "(package-build--package rcp (package-build--checkout rcp))" \
-	--eval "(package-install-file (car (file-expand-wildcards (concat package-build-archive-dir \"ess*.tar\"))))" > dist/package.out 2>&1
+	$(EMACSBATCH) -L dist/package-build-$(PKBUILD) -l tmp/ess-package.el > dist/package.out 2>&1
 
-.PHONY: test-install
-test-install:
+.PHONY: install-dry
+install-dry:
 	-rm -f dist/package.out
-	$(MAKE) test-install-1
+	$(MAKE) install-dry-1
 
-test-install-1: dist/package.out
+install-dry-1: dist/package.out
 	@! ( cat dist/package.out | egrep -a "Error: " )
 
-install: dist dist/package.out ess-autoloads.el
+install: dist install-dry ess-autoloads.el
 	-$(INSTALLDIR) $(LISPDIR)
 	$(INSTALL) dist/ess-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9].*/ess-pkg.el $(LISPDIR)
-	$(INSTALL) $(ELS) ess-autoloads.el $(LISPDIR)
+	$(INSTALL) $(ELS) $(LISPDIR)
 	$(INSTALL) $(ELC) $(LISPDIR)
 	if [ -f /etc/debian_version -a -n "$(SITELISP)" -a ! -f "$(SITELISP)/ess-site.el" ] ; \
 	then \

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -1,12 +1,13 @@
 ### Makefile - for compiled e-lisp of ESS distribution.
 ###
 
-## Before making changes here, please take a look at Makeconf
-LOCAL_CONF := $(strip $(wildcard ../Makeconf.local))
-ifneq ($(LOCAL_CONF),)
-	include ../Makeconf.local
-endif
 include ../Makeconf
+LOCAL_CONF := $(strip $(wildcard ../Makeconf.local))
+ifeq ($(LOCAL_CONF),)
+$(error "No ../Makeconf.local found.  Please read INSTALL")
+else
+include ../Makeconf.local
+endif
 
 ## For noweb extraction of code and documentation.
 
@@ -65,7 +66,7 @@ install: dist install-dry ess-autoloads.el
 	-$(INSTALLDIR) $(LISPDIR)
 	$(INSTALL) dist/ess-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9].*/ess-pkg.el $(LISPDIR)
 	$(INSTALL) $(ELS) $(LISPDIR)
-	$(INSTALL) $(ELC) $(LISPDIR)
+	$(INSTALL) $(filter-out ess-autoloads.elc, $(ELC)) $(LISPDIR)
 	if [ -f /etc/debian_version -a -n "$(SITELISP)" -a ! -f "$(SITELISP)/ess-site.el" ] ; \
 	then \
 		ln -s $(LISPDIR)/ess-site.el $(SITELISP)/ess-site.el ; \
@@ -105,7 +106,7 @@ julia-mode.el:
 
 ess-julia.elc: julia-mode.elc
 
-ess-autoloads.el: $(ELS)
+ess-autoloads.el: $(filter-out ess-autoloads.el, $(ELS))
 	$(EMACSBATCH) --eval "(package-initialize)" --eval "(package-generate-autoloads \"ess\" \".\")"
 
 ### File Dependencies

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -2,6 +2,10 @@
 ###
 
 ## Before making changes here, please take a look at Makeconf
+LOCAL_CONF := $(strip $(wildcard ../Makeconf.local))
+ifneq ($(LOCAL_CONF),)
+	include ../Makeconf.local
+endif
 include ../Makeconf
 
 ## For noweb extraction of code and documentation.
@@ -27,6 +31,8 @@ ELS = $(wildcard *.el obsolete/*.el)
 ELS := $(filter-out ess-autoloads.el, $(ELS))
 ELC = $(ELS:.el=.elc)
 
+PKBUILD:=2.3
+
 # ESSR_VER =`cat ../etc/ESSR-VERSION`
 ##ESSR_VER = $(shell cat ../etc/ESSR-VERSION)
 
@@ -37,10 +43,44 @@ all: julia-mode.el $(ELC) ess-custom.el ess-autoloads.el
 .PHONY: dist
 dist: all
 
-install: dist
+dist/package.out: 
+	$(INSTALLDIR) dist
+	if [ ! -s "dist/$(PKBUILD).tar.gz" ] ; then \
+	  cd dist ; curl -sLOk https://github.com/melpa/package-build/archive/$(PKBUILD).tar.gz ; fi
+	cd dist ; tar xfz $(PKBUILD).tar.gz
+	cd dist/package-build-$(PKBUILD) ; make -s loaddefs
+	$(INSTALLDIR) dist/recipes
+	if [ ! -s "dist/recipes/ess" ] ; then \
+	  cd dist/recipes ; curl -sLOk https://raw.githubusercontent.com/melpa/melpa/master/recipes/ess ; fi
+	$(EMACSBATCH) -L dist/package-build-$(PKBUILD) \
+	--eval "(require 'package-build)" \
+	--eval "(setq debug-on-error t)" \
+	--eval "(setq package-user-dir (expand-file-name \"dist\"))" \
+	--eval "(package-initialize)" \
+	--eval "(add-to-list 'package-archives '(\"melpa\" . \"http://melpa.org/packages/\"))" \
+	--eval "(package-refresh-contents)" \
+	--eval "(setq rcp (package-recipe-lookup \"ess\"))" \
+	--eval "(unless (file-exists-p package-build-archive-dir) \
+	           (make-directory package-build-archive-dir))" \
+	--eval "(unless (zerop (length \"$(TRAVIS_PULL_REQUEST_SLUG)\")) \
+	          (oset rcp :repo \"$(TRAVIS_PULL_REQUEST_SLUG)\") \
+	          (oset rcp :branch \"$(TRAVIS_PULL_REQUEST_BRANCH)\") \
+	          (oset rcp :commit \"$(TRAVIS_PULL_REQUEST_SHA)\"))" \
+	--eval "(package-build--package rcp (package-build--checkout rcp))" \
+	--eval "(package-install-file (car (file-expand-wildcards (concat package-build-archive-dir \"ess*.tar\"))))" > dist/package.out 2>&1
+
+.PHONY: test-install
+test-install:
+	-rm -f dist/package.out
+	$(MAKE) test-install-1
+
+test-install-1: dist/package.out
+	@! ( cat dist/package.out | egrep -a "Error: " )
+
+install: dist dist/package.out ess-autoloads.el
 	-$(INSTALLDIR) $(LISPDIR)
-	$(INSTALL) $(ELS) $(LISPDIR)
-	$(INSTALL) ess-autoloads.el $(LISPDIR)
+	$(INSTALL) dist/ess-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9].*/ess-pkg.el $(LISPDIR)
+	$(INSTALL) $(ELS) ess-autoloads.el $(LISPDIR)
 	$(INSTALL) $(ELC) $(LISPDIR)
 	if [ -f /etc/debian_version -a -n "$(SITELISP)" -a ! -f "$(SITELISP)/ess-site.el" ] ; \
 	then \
@@ -58,8 +98,10 @@ uninstall:
 clean:
 	rm -f $(ELC)
 	rm -f ess-autoloads.el
+	rm -rf dist
 
 distclean: clean
+
 # and potentially more
 
 ### Targets below here are only for developers - and these must have perl
@@ -79,13 +121,8 @@ julia-mode.el:
 
 ess-julia.elc: julia-mode.elc
 
-ess-autoloads.el:
-	@printf	"\nGenerating $@\n"
-	$(EMACSBATCH) --eval "(progn\
-	(setq make-backup-files nil)\
-	(setq generated-autoload-file (expand-file-name \"$@\"))\
-	(setq find-file-visit-truename t)\
-	(update-directory-autoloads default-directory))"
+ess-autoloads.el: $(ELS)
+	$(EMACSBATCH) --eval "(package-initialize)" --eval "(package-generate-autoloads \"ess\" \".\")"
 
 ### File Dependencies
 

--- a/lisp/tmp/ess-package.el
+++ b/lisp/tmp/ess-package.el
@@ -1,0 +1,58 @@
+;;; ess-package.el --- user customization of ESS
+
+;; Copyright (C) 1993 David M. Smith
+;; Copyright (C) 1997--2010 A.J. Rossini, Richard M. Heiberger, Martin
+;;      Maechler, Kurt Hornik, Rodney Sparapani, and Stephen Eglen.
+;; Copyright (C) 2011--2018 A.J. Rossini, Richard M. Heiberger, Martin
+;;      Maechler, Kurt Hornik, Rodney Sparapani, Stephen Eglen,
+;;      Vitalie Spinu, and Lionel Henry.
+
+;; Author: David Smith <D.M.Smith@lancaster.ac.uk>
+;; Created: 12 Nov 1993
+;; Maintainer: ESS-core <ESS-core@r-project.org>
+;; Keywords: local
+
+;; This file is part of ESS
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; A copy of the GNU General Public License is available at
+;; https://www.r-project.org/Licenses/
+
+
+;;; Commentary:
+;; We reconstruct the melpa packaging logic to effect a melpa install directly
+;; from the github source.  Code entrypoint is `make install-dry' from the lisp
+;; subdirectory.
+
+;;; Code:
+
+(require 'package-build)
+(setq package-user-dir (expand-file-name "dist"))
+(package-initialize)
+(add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/")) ;; dependencies
+(package-refresh-contents)
+(setq rcp (package-recipe-lookup "ess"))
+(unless (file-exists-p package-build-archive-dir)
+  (make-directory package-build-archive-dir))
+(let ((slug (getenv "TRAVIS_PULL_REQUEST_SLUG"))
+      (branch (getenv "TRAVIS_PULL_REQUEST_BRANCH"))
+      (commit (getenv "TRAVIS_PULL_REQUEST_SHA")))
+  (when slug
+    (oset rcp :repo slug))
+  (when branch
+    (oset rcp :branch branch))
+  (when commit
+    (oset rcp :commit commit)))
+(let ((debug-on-error t))
+  (package-build--package rcp (package-build--checkout rcp))
+  (package-install-file (car (file-expand-wildcards 
+                              (concat package-build-archive-dir "ess*.tar")))))


### PR DESCRIPTION
Remove any suggestion that `Makeconf` should be edited.
Remove any suggestion that package can be installed to systemwide directories (a home directory install becomes the *only* option).
Add an `INSTALL` file with instructions for install.