### PR TITLE
Add links to help topics in help buffers

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -61,6 +61,12 @@ ess-gen-proc-buffer-name:project-or-directory. As the name suggests,
 these now rely on project.el (included with Emacs) rather than
 projectile.el, which is a third-party package.
 
+@item ESS[R] help pages now provide links to other help topics.
+This is similar with what you would see with, for example
+@code{options(help_type = ``html'')} but works with the plain-text
+version as well. This only works with @code{options(useFancyQuotes =
+TRUE)} (the default).
+
 @item ESS removed support for many unused languages.
 This includes old versions of S+, ARC, OMG, VST, and XLS.
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2668,7 +2668,6 @@ the variable `ess-help-own-frame' is non-nil."
   :type 'alist
   :package-version '(ess . "18.10"))
 
-
  ; Faces
 ;;;=====================================================
 

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -169,7 +169,6 @@ suplied, it is used instead of `inferior-ess-help-command'."
   (let ((inhibit-modification-hooks t)
         (inhibit-read-only t))
     (delete-region (point-min) (point-max))
-    (ess--help-major-mode)
     (let ((command (if (and command (string-match-p "%s" command))
                        (format command object)
                      command)))
@@ -179,7 +178,8 @@ suplied, it is used instead of `inferior-ess-help-command'."
       (ess-nuke-help-bs))
     (goto-char (point-min))
     (set-buffer-modified-p 'nil)
-    (setq truncate-lines nil)))
+    (setq truncate-lines nil)
+    (ess--help-major-mode)))
 
 (defun ess--help-kill-bogus-buffer-maybe (buffer)
   "Internal, try to kill bogus BUFFER with message. Return t if killed."


### PR DESCRIPTION
I like the links you get from the HTML help pages but I want to be able to view them in Emacs instead of a browser. This works fairly well by opening them up in eww in Emacs:

```R
if (Sys.getenv("INSIDE_EMACS") != ""){
  options(browser =
            function(url)
              system2("emacsclient",
                      paste0("--eval '(eww \"", url, "\")'")))
  options(help_type = "html")
}
```

but it's still slower than the plain text pages we serve by default.

This PR adds links to the plain text style pages. It works by searching for pairs of matching "fancy" (i.e. unicode) quotes ~and seeing if we know about a help topic for the word between them. If so,~ we add a button that links to the corresponding help page.

For all the help pages I tested, the slowdown as we regex-search through the buffer is not noticeable. I imagine if you find a super complicated or long buffer it might take a quarter of a second or something to add the links. ~So I added a defcustom to control this behavior.~
