### PR TITLE
Move a few files to lexical binding

### DIFF
--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -1,4 +1,4 @@
-;;; ess-r-completion.el --- R completion
+;;; ess-r-completion.el --- R completion  -*- lexical-binding: t; -*-
 ;;
 ;; Copyright (C) 2015 A.J. Rossini, Richard M. Heiberger, Martin Maechler, Kurt
 ;;      Hornik, Rodney Sparapani, Stephen Eglen and Vitalie Spinu.
@@ -86,8 +86,7 @@ to look up any doc strings."
            ;; Subtract 1 from window width since will cause a wraparound and
            ;; resize of the echo area.
            (W (1- (- (window-width (minibuffer-window))
-                     (+ 2 (length funname)))))
-           newdoc)
+                     (+ 2 (length funname))))))
       (setq doc
             (if (or (<= (length doc) W)
                     (null ess-eldoc-abbreviation-style)
@@ -277,7 +276,7 @@ To be used instead of ESS' completion engine for R versions >= 2.7.0."
 
 (defvar ess--cached-sp-objects nil)
 
-(defun ess--get-cached-completions (prefix &optional point)
+(defun ess--get-cached-completions (prefix &optional _point)
   (if (string-match-p "[]:$@[]" prefix)
       ;; call proc for objects
       (cdr (ess-r-get-rcompletions nil nil prefix))

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -1,4 +1,4 @@
-;;; ess-r-package.el --- Package development mode for R.
+;;; ess-r-package.el --- Package development mode for R.  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2011-2015 Lionel Henry, Vitalie Spinu, A.J. Rossini, Richard
 ;;      M. Heiberger, Martin Maechler, Kurt Hornik, Rodney Sparapani, and
@@ -558,7 +558,7 @@ package mode. Use this function if state of the buffer such as
 
 
 ;;;*;;; Deprecated variables and functions
-(defun ess-developer (&optional val)
+(defun ess-developer (&optional _val)
   (error "As of ESS 16.04, `ess-developer' is deprecated. Use `ess-r-set-evaluation-env' instead"))
 
 (defalias 'ess-toggle-developer 'ess-developer)

--- a/lisp/ess-rd.el
+++ b/lisp/ess-rd.el
@@ -1,4 +1,4 @@
-;; ess-rd.el --- Support for editing R documentation (Rd) source
+;; ess-rd.el --- Support for editing R documentation (Rd) source  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 1997--2005  A.J. Rossini, Richard M. Heiberger, Martin
 ;;      Maechler, Kurt Hornik, Rodney Sparapani, and Stephen Eglen.

--- a/lisp/ess-rdired.el
+++ b/lisp/ess-rdired.el
@@ -1,4 +1,4 @@
-;;; ess-rdired.el --- prototype object browser for R, looks like dired mode.
+;;; ess-rdired.el --- prototype object browser for R, looks like dired mode.  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2002--2004 A.J. Rossini, Richard M. Heiberger, Martin
 ;;      Maechler, Kurt Hornik, Rodney Sparapani, and Stephen Eglen.
@@ -381,9 +381,8 @@ User is queried first to check that objects should really be deleted."
   (interactive)
   (kill-buffer ess-rdired-buffer))
 
-(defun ess-rdired-revert-buffer (ignore noconfirm)
-  "Update the buffer list (in case object list has changed).
-Arguments IGNORE and NOCONFIRM currently not used."
+(defun ess-rdired-revert-buffer ()
+  "Update the buffer list (in case object list has changed)."
   (ess-rdired))
 
 (defun ess-rdired-help ()

--- a/test/ess-inf-tests.el
+++ b/test/ess-inf-tests.el
@@ -40,6 +40,22 @@
                          (buffer-string))
                        "[1] TRUE")))))
 
+(ert-deftest ess-async-command ()
+  ;; (ess-async-command "{cat(1:5);Sys.sleep(5);cat(2:6)}\n" nil (get-process "R")
+  ;;                    (lambda (proc) (message "done")))
+  ;; (ess-async-command "{cat(1:5);Sys.sleep(5);cat(2:6)}\n" nil (get-process "R")
+  ;;                    (lambda (proc) (message "done"))
+  ;;                    t)
+  ;; (ess-async-command "{cat(1:5);Sys.sleep(5);cat(2:6)}\n" nil (get-process "R")
+  ;;                    (lambda (proc) (message "done"))
+  (with-r-running nil
+    (let ((output-buffer (get-buffer-create " *ess-async-text-command-output*"))
+          output)
+      (ess-async-command "{cat(1:5);Sys.sleep(0.5);cat(2:6)}\n" output-buffer (get-process "R")
+                         (lambda (proc string) (setq output string)))
+      (sleep-for 0.6)
+      (should (string= "2 3 4 5 6> " output)))))
+
 (ert-deftest ess-run-presend-hooks-test ()
   (with-r-running nil
     (let ((ess-presend-filter-functions (list (lambda (string) "\"bar\""))))


### PR DESCRIPTION
The changes aren't as big as github makes them look. I removed a `let` binding in inferior-ess which changes the indentation for a large part of that big function.

I think the biggest change is `inferior-ess-make-comint`. I think the way the code was written we'd never reach one part of the if statement that calls that function so I collapsed all that (hence the removed let binding). Seems to work on my end.

Other than that, it's mostly cleaning up unused variables and arguments.