### PR TITLE
Compilation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ etc: version
 
 .PHONY: test
 test: version
+	cd lisp; $(MAKE) test
 	cd test; $(EMACS) --script run-tests
 
 generate-indent-cases:

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -51,6 +51,23 @@ uninstall:
 distclean clean:
 	rm -f $(ELC) ess-autoloads.el julia-mode.el .dependencies
 
+.PHONY: compile
+compile:
+	! ( $(COMPILE) $(shell git ls-files *.el) 2>&1 | \
+	  awk '{ \
+	         if (/^ /) { \
+	           gsub(/^ +/, " ", $$0); \
+	           printf "%s", $$0 \
+	         } else { \
+	           printf "\n%s", $$0 \
+	         } \
+	       }' \
+	  | egrep -a "not known|Error|free variable|error for|Use of gv-ref" )
+	rm -f $(ELC)
+
+.PHONY: test
+test: compile
+
 
 ### File Targets
 


### PR DESCRIPTION
I am unaware of a `make compile` target.  As a C dev, I continually `make compile` after a string of changes to ensure sanity.  Likewise, the unconventional incantation in `lisp/Makefile` has served me in good stead in the past for developing elisp.

@jabranham I agree the incantation isn't the "best practices" way to `make compile`.  Can you help?