### PR TITLE
Reappeal ess-r-source-mode to make xref useful (was #475 xref backend for R)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - sudo apt-get install -y --no-install-recommends --allow-unauthenticated
       r-recommended
       r-cran-roxygen2
+      r-cran-testthat
       texinfo
       texlive-latex-base
       texlive-latex-recommended

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,9 @@ etc: version
 	cd etc; $(MAKE)
 
 .PHONY: test
-test: version
+test: version all
 	cd test; $(EMACS) --script run-tests
+	cd test; Rscript test-ESSR.R
 
 generate-indent-cases:
 	cd test; $(EMACS) --script generate-indent-cases

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1501,6 +1501,9 @@ line starts with the roxy prefix.")
 
 ;; SJE -- this should not be defcustom - user does not set it.
 (defvaralias 'ess-current-process-name 'ess-local-process-name)
+
+;; should this have been make-buffer-local-variable?
+;; we always setq-local `ess-local-process-name' per buffer
 (defvar ess-local-process-name nil
   "The name of the ESS process associated with the current buffer.")
 (put 'ess-local-process-name 'risky-local-variable t)

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -2317,12 +2317,11 @@ If exclude-first is non-nil, don't return objects in first positon (.GlobalEnv).
 
 (defun ess-get-words-from-vector (command &optional no-prompt-check wait proc)
   "Evaluate the S command COMMAND, which returns a character vector.
-Return the elements of the result of COMMAND as an alist of
+Return the elements of the result of COMMAND as a list of
 strings. COMMAND should have a terminating newline.
 NO-PROMPT-CHECK, WAIT, and PROC are passed to `ess-command'.
-FILTER may be the keyword 'non-... or nil. To avoid truncation of
-long vectors, wrap your command (%s) like this, or a version with
-explicit options(max.print=1e6): \"local({ out <- try({%s});
+To avoid truncation of long vectors, wrap your command (%s) like this, 
+or a version with explicit options(max.print=1e6): \"local({ out <- try({%s});
 print(out, max=1e6) })\n\"."
   (unless proc
     (inferior-ess-force))

--- a/lisp/ess-r-flymake.el
+++ b/lisp/ess-r-flymake.el
@@ -163,9 +163,13 @@ into a list and call REPORT-FN on it."
        for msg = (match-string 4)
        for (beg . end) = (let ((line (string-to-number (match-string 1)))
                                (col (string-to-number (match-string 2))))
-                           (flymake-diag-region src-buffer line col))
+                           (if (fboundp 'flymake-diag-region)
+                               (flymake-diag-region src-buffer line col)
+                             (error "flymake-diag-region unbound (emacs-26 required)")))
        for type = (ess-r--flymake-msg-type (match-string 3))
-       collect (flymake-make-diagnostic src-buffer beg end type msg)
+       collect (if (fboundp 'flymake-make-diagnostic)
+                   (flymake-make-diagnostic src-buffer beg end type msg)
+                 (error "flymake-make-diagnostic unbound (emacs-26 required)"))
        into diags
        finally (funcall report-fn diags)))))
 
@@ -182,7 +186,9 @@ REPORT-FN is flymake's callback function."
            (not (ess-process-live-p)))
       (progn
         (funcall report-fn nil)
-        (mapc #'delete-overlay (flymake--overlays)))
+        (if (fboundp 'flymake--overlays)
+            (mapc #'delete-overlay (flymake--overlays))
+          (error "flymake--overlays unbound (emacs-26 required)")))
     (let ((src-buffer (current-buffer)))
       (setq ess-r--flymake-proc
             (make-process

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -59,13 +59,6 @@ See also `ess-r-set-evaluation-env' and `ess-r-evaluation-env'."
 Cons cell of two strings. CAR is the package name active in the
 current buffer. CDR is the path to its source directory.")
 
-(define-obsolete-variable-alias 'ess-r-package-library-path 'ess-r-package-library-paths "v18.04")
-(defcustom ess-r-package-library-paths nil
-  "Default path to find user packages.
-Can be either a string specifying a directory or a list of directories."
-  :group 'ess-r-package-library-paths
-  :type `(choice string (repeat string)))
-
 (defvar ess-r-package-root-file "DESCRIPTION"
   "Presence of this file indicates the project's root.")
 
@@ -90,6 +83,10 @@ a R package.")
 All children of these directories are also considered source
 containing directories.  Use `ess-r-package-source-dirs' to get
 all source dirs recursively within the current package.")
+
+(defsubst ess-r-package-library-paths ()
+  "Return output of .libPaths()"
+  (ess-get-words-from-vector ".libPaths()\n"))
 
 
 ;;;*;;; Package Detection
@@ -215,9 +212,7 @@ Root is determined by locating `ess-r-package-root-file'."
   (interactive)
   (let* ((pkg-path (read-directory-name
                     "Path: " (or (ess-r-package--find-package-path)
-                                 (if (stringp ess-r-package-library-paths)
-                                     ess-r-package-library-paths
-                                   (car ess-r-package-library-paths)))
+                                 (car (ess-r-package-library-paths)))
                     nil t))
          (pkg-name (ess-r-package--find-package-name pkg-path))
          (pkg-info (cons pkg-name pkg-path)))
@@ -425,9 +420,7 @@ Default location is determined by the first element of
 `ess-r-package-library-paths'."
   (interactive)
   (let* ((command "devtools::create(\"%s\")")
-         (default-path (if (stringp ess-r-package-library-paths)
-                           ess-r-package-library-paths
-                         (car ess-r-package-library-paths)))
+         (default-path (car (ess-r-package-library-paths)))
          (path (read-directory-name "Path: " default-path)))
     (ess-eval-linewise (format command path))))
 

--- a/lisp/ess-r-xref.el
+++ b/lisp/ess-r-xref.el
@@ -27,13 +27,7 @@
 
 ;;; Code:
 
-(when (>= emacs-major-version 25)
-  (require 'subr-x)
-  (require 'xref))
-;; Kludge to silence the byte compiler until we drop support for Emacs 24.
-(declare-function xref-make "xref")
-(declare-function xref-make-buffer-location "xref")
-(declare-function xref-make-file-location "xref")
+(require 'xref)
 (require 'ess-inf)
 (require 'ess-utils)
 (require 'ess-r-package)
@@ -56,7 +50,7 @@ srcrefs point to temporary locations."
 
 (cl-defmethod xref-backend-definitions ((_backend (eql ess-r)) symbol)
   (inferior-ess-r-force)
-  (when (and (eq major-mode 'ess-mode) (string= ess-language "S"))
+  (when (and (eq major-mode 'ess-r-mode) (string= ess-language "S"))
     (let ((tempfile (make-temp-file ".ess_attach_libs")))
       (with-temp-file tempfile
         (insert (buffer-string)))

--- a/test/ESSR/test-completion.R
+++ b/test/ESSR/test-completion.R
@@ -1,0 +1,8 @@
+context("completion.R")
+test_that(".ess_fn_pkg", {
+    library(devtools)
+    expect_output(.ess_fn_pkg("eval"), "^base$")
+    expect_output(.ess_fn_pkg("sqrt"), NA)
+    expect_output(.ess_fn_pkg("adfljsdfl"), NA)
+    expect_output(.ess_fn_pkg("use_testthat"), "^devtools$")
+})

--- a/test/ESSR/test-completion.R
+++ b/test/ESSR/test-completion.R
@@ -1,6 +1,5 @@
 context("completion.R")
 test_that(".ess_fn_pkg", {
-    library(devtools)
     expect_output(.ess_fn_pkg("eval"), "^base$")
     expect_output(.ess_fn_pkg("sqrt"), NA)
     expect_output(.ess_fn_pkg("adfljsdfl"), NA)

--- a/test/ESSR/test-completion.R
+++ b/test/ESSR/test-completion.R
@@ -4,5 +4,5 @@ test_that(".ess_fn_pkg", {
     expect_output(.ess_fn_pkg("eval"), "^base$")
     expect_output(.ess_fn_pkg("sqrt"), NA)
     expect_output(.ess_fn_pkg("adfljsdfl"), NA)
-    expect_output(.ess_fn_pkg("use_testthat"), "^devtools$")
+    expect_output(.ess_fn_pkg("history"), "^utils$")
 })

--- a/test/ess-inf-tests.el
+++ b/test/ess-inf-tests.el
@@ -9,7 +9,7 @@
 ;;; Startup
 
 (defun ess-r-tests-startup-output ()
-  (let* ((proc (ess-vanila-R))
+  (let* ((proc (ess-vanilla-R))
          (output-buffer (process-buffer proc)))
     (unwind-protect
         (with-current-buffer output-buffer
@@ -194,30 +194,32 @@ some. text
   (skip-unless (and (or (executable-find "R-3.2.1")
                         (getenv "CONTINUOUS_INTEGRATION"))
                     (> emacs-major-version 25)))
-  (should
-   (string= "*R-3.2.1:1*"
-            (let ((ess-use-inferior-program-in-buffer-name t)
-                  (ess-plain-first-buffername nil)
-                  (ess-gen-proc-buffer-name-function #'ess-gen-proc-buffer-name:simple)
-                  (ess-ask-for-ess-directory nil)
-                  (name))
-              (R-3.2.1)
-              (setq name (buffer-name))
-              (set-process-query-on-exit-flag (get-buffer-process (current-buffer)) nil)
-              (kill-process (get-buffer-process name))
-              ;; FIXME: Does not work in batch mode
-              ;; (kill-buffer name)
-              name)))
-  (should
-   (string= "*R-3.2.1:2*"
-            (let ((ess-use-inferior-program-name-in-buffer-name t)
-                  (ess-plain-first-buffername nil)
-                  (ess-gen-proc-buffer-name-function #'ess-gen-proc-buffer-name:simple)
-                  (ess-ask-for-ess-directory nil)
-                  (name))
-              (R-3.2.1)
-              (setq name (buffer-name))
-              (set-process-query-on-exit-flag (get-buffer-process (current-buffer)) nil)
-              (kill-process (get-buffer-process name))
-              ;; (kill-buffer name)
-              name))))
+  (let (to-kill)
+    (should
+     (string= "*R-3.2.1:1*"
+              (let ((ess-use-inferior-program-in-buffer-name t)
+                    (ess-plain-first-buffername nil)
+                    (ess-gen-proc-buffer-name-function #'ess-gen-proc-buffer-name:simple)
+                    (ess-ask-for-ess-directory nil)
+                    (name))
+                (R-3.2.1)
+                (setq name (buffer-name))
+                (set-process-query-on-exit-flag (get-buffer-process (current-buffer)) nil)
+                (push (get-buffer-process name) to-kill)
+                ;; FIXME: Does not work in batch mode
+                ;; (kill-buffer name)
+                name)))
+    (should
+     (string= "*R-3.2.1:2*"
+              (let ((ess-use-inferior-program-name-in-buffer-name t)
+                    (ess-plain-first-buffername nil)
+                    (ess-gen-proc-buffer-name-function #'ess-gen-proc-buffer-name:simple)
+                    (ess-ask-for-ess-directory nil)
+                    (name))
+                (R-3.2.1)
+                (setq name (buffer-name))
+                (set-process-query-on-exit-flag (get-buffer-process (current-buffer)) nil)
+                (push (get-buffer-process name) to-kill)
+                ;; (kill-buffer name)
+                name)))
+    (mapc #'kill-process to-kill)))

--- a/test/ess-org-tests.el
+++ b/test/ess-org-tests.el
@@ -7,7 +7,7 @@
 
 (defun test-org-R-ouput (expect input)
   (declare (indent 1))
-  (let ((proc (ess-vanila-R))
+  (let ((proc (ess-vanilla-R))
         (org-confirm-babel-evaluate nil)
         (ess-ask-for-ess-directory nil)
         (inhibit-message ess-inhibit-message-in-tests))

--- a/test/ess-r-tests-utils.el
+++ b/test/ess-r-tests-utils.el
@@ -73,7 +73,7 @@ inserted text."
        ,@body)))
 (def-edebug-spec ess-cpp-test-with-temp-text (form body))
 
-(defun ess-vanila-R ()
+(defun ess-vanilla-R ()
   "Start vanila R process and return the process object."
   (save-window-excursion
     (let ((inhibit-message ess-inhibit-message-in-tests)
@@ -92,7 +92,7 @@ prompts in the output are replaced with '> '. There is no full
 proof way to test for prompts given that process output could be
 split arbitrary."
   (let ((prompt-regexp "^\\([+.>] \\)\\{2,\\}")
-        (proc (ess-vanila-R))
+        (proc (ess-vanilla-R))
         (inhibit-message ess-inhibit-message-in-tests))
     ;; just in case
     (ess-wait-for-process proc)
@@ -166,7 +166,7 @@ representative to the common interactive use with tracebug on."
      (save-window-excursion
        (switch-to-buffer r-file-buffer)
        (R-mode)
-       (let* ((*proc* (ess-vanila-R))
+       (let* ((*proc* (ess-vanilla-R))
               (ess-local-process-name (process-name *proc*))
               (output-buffer (process-buffer *proc*)))
          (unwind-protect

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -116,6 +116,15 @@
     (should (equal (ess-get-words-from-vector "letters[1:2]\n")
                    (list "a" "b")))))
 
+;;; ess-r-xref
+
+(ert-deftest ess-r-xref ()
+  (let ((inhibit-message ess-inhibit-message-in-tests))
+    (with-r-running nil
+      (with-r-file nil
+        (xref-find-definitions "sqrt")
+        (switch-to-buffer "*definition[R]:sqrt*")
+        (should (search "GlobalEnv" header-line-format))))))
 
 ;;; ess-r-package-mode
 

--- a/test/run-tests
+++ b/test/run-tests
@@ -15,6 +15,7 @@
 (require 'ess-r-tests-utils)
 (setq ess-inhibit-message-in-tests t)
 (setq ert-batch-backtrace-right-margin 130)
+(setq ess-history-file nil)
 
 ;; lintr probably isn't installed in the test suite and flymake will
 ;; complain about that. Disable it during tests.

--- a/test/test-ESSR.R
+++ b/test/test-ESSR.R
@@ -1,3 +1,3 @@
 source('../etc/ESSR/R/.load.R')
 load.ESSR('../etc/ESSR/R')
-testthat::test_dir("ESSR")
+testthat::test_dir("ESSR", stop_on_failure=TRUE)

--- a/test/test-ESSR.R
+++ b/test/test-ESSR.R
@@ -1,0 +1,3 @@
+source('../etc/ESSR/R/.load.R')
+load.ESSR('../etc/ESSR/R')
+testthat::test_dir("ESSR")


### PR DESCRIPTION
From #475 

> > If you just remove the ess-r-source-mode I think this is good to merge!
> 
> I have removed this code, as you both requested. However, I'll make one final plea for its inclusion:

Not only do I see a real difference between `ess-r-source-mode` and `ess-dump-object-info-edit-buffer` in both function and intent, I also don't see how they could share code.  My experience has been that @atheriel's original PR works exactly how I'd want it -- the source viewing buffers are read-only and buried via `q`.  I can `M-.` and `M-,` to my heart's content.  

Other changes include a preliminary `test_that` for ESSR and setting `ess-r-package-library-paths` to a `libPaths()` call.