### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ env:
   - EVM_EMACS=emacs-26.1-travis
   - EVM_EMACS=emacs-git-snapshot-travis
 
+matrix:
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis
+
 before_install:
   - echo "deb https://cloud.r-project.org/bin/linux/ubuntu trusty/" | sudo tee -a /etc/apt/sources.list
   - sudo add-apt-repository ppa:marutter/c2d4u -y
@@ -38,7 +42,4 @@ script:
 - R --version
 - cd lisp; make julia-mode.elc
 - cd ..
-- cp targets/travis-setup.el setup
-- cp targets/travis-setup.el lisp/setup
-- make -k all "EMACSBATCH = emacs -batch -Q -l setup"
-- make test
+- make -C test -k all

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ etc: version
 	cd etc; $(MAKE)
 
 .PHONY: test
-test: version
-	cd test; $(EMACS) --script run-tests
+	$(MAKE) -C test all
 
 generate-indent-cases:
 	cd test; $(EMACS) --script generate-indent-cases

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -25,12 +25,14 @@ COMPILE = $(EMACSBATCH) --directory . -f batch-byte-compile
 
 ### Targets
 
-.PHONY: all dist install uninstall distclean clean
+.PHONY: all dist install uninstall distclean clean compile
 
 ELS = $(filter-out ess-autoloads.el, $(wildcard *.el obsolete/*.el)) julia-mode.el
 ELC = $(ELS:.el=.elc)
 
-all dist: $(ELC) ess-autoloads.el
+all dist: compile ess-autoloads.el
+
+compile: $(ELC)
 
 install: dist
 	-$(INSTALLDIR) $(LISPDIR)

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -59,6 +59,13 @@
 (declare-function ess-mode "ess")
 (declare-function ess-complete-object-name "ess-r-completion")
 
+;; The following declares can be removed once we drop Emacs 25
+(declare-function tramp-file-name-method "tramp")
+(declare-function tramp-file-name-user "tramp")
+(declare-function tramp-file-name-host "tramp")
+(declare-function tramp-file-name-localname "tramp")
+(declare-function tramp-file-name-hop "tramp")
+
 (defvar inferior-ess-mode-syntax-table
   (let ((tab (copy-syntax-table comint-mode-syntax-table)))
     tab)

--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -301,7 +301,7 @@ To be used instead of ESS' completion engine for R versions >= 2.7.0."
           ;; reread new package, but not rda, much faster and not needed anyways
           (process-put *proc* 'sp-for-ac-changed? nil)))
       (apply 'append
-             (cddar ess-sl-modtime-alist) ; .GlobalEnv
+             (cl-cddar ess-sl-modtime-alist) ; .GlobalEnv
              (mapcar 'cddr ess--cached-sp-objects)))))
 
 

--- a/lisp/ess-r-flymake.el
+++ b/lisp/ess-r-flymake.el
@@ -38,6 +38,12 @@
 (require 'flymake)
 (require 'project)
 
+;; Appease the byte compiler for Emacs 25. Remove after dropping
+;; support for Emacs 25.
+(declare-function flymake-diag-region "flymake")
+(declare-function flymake-make-diagnostic "flymake")
+(declare-function flymake--overlays "flymake")
+
 (defcustom ess-r-flymake-linters
   '("closed_curly_linter = NULL"
     "commas_linter = NULL"

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -93,6 +93,12 @@
 ;; here.
 (declare-function tramp-dissect-file-name "tramp")
 (declare-function tramp-get-remote-tmpdir "tramp")
+;; The following declares can be removed once we drop Emacs 25
+(declare-function tramp-file-name-method "tramp")
+(declare-function tramp-file-name-user "tramp")
+(declare-function tramp-file-name-host "tramp")
+(declare-function tramp-file-name-localname "tramp")
+(declare-function tramp-file-name-hop "tramp")
 
 
 (defgroup ess-tracebug nil

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -44,6 +44,12 @@
 (declare-function evil-normal-state "evil")
 (declare-function color-lighten-name "color")
 (declare-function tramp-dissect-file-name "tramp")
+;; The following declares can be removed once we drop Emacs 25
+(declare-function tramp-file-name-method "tramp")
+(declare-function tramp-file-name-user "tramp")
+(declare-function tramp-file-name-host "tramp")
+(declare-function tramp-file-name-localname "tramp")
+(declare-function tramp-file-name-hop "tramp")
 
 
 ;;*;; Internal ESS tools and variables

--- a/targets/travis-setup.el
+++ b/targets/travis-setup.el
@@ -1,4 +1,4 @@
 
 (put 'if-let 'byte-obsolete-info nil)
 (put 'when-let 'byte-obsolete-info nil)
-(setq byte-compile-error-on-warn (= emacs-major-version 26))
+(setq byte-compile-error-on-warn t)

--- a/targets/travis-setup.el
+++ b/targets/travis-setup.el
@@ -1,4 +1,0 @@
-
-(put 'if-let 'byte-obsolete-info nil)
-(put 'when-let 'byte-obsolete-info nil)
-(setq byte-compile-error-on-warn t)

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,7 +3,7 @@ EMACS?=emacs
 .PHONY: literate
 
 
-all:
+all: compile
 	${EMACS} -Q --script run-tests
 
 ess:
@@ -29,3 +29,8 @@ indent-cases:
 
 literate-cases:
 	${EMACS} -Q --script generate-literate-cases
+
+.PHONY: compile
+compile:
+	@cd ../lisp && make -k all \
+		"EMACSBATCH = emacs --batch --eval \"(setq byte-compile-error-on-warn t)\""


### PR DESCRIPTION
A few improvements: 

- Provide a way to mimic travis erroring on compile warnings locally (@vspinu asked for this)
- Eliminate byte compile warnings on Emacs 25
- Simplify travis script

I've moved the git-snapshot travis build to an allowed failure for the moment. The EVM build is 9 months old and if-let has been un-obsoleted since then. I've raised an issue over there and will move it back to required successes once the git snapshot gets updated.