### PR TITLE
Support ess-load-library outside of R

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1340,6 +1340,27 @@ of `ess-async-command' with an explicit interrupt-callback."
                        (ess-async-command ,com ,buf ,proc ,callback ',int-cb)))))
     (run-with-idle-timer delay nil com-fun)))
 
+(defun ess-load-library ()
+  "Prompt and load dialect specific library/package/module.
+Note that add-ons in R are called 'packages' and the name of this
+function has nothing to do with R package mechanism, but it
+rather serves a generic, dialect independent purpose. It is also
+similar to `load-library' Emacs function."
+  (interactive)
+  (let ((ess-eval-visibly-p t)
+        (packs (ess-installed-packages))
+        pack)
+    (setq pack (ess-completing-read "Load" packs))
+    (ess-load-library--override pack)
+    (ess--mark-search-list-as-changed)
+    (display-buffer (buffer-name (process-buffer (get-process ess-current-process-name))))))
+
+(cl-defgeneric ess-installed-packages ()
+  "Return a list of installed packages.")
+
+(cl-defgeneric ess-load-library--override (pack)
+  "Load library/package PACK.")
+
 
 ;;*;;  Evaluating lines, paragraphs, regions, and buffers.
 

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -110,6 +110,14 @@ See `comint-input-sender'."
             (t ;; normal command
              (inferior-ess-input-sender proc string))))))
 
+(cl-defmethod ess-installed-packages (&context ((string= ess-dialect "julia") (eql t)))
+  "Return list of installed julia packages."
+  ;; FIXME: This doesn't work if the user hasn't done "using Pkg" yet
+  (ess-get-words-from-vector "keys(Pkg.installed())\n"))
+
+(cl-defmethod ess-load-library--override (pack &context ((string= ess-dialect "julia") (eql t)))
+  (ess-eval-linewise (format "using %s\n" pack)))
+
 
 ;;; COMPLETION
 (defun ess-julia-latexsub-completion ()

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -1038,24 +1038,13 @@ Placed into `ess-presend-filter-functions' for R dialects."
     (ess--mark-search-list-as-changed))
   string)
 
-(defun ess-load-library ()
-  "Prompt and load dialect specific library/package/module.
+(cl-defmethod ess-installed-packages (&context ((string= ess-dialect "R") (eql t)))
+  ;;; FIXME? .packages() does not cache; installed.packages() does but is slower first time
+  (ess-get-words-from-vector "print(.packages(T), max=1e6)\n"))
 
-Note that add-ons in R are called 'packages' and the name of this
-function has nothing to do with R package mechanism, but it
-rather serves a generic, dialect independent purpose. It is also
-similar to `load-library' Emacs function."
-  (interactive)
-  (if (not (string-match "^R" ess-dialect))
-      (message "Sorry, not available for %s" ess-dialect)
-    (let ((ess-eval-visibly-p t)
-;;; FIXME? .packages() does not cache; installed.packages() does but is slower first time
-          (packs (ess-get-words-from-vector "print(.packages(T), max=1e6)\n"))
-          pack)
-      (setq pack (ess-completing-read "Load" packs))
-      (ess-eval-linewise (format "library('%s')\n" pack))
-      (ess--mark-search-list-as-changed)
-      (display-buffer (buffer-name (process-buffer (get-process ess-current-process-name)))))))
+(cl-defmethod ess-load-library--override (pack &context ((string= ess-dialect "R") (eql t)))
+  "Load an R package."
+  (ess-eval-linewise (format "library('%s')\n" pack)))
 
 (define-obsolete-function-alias 'ess-library 'ess-load-library "ESS[12.09-1]")
 


### PR DESCRIPTION
New generics ess-installed-packages and ess--load-library provide
support for ess-load-library, which is moved from ess-r-mode.el to
ess-inf.el

Closes #299