### PR TITLE
Simplify package info retrieval

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -18,10 +18,13 @@ inf:
 	${EMACS} -Q --script run-tests --inf
 
 r:
-	${EMACS} -Q --script run-tests --rstats
+	${EMACS} -Q --script run-tests --r
 
 r-indent:
-	${EMACS} -Q --script run-tests --rstats-indent
+	${EMACS} -Q --script run-tests --r-indent
+
+r-pkg:
+	${EMACS} -Q --script run-tests --r-pkg
 
 literate:
 	${EMACS} -Q --script run-tests --literate

--- a/test/ess-r-package-tests.el
+++ b/test/ess-r-package-tests.el
@@ -57,3 +57,17 @@
         (should (string-match "Process R\\(:.\\)? \\(finished\\|killed\\)"
                               (with-current-buffer proc-buffer
                                 (buffer-string))))))))
+
+(ert-deftest ess-r-package-package-info-test ()
+  (let ((kill-buffer-query-functions nil)
+        (ess-r-package-auto-activate nil))
+    (with-r-file "dummy-pkg/R/test.R"
+      (let ((pkg-info (ess-r-package-info)))
+        (should (string= (car pkg-info) "foo"))
+        (should (string-match-p "dummy-pkg$" (cdr pkg-info)))
+        (kill-buffer)))
+    (with-c-file "dummy-pkg/src/test.c"
+      (let ((pkg-info (ess-r-package-info)))
+        (should (string= (car pkg-info) "foo"))
+        (should (string-match-p "dummy-pkg$" (cdr pkg-info)))
+        (kill-buffer)))))

--- a/test/ess-r-package-tests.el
+++ b/test/ess-r-package-tests.el
@@ -1,4 +1,5 @@
 (require 'ert)
+(require 'ess-r-mode)
 (require 'ess-r-package)
 (require 'ess-r-tests-utils)
 
@@ -63,11 +64,11 @@
         (ess-r-package-auto-activate nil))
     (with-r-file "dummy-pkg/R/test.R"
       (let ((pkg-info (ess-r-package-info)))
-        (should (string= (car pkg-info) "foo"))
-        (should (string-match-p "dummy-pkg$" (cdr pkg-info)))
+        (should (string= (alist-get :name pkg-info) "foo"))
+        (should (string-match-p "dummy-pkg$" (alist-get :root pkg-info)))
         (kill-buffer)))
     (with-c-file "dummy-pkg/src/test.c"
       (let ((pkg-info (ess-r-package-info)))
-        (should (string= (car pkg-info) "foo"))
-        (should (string-match-p "dummy-pkg$" (cdr pkg-info)))
+        (should (string= (alist-get :name pkg-info) "foo"))
+        (should (string-match-p "dummy-pkg$" (alist-get :root pkg-info)))
         (kill-buffer)))))

--- a/test/run-tests
+++ b/test/run-tests
@@ -3,7 +3,7 @@
 
 ;; This script must be run from the test directory
 ;; With no argument, run all tests. Otherwise run only mentioned tests.
-;; Possible arguments: --rstats --rstats-indent
+;; Possible arguments: --r --r-indent etc.
 
 (let ((current-directory (file-name-directory load-file-name)))
   (setq ess-test-path (expand-file-name "." current-directory))
@@ -21,18 +21,20 @@
 (setq ess-use-flymake nil)
 
 (when (= (length argv) 0)
-  (setq argv '("--ess" "--inf" "--rstats" "--rstats-indent" "--literate")))
+  (setq argv '("--ess" "--inf" "--r" "--r-indent" "--r-pkg" "--literate")))
 
 (when (member "--ess" argv)
   (load (expand-file-name "ess-tests.el" ess-test-path) nil t))
 (when (member "--inf" argv)
   (load (expand-file-name "ess-inf-tests.el" ess-test-path) nil t)
   (load (expand-file-name "ess-org-tests.el" ess-test-path) nil t))
-(when (member "--rstats" argv)
+(when (member "--r" argv)
   (load (expand-file-name "ess-r-tests.el" ess-test-path) nil t)
   (load (expand-file-name "ess-r-package-tests.el" ess-test-path) nil t))
-(when (member "--rstats-indent" argv)
+(when (member "--r-indent" argv)
   (load (expand-file-name "ess-indentation-tests.el" ess-test-path) nil t))
+(when (member "--r-pkg" argv)
+  (load (expand-file-name "ess-r-package-tests.el" ess-test-path) nil t))
 (when (member "--literate" argv)
   (load (expand-file-name "ess-literate-tests.el" ess-test-path) nil t)
   (elt-deftest test-elt () "elt.R")


### PR DESCRIPTION

Simplifications of pkg-info retrieval. Basically make `ess-r-package-info` the only work-horse which retrieves and sets `ess-r-package--project-cache`. It was quite confusing that we were manipulation the cache in multiple places.  

The adaptation to `package.el` confused things a bit. Now we have two functions with separate concerns `ess-r-package-project` and `ess-r-package-info`. 

(overwrites @lionel-'s recent fixes)