### PR TITLE
Support function navigation in julia buffers

### DIFF
--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -1327,6 +1327,103 @@ Then run `inferior-ess-r-reload-hook'."
 
 ;;*;; Editing Tools
 
+(cl-defmethod ess-beginning-of-function--override
+  (no-error &context ((string= ess-dialect "R") (eql t)))
+  "Find beginning of R function."
+  (let ((init-point (point))
+        (in-set-S4 nil)
+        beg end done)
+    ;; Note that we must be sure that we are past the 'function (' text,
+    ;; such that ess-function-pattern is found in BACKwards later.
+    ;; In case we're sitting in a function or setMethod() header,
+    ;; we need to move further.
+    ;; But not too far! {wrongly getting into next function}
+    (if (search-forward "("
+                        (ess-line-end-position 2) t) ; at most end of next line
+        (forward-char 1))
+    ;; TODO: replace the above by hopefully more sucessful logic:
+    ;; 1. If we have 'function *(' in the same line, move to end of that line
+    ;; 2. if *not*, skip all comment lines (concat space comment-char .* "\n")
+    ;;    and only* then do something like the
+    ;;    (search-forward '(' .. (..line-end.. 2) )  above
+
+    (setq end (point))             ; = init-point when nothing found
+
+    (ess-write-to-dribble-buffer
+     (format "ess-BEG-of-fun after 'search-FWD (': Ini-pt %d, (p)-Ini-pt = %d\n"
+             init-point (- end init-point)))
+    (if (and (> end 1)
+             (re-search-backward ;; in case of setMethod() etc ..
+              ess-r-set-function-start
+              ;; at most 1 line earlier {2 is too much: finds previous sometimes}
+              (+ 1 (ess-line-end-position -1)) t))
+
+        (progn ;; yes we *have* an S4  setMethod(..)-like
+          (setq in-set-S4 t
+                beg (point))
+          (ess-write-to-dribble-buffer
+           (format " set*() function start at position %d" beg))
+          ;; often need to move even further to have 'function(' to our left
+          ;;        (if (search-forward "function" end t)
+          ;;            (ess-write-to-dribble-buffer
+          ;;             (format " -> 'function' already at pos %d\n" (point)))
+          ;;          ;; else need to move further
+          (goto-char end)
+          ;; search 4 lines, we are pretty sure now:
+          (search-forward
+           "function" (ess-line-end-position 4) t)
+          ;;        )
+          (search-forward "(" (ess-line-end-position) t))
+      ;; else: regular function; no set*Method(..)
+      (ess-write-to-dribble-buffer "ELSE  not in setMethod() header ...\n"))
+
+    (while (not done)
+      ;; Need this while loop to skip over local function definitions
+
+      ;; In the case of non-success, it is inefficiently
+      ;; going back in the buffer through all function definitions...
+      (unless
+          (and (re-search-backward ess-function-pattern (point-min) t)
+               (not (ess-inside-string-or-comment-p (point))))
+        (goto-char init-point)
+        (if no-error
+            (setq  done t  beg nil)
+          ;; else [default]:
+          (error "Point is not in a function according to `ess-function-pattern'")))
+      (unless done
+        (setq beg (point))
+        (ess-write-to-dribble-buffer
+         (format "\tMatch,Pt:(%d,%d),%d\n"
+                 (match-beginning 0) (match-end 0) beg))
+        (setq in-set-S4 (looking-at ess-r-set-function-start))
+        (forward-list 1)              ; get over arguments
+
+        ;; The following used to bomb  "Unbalanced parentheses", n1, n2
+        ;; when the above (search-forward "(" ..) wasn't delimited :
+        (unless in-set-S4 (forward-sexp 1)) ; move over braces
+        ;;DBG (ess-write-to-dribble-buffer "|")
+        (setq end (point))
+        (goto-char beg)
+        ;; current function must begin and end around point
+        (setq done (and (>= end init-point) (<= beg init-point)))))
+    beg))
+
+(cl-defmethod ess-end-of-function--override
+  (&context ((string= ess-dialect "R") (eql t)))
+  ;; *hack* only for S (R || S+): are we in setMethod(..) etc?
+  (let ((in-set-S4 (looking-at ess-r-set-function-start))
+        (end-pos))
+    (forward-list 1)      ; get over arguments || whole set*(..)
+    (unless in-set-S4 (forward-sexp 1)) ; move over braces
+    ;; For one-line functions withOUT '{ .. }' body  -- added 2008-07-23 --
+    ;; particularly helpful for C-c C-c (ess-eval-function-or-paragraph-and-step):
+    (setq end-pos (ess-line-end-position))
+    (while (< (point) end-pos) ; if not at end of line, move further forward
+      (goto-char ;; careful not to move too far; e.g. *not* over empty lines:
+       (min (save-excursion (forward-sexp 1) (point))
+            (save-excursion (forward-paragraph 1) (point)))))
+    (point)))
+
 ;;;*;;; Indentation Engine
 
 ;; Written by Lionel Henry in mid 2015

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -31,6 +31,7 @@
 ;;; Code:
 (require 'cl-lib)
 (eval-when-compile
+  (require 'subr-x)
   (require 'tramp))
 ;; The only ESS file this file should depend on is ess-custom.el
 (require 'cl-lib)
@@ -1005,113 +1006,25 @@ it cannot find a function beginning."
   ;; beginning-of-defun-function specification
   ;; FIXME: should __WORK__ in the crucial case: large function w/ internal function defs
   (interactive)
-  (let ((init-point (point))
-        (in-set-S4 nil)
-        beg end done)
+  (ess-beginning-of-function--override no-error))
 
-    ;; Note that we must be sure that we are past the 'function (' text,
-    ;; such that ess-function-pattern is found in BACKwards later.
-    ;; In case we're sitting in a function or setMethod() header,
-    ;; we need to move further.
-    ;; But not too far! {wrongly getting into next function}
-    (if (search-forward "("
-                        (ess-line-end-position 2) t) ; at most end of next line
-        (forward-char 1))
-    ;; TODO: replace the above by hopefully more sucessful logic:
-    ;; 1. If we have 'function *(' in the same line, move to end of that line
-    ;; 2. if *not*, skip all comment lines (concat space comment-char .* "\n")
-    ;;    and only* then do something like the
-    ;;    (search-forward '(' .. (..line-end.. 2) )  above
+(cl-defgeneric ess-beginning-of-function--override (no-error))
 
-    (setq end (point))             ; = init-point when nothing found
-
-    (ess-write-to-dribble-buffer
-     (format "ess-BEG-of-fun after 'search-FWD (': Ini-pt %d, (p)-Ini-pt = %d\n"
-             init-point (- end init-point)))
-    (if (and (> end 1)
-             (re-search-backward ;; in case of setMethod() etc ..
-              ess-r-set-function-start
-              ;; at most 1 line earlier {2 is too much: finds previous sometimes}
-              (+ 1 (ess-line-end-position -1)) t))
-
-        (progn ;; yes we *have* an S4  setMethod(..)-like
-          (setq in-set-S4 t
-                beg (point))
-          (ess-write-to-dribble-buffer
-           (format " set*() function start at position %d" beg))
-          ;; often need to move even further to have 'function(' to our left
-          ;;        (if (search-forward "function" end t)
-          ;;            (ess-write-to-dribble-buffer
-          ;;             (format " -> 'function' already at pos %d\n" (point)))
-          ;;          ;; else need to move further
-          (goto-char end)
-          ;; search 4 lines, we are pretty sure now:
-          (search-forward
-           "function" (ess-line-end-position 4) t)
-          ;;        )
-          (search-forward "(" (ess-line-end-position) t))
-      ;; else: regular function; no set*Method(..)
-      (ess-write-to-dribble-buffer "ELSE  not in setMethod() header ...\n"))
-
-    (while (not done)
-      ;; Need this while loop to skip over local function definitions
-
-      ;; In the case of non-success, it is inefficiently
-      ;; going back in the buffer through all function definitions...
-      (unless
-          (and (re-search-backward ess-function-pattern (point-min) t)
-               (not (ess-inside-string-or-comment-p (point))))
-        (goto-char init-point)
-        (if no-error
-            (setq  done t  beg nil)
-          ;; else [default]:
-          (error "Point is not in a function according to 'ess-function-pattern'")))
-      (unless done
-        (setq beg (point))
-        (ess-write-to-dribble-buffer
-         (format "\tMatch,Pt:(%d,%d),%d\n"
-                 (match-beginning 0) (match-end 0) beg))
-        (setq in-set-S4 (looking-at ess-r-set-function-start))
-        (forward-list 1)              ; get over arguments
-
-        ;; The following used to bomb  "Unbalanced parentheses", n1, n2
-        ;; when the above (search-forward "(" ..) wasn't delimited :
-        (unless in-set-S4 (forward-sexp 1)) ; move over braces
-        ;;DBG (ess-write-to-dribble-buffer "|")
-        (setq end (point))
-        (goto-char beg)
-        ;; current function must begin and end around point
-        (setq done (and (>= end init-point) (<= beg init-point)))))
-    beg))
-
-(defun ess-end-of-function (&optional beginning no-error)
+(defun ess-end-of-function (&optional _ignored no-error)
   "Leave the point at the end of the current ESS function.
-Optional argument for location of BEGINNING.  Return '(beg end)."
+NO-ERROR is passed to `ess-beginning-of-function'. Return a list
+with two elements, beginning and end position of the function."
   (interactive)
-  (if beginning
-      (goto-char beginning)
-    (setq beginning (ess-beginning-of-function no-error)))
-  (if beginning
-      ;; *hack* only for S (R || S+): are we in setMethod(..) etc?
-      (let ((in-set-S4 (looking-at ess-r-set-function-start))
-            (end-pos))
-        (ess-write-to-dribble-buffer
-         (format "ess-END-of-fun: S4=%s, beginning = %d\n" in-set-S4 beginning))
-        (forward-list 1)      ; get over arguments || whole set*(..)
-        (unless in-set-S4 (forward-sexp 1)) ; move over braces
-        (ess-write-to-dribble-buffer
-         (format "ess-END-of-fun: found #1 : %d\n" (point)))
+  (if-let ((cur-pos (point))
+           (beginning (ess-beginning-of-function no-error))
+           (end (ess-end-of-function--override)))
+      (if (> cur-pos end)
+          (user-error "Point not inside a function.")
+        (list beginning end))))
 
-        ;; For one-line functions withOUT '{ .. }' body  -- added 2008-07-23 --
-        ;; particularly helpful for C-c C-c (ess-eval-function-or-paragraph-and-step):
-        (setq end-pos (ess-line-end-position))
-        (while (< (point) end-pos) ; if not at end of line, move further forward
-          (goto-char ;; careful not to move too far; e.g. *not* over empty lines:
-           (min (save-excursion (forward-sexp 1) (point))
-                (save-excursion (forward-paragraph 1) (point)))))
-        (list beginning (point)))
-    ;; else: 'no-error': we are not in a function
-    nil))
+(cl-defgeneric ess-end-of-function--override ()
+  "Move point to the end of the current function, return point.
+May assume point begins at the beginning of a function.")
 
 (defun ess-symbol-at-point ()
   "Like `symbol-at-point' but consider fully qualified names.

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,12 +1,17 @@
 
 include ../Makeconf
 
-.PHONY: literate all julia lisp ess inf r r-indent literate cases indent-cases literate-cases
+.PHONY: literate all julia julia-tests \
+	lisp ess inf r r-indent literate \
+	cases indent-cases literate-cases
 
 all: compile lisp
 
 julia:
 	$(MAKE) -C .. julia
+
+julia-tests: julia
+	${EMACS} -Q --script run-tests --julia
 
 lisp: julia
 	${EMACS} -Q --script run-tests

--- a/test/ess-julia-tests.el
+++ b/test/ess-julia-tests.el
@@ -1,0 +1,56 @@
+(require 'cl-lib)
+(require 'ert)
+(require 'ess-julia)
+
+(defmacro ess-julia-test-with-temp-text (text &rest body)
+  "Run body in a temporary buffer with `ess-julia-mode' as the active
+mode holding TEXT.  If the string \"¶\" appears in TEXT
+then remove it and place the point there before running BODY,
+otherwise place the point at the beginning of the inserted text."
+  (declare (indent 1))
+  `(let ((inside-text (if (stringp ,text) ,text (eval ,text)))
+	 (ess-julia-mode-hook nil))
+     (with-temp-buffer
+       (ess-julia-mode)
+       (let ((point (string-match "¶" inside-text)))
+	 (if point
+	     (progn
+	       (insert (replace-match "" nil nil inside-text))
+	       (goto-char (1+ (match-beginning 0))))
+	   (insert inside-text)
+	   (goto-char (point-min))))
+       ,@body)))
+(def-edebug-spec ess-julia-test-with-temp-text (form body))
+
+(ert-deftest ess-julia-function-beg-end ()
+  (ess-julia-test-with-temp-text
+      "function x(a)\n  a + 1\nend\n"
+    (search-forward "x(a)")
+    (ess-beginning-of-function)
+    (should (eql (point) 1))
+    (should (cl-equalp (ess-end-of-function) '(1 26))))
+  (ess-julia-test-with-temp-text
+      "function x(a)\n  a + 1\n  function (b)\n    b + 2\n    end\nend\n"
+    (search-forward "x(a)")
+    (should (eql (ess-beginning-of-function) 1))
+    (search-forward "b + 2")
+    ;; Ignore nested functions:
+    (should (eql (ess-beginning-of-function) 1))
+    ;; FIXME: This isn't right, should be 1 67?
+    (should (cl-equalp (ess-end-of-function) '(1 59))))
+  (ess-julia-test-with-temp-text
+      "macro p(n)\n  return n\nend\n"
+    (search-forward "return")
+    (ess-beginning-of-function)
+    (should (eql (point) 1)))
+  (ess-julia-test-with-temp-text
+      "f(x, y) = x + y"
+    (search-forward "x + ")
+    (ess-beginning-of-function)
+    (should (eql (point) 1))
+    (should (cl-equalp (ess-end-of-function) `(,(point-min) ,(point-max)))))
+  (ess-julia-test-with-temp-text
+      "1 + 1"
+    (search-forward "+")
+    (should-error (ess-beginning-of-function))
+    (should-error (ess-end-of-function))))

--- a/test/run-tests
+++ b/test/run-tests
@@ -21,7 +21,7 @@
 (setq ess-use-flymake nil)
 
 (when (= (length argv) 0)
-  (setq argv '("--ess" "--inf" "--rstats" "--rstats-indent" "--literate")))
+  (setq argv '("--ess" "--inf" "--rstats" "--rstats-indent" "--literate" "--julia")))
 
 (when (member "--ess" argv)
   (load (expand-file-name "ess-tests.el" ess-test-path) nil t))
@@ -33,6 +33,8 @@
   (load (expand-file-name "ess-r-package-tests.el" ess-test-path) nil t))
 (when (member "--rstats-indent" argv)
   (load (expand-file-name "ess-indentation-tests.el" ess-test-path) nil t))
+(when (member "--julia" argv)
+  (load (expand-file-name "ess-julia-tests.el" ess-test-path) nil t))
 (when (member "--literate" argv)
   (load (expand-file-name "ess-literate-tests.el" ess-test-path) nil t)
   (elt-deftest test-elt () "elt.R")


### PR DESCRIPTION
ess-beginning-of-function and ess-end-of-function now allow generic
overrides

Closes #777, closes #779

Co-authored-by: nverno <noah.v.peart@gmail.com>

@nverno - I combined our ideas for julia function navigation. WDYT? 