### PR TITLE
Remove ess-step-line and fix evaluation of paragraphs on empty lines

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1546,6 +1546,10 @@ current function, otherwise (in case of an error) return nil."
 Prefix arg VIS toggles visibility of ess-code as for `ess-eval-region'."
   (interactive "P")
   (save-excursion
+    (ignore-errors
+      ;; Evaluation is forward oriented
+      (forward-line -1)
+      (ess-next-code-line 1))
     (let ((beg (progn (backward-paragraph) (point)))
           (end (progn (forward-paragraph) (point))))
       (ess-eval-region beg end vis))))

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1568,7 +1568,8 @@ Otherwise send the current paragraph to the inferior ESS process.
 Prefix arg VIS toggles visibility of ess-code as for
 `ess-eval-region'."
   (interactive "P")
-  (ess-step-line (ess-eval-function-or-paragraph vis)))
+  (ess-skip-thing (ess-eval-function-or-paragraph vis))
+  (ess-next-code-line))
 
 (defun ess-eval-region-or-function-or-paragraph (&optional vis)
   "Send the region, function, or paragraph depending on context.
@@ -1590,7 +1591,8 @@ step to the next code line or to the end of region if region was
 active. Prefix arg VIS toggles visibility of ess-code as for
 `ess-eval-region'."
   (interactive "P")
-  (ess-step-line (ess-eval-region-or-function-or-paragraph vis)))
+  (ess-eval-region-or-function-or-paragraph vis)
+  (ess-next-code-line))
 
 (defun ess-eval-region-or-line-and-step (&optional vis)
   "Evaluate region if active, otherwise `ess-eval-line-and-step'.
@@ -1624,11 +1626,12 @@ VIS has same meaning as for `ess-eval-region'."
     (ess-eval-region beg end vis msg)))
 
 (defun ess-eval-line-and-step (&optional vis)
-  "Evaluate the current line and `ess-step-line' to the \"next\" line.
+  "Evaluate the current line and step to the \"next\" line.
 See `ess-eval-region' for VIS."
   (interactive "P")
   (ess-eval-line vis)
-  (ess-step-line 'line))
+  (ess-skip-thing 'line)
+  (ess-next-code-line))
 
 (defun ess-eval-line-visibly-and-step (&optional simple-next)
   "Evaluate the current line visibly and step to the \"next\" line.
@@ -1638,15 +1641,16 @@ is non-nil both SIMPLE-NEXT and EVEN-EMPTY are interpreted as
 true.
 
 Note that when inside a package and namespaced evaluation is in
-place (see `ess-r-set-evaluation-env') evaluation of multiline
-input will fail."
+place (see `ess-r-set-evaluation-env'), the evaluation of
+multiline input will fail."
   (interactive "P")
   (ess-force-buffer-current)
   (display-buffer (ess-get-process-buffer))
   (let ((ess-eval-visibly t)
         (ess-eval-empty (or ess-eval-empty simple-next)))
     (ess-eval-line)
-    (ess-step-line 'line)))
+    (ess-skip-thing 'line)
+    (ess-next-code-line)))
 
 (defun ess-eval-line-invisibly-and-step ()
   "Evaluate the current line invisibly and step to the next line.
@@ -1702,7 +1706,8 @@ If not inside a paragraph, evaluate the next one. VIS has same
 meaning as for `ess-eval-region'."
   (interactive "P")
   (ess-eval-paragraph vis)
-  (ess-step-line 'paragraph))
+  (ess-skip-thing 'paragraph)
+  (ess-next-code-line))
 
  ; Inferior ESS mode
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/ess-inf-tests.el
+++ b/test/ess-inf-tests.el
@@ -87,19 +87,19 @@ OUT-STRING is the content of the region captured by
        ,@body)))
 
 (ert-deftest ess-eval-and-step-test ()
+  (let ((inhibit-message ess-inhibit-message-in-tests))
+    (let ((output "\nreal <- code\n"))
+      (ess-test-interactive-eval output
+        (insert (format "## comment\n%s" output))
+        (forward-line -1)
+        (ess-eval-region-or-function-or-paragraph-and-step)))
 
-  (let ((output "\nreal <- code\n"))
-    (ess-test-interactive-eval output
-      (insert (format "## comment\n%s" output))
-      (forward-line -1)
-      (ess-eval-region-or-function-or-paragraph-and-step)))
-
-  (let ((output "\nxyz <- function {\n}\n"))
-    (ess-test-interactive-eval output
-      (insert (format "## comment\n%s" output))
-      (goto-char (point-min))
-      (forward-line 1)
-      (ess-eval-region-or-function-or-paragraph-and-step))))
+    (let ((output "\nxyz <- function {\n}\n"))
+      (ess-test-interactive-eval output
+        (insert (format "## comment\n%s" output))
+        (goto-char (point-min))
+        (forward-line 1)
+        (ess-eval-region-or-function-or-paragraph-and-step)))))
 
 (ert-deftest ess-verbose-setwd-test ()
   (with-r-running nil

--- a/test/ess-inf-tests.el
+++ b/test/ess-inf-tests.el
@@ -40,7 +40,7 @@
                          (buffer-string))
                        "[1] TRUE")))))
 
-(ert-deftest ess-async-command ()
+(ert-deftest ess-async-command-test ()
   ;; (ess-async-command "{cat(1:5);Sys.sleep(5);cat(2:6)}\n" nil (get-process "R")
   ;;                    (lambda (proc) (message "done")))
   ;; (ess-async-command "{cat(1:5);Sys.sleep(5);cat(2:6)}\n" nil (get-process "R")
@@ -200,7 +200,7 @@ some. text
     (should (string= (ess-build-load-command "file")
                      "source('file')\n"))))
 
-(ert-deftest ess-get-words-from-vector ()
+(ert-deftest ess-get-words-from-vector-test ()
   (with-r-running nil
     (should (cl-every #'string= (ess-get-words-from-vector "c('1')\n") '("1")))
     (should (cl-every #'string= (ess-get-words-from-vector "c('1', \"2\")\n") '("1" "2")))
@@ -215,12 +215,12 @@ some. text
 ;; loaded. They're skipped unless you've defined the environment
 ;; variable CONTINUOUS_INTEGRATION or R-3.2.1 is found by
 ;; `executable-find'.
-(ert-deftest runner-R-3.2.1-defined ()
+(ert-deftest runner-R-3.2.1-defined-test ()
   (skip-unless (or (executable-find "R-3.2.1")
                    (getenv "CONTINUOUS_INTEGRATION")))
   (should (fboundp 'R-3.2.1)))
 
-(ert-deftest runner-R-3.2.1-buffer-name ()
+(ert-deftest runner-R-3.2.1-buffer-name-test ()
   (skip-unless (and (or (executable-find "R-3.2.1")
                         (getenv "CONTINUOUS_INTEGRATION"))
                     (> emacs-major-version 25)))

--- a/test/ess-org-tests.el
+++ b/test/ess-org-tests.el
@@ -23,23 +23,23 @@
           (should (re-search-backward expect nil t)))
       (kill-process proc))))
 
-(ert-deftest test-org-ob-R-output ()
+(ert-deftest test-org-ob-R-output-test ()
   (test-org-R-ouput "hello"
     "#+BEGIN_SRC R :results output\n  \"hello\"\n#+END_SRC"))
 
-(ert-deftest test-org-ob-R-session-output ()
+(ert-deftest test-org-ob-R-session-output-test ()
   (test-org-R-ouput "hello"
     "#+BEGIN_SRC R :session :results output\n  \"hello\"\n#+END_SRC"))
 
-(ert-deftest test-org-ob-R-value ()
+(ert-deftest test-org-ob-R-value-test ()
   (test-org-R-ouput "hello"
     "#+BEGIN_SRC R :results value\n  \"hello\"\n#+END_SRC"))
 
-(ert-deftest test-org-ob-R-session-value ()
+(ert-deftest test-org-ob-R-session-value-test ()
   (test-org-R-ouput "hello"
     "#+BEGIN_SRC R :session :results value\n  \"hello\"\n#+END_SRC"))
 
-(ert-deftest test-org-ob-R-data-frame ()
+(ert-deftest test-org-ob-R-data-frame-test ()
   (test-org-R-ouput "| 3 | c |"
     "#+BEGIN_SRC R :session :results value :colnames yes\n  data.frame(x=1:3, y=c(\"a\",\"b\",\"c\"))\n#+END_SRC"))
 

--- a/test/ess-r-package-tests.el
+++ b/test/ess-r-package-tests.el
@@ -3,29 +3,29 @@
 (require 'ess-r-package)
 (require 'ess-r-tests-utils)
 
-(ert-deftest ess-r-package-auto-activation ()
+(ert-deftest ess-r-package-auto-activation-test ()
   (let ((inhibit-message ess-inhibit-message-in-tests))
     (with-temp-buffer
       (text-mode)
       (hack-local-variables)
       (should (not ess-r-package-mode)))
     (with-r-file "dummy-pkg/R/test.R"
-                 (hack-local-variables)
-                 (should ess-r-package-mode))))
+      (hack-local-variables)
+      (should ess-r-package-mode))))
 
-(ert-deftest ess-r-package-auto-activation-in-shell ()
+(ert-deftest ess-r-package-auto-activation-in-shell-test ()
   (let ((kill-buffer-query-functions nil))
     (with-r-file "dummy-pkg/R/test.R"
-                 (shell)
-                 (should ess-r-package-mode)
-                 (kill-buffer))
+      (shell)
+      (should ess-r-package-mode)
+      (kill-buffer))
     (with-r-file "dummy-pkg/R/test.R"
-                 (let ((ess-r-package-auto-activate t))
-                   (shell)
-                   (should ess-r-package-mode))
-                 (kill-buffer))))
+      (let ((ess-r-package-auto-activate t))
+        (shell)
+        (should ess-r-package-mode))
+      (kill-buffer))))
 
-(ert-deftest ess-r-package-auto-no-activation-in-shell ()
+(ert-deftest ess-r-package-auto-no-activation-in-shell-test ()
   (let ((kill-buffer-query-functions nil))
     (with-r-file "dummy-pkg/R/test.R"
       (let ((ess-r-package-exclude-modes '(shell-mode)))
@@ -38,7 +38,7 @@
         (should (not ess-r-package-mode))
         (kill-buffer)))))
 
-(ert-deftest ess-r-package-vars ()
+(ert-deftest ess-r-package-vars-test ()
   (with-c-file "dummy-pkg/src/test.c"
     (let ((r-setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist)))
           (r-getwd-cmd (cdr (assq 'ess-getwd-command ess-r-customize-alist))))

--- a/test/ess-r-package-tests.el
+++ b/test/ess-r-package-tests.el
@@ -14,7 +14,8 @@
       (should ess-r-package-mode))))
 
 (ert-deftest ess-r-package-auto-activation-in-shell-test ()
-  (let ((kill-buffer-query-functions nil))
+  (let ((inhibit-message ess-inhibit-message-in-tests)
+        (kill-buffer-query-functions nil))
     (with-r-file "dummy-pkg/R/test.R"
       (shell)
       (should ess-r-package-mode)

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -6,7 +6,7 @@
 
 ;;; R
 
-(ert-deftest ess-r-inherits-prog-mode ()
+(ert-deftest ess-r-inherits-prog-mode-test ()
   (let ((prog-mode-hook (lambda () (setq ess-test-prog-hook t))))
     (with-r-file nil
       (should (derived-mode-p 'prog-mode))
@@ -21,7 +21,7 @@
              (setq map (keymap-parent map))))
          found)))))
 
-(ert-deftest ess-build-eval-command-R ()
+(ert-deftest ess-build-eval-command-R-test ()
   (let ((command "command(\"string\")")
         (ess-dialect "R"))
     (should (string= (ess-build-eval-command command)
@@ -31,7 +31,7 @@
     (should (string= (ess-build-eval-command command t t "file.ext" "foo")
                      ".ess.ns_eval(\"command(\\\"string\\\")\", visibly = TRUE, output = TRUE, package = 'foo', verbose = TRUE, file = 'file.ext')\n"))))
 
-(ert-deftest ess-build-load-command-R ()
+(ert-deftest ess-build-load-command-R-test ()
   (let ((ess-dialect "R"))
     (should (string= (ess-build-load-command "file.ext")
                      ".ess.source('file.ext', visibly = FALSE, output = FALSE)\n"))
@@ -40,7 +40,7 @@
     (should (string= (ess-build-load-command "file.ext" nil t "foo")
                      ".ess.ns_source('file.ext', visibly = FALSE, output = TRUE, package = 'foo', verbose = TRUE)\n"))))
 
-(ert-deftest inferior-ess-inherits-from-comint ()
+(ert-deftest inferior-ess-inherits-from-comint-test ()
   (with-temp-buffer
     (inferior-ess-r-mode)
     ;; Derive from comint
@@ -55,21 +55,21 @@
            (setq map (keymap-parent map))))
        found))))
 
-(ert-deftest ess-r-send-single-quoted-strings ()
+(ert-deftest ess-r-send-single-quoted-strings-test ()
   (with-r-running nil
     (insert "'hop'\n")
     (let (ess-eval-visibly)
       (should (output= (ess-eval-buffer nil)
                        "[1] \"hop\"")))))
 
-(ert-deftest ess-r-send-double-quoted-strings ()
+(ert-deftest ess-r-send-double-quoted-strings-test ()
   (with-r-running nil
     (insert "\"hop\"\n")
     (let (ess-eval-visibly)
       (should (output= (ess-eval-buffer nil)
                        "[1] \"hop\"")))))
 
-(ert-deftest ess-eval-line ()
+(ert-deftest ess-eval-line-test ()
   (with-r-running nil
     (insert "1 + 1")
     (let (ess-eval-visibly)
@@ -79,7 +79,7 @@
       (should (output= (ess-eval-line)
                        "1 + 1\n[1] 2")))))
 
-(ert-deftest ess-eval-region ()
+(ert-deftest ess-eval-region-test ()
   (with-r-running nil
     (insert "1 + \n1")
     (let (ess-eval-visibly)
@@ -90,7 +90,7 @@
       (should (output= (ess-eval-region (point-min) (point-max) nil)
                        "1 + \n1\n[1] 2")))))
 
-(ert-deftest ess-r-eval-rectangle-mark-mode ()
+(ert-deftest ess-r-eval-rectangle-mark-mode-test ()
   (with-r-running nil
     (insert "x <- 1\nx\nx + 1\nx  +  2\n")
     (let (ess-eval-visibly)
@@ -103,7 +103,7 @@
                          (ess-eval-region-or-line-and-step))
                        "> [1] 1\n> [1] 2\n> [1] 3")))))
 
-(ert-deftest ess-set-working-directory ()
+(ert-deftest ess-set-working-directory-test ()
   (with-r-running nil
     (ess-set-working-directory "/")
     (ess-eval-linewise "getwd()" 'invisible)
@@ -111,14 +111,14 @@
                      "setwd('/')\n> [1] \"/\""))
     (should (string= default-directory "/"))))
 
-(ert-deftest ess-inferior-force ()
+(ert-deftest ess-inferior-force-test ()
   (with-r-running nil
     (should (equal (ess-get-words-from-vector "letters[1:2]\n")
                    (list "a" "b")))))
 
 ;;; Namespaced evaluation
 
-(ert-deftest ess-r-run-presend-hooks ()
+(ert-deftest ess-r-run-presend-hooks-test ()
   (with-r-running nil
     (let ((ess-presend-filter-functions (list (lambda (string) "\"bar\"")))
           (ess-r-evaluation-env "base")
@@ -127,7 +127,7 @@
       (should (output= (ess-eval-region (point-min) (point-max) nil)
                        "[1] \"bar\"")))))
 
-(ert-deftest ess-r-namespaced-eval-no-sourced-message ()
+(ert-deftest ess-r-namespaced-eval-no-sourced-message-test ()
   (with-r-running nil
     (let ((ess-r-evaluation-env "base")
           ess-eval-visibly)
@@ -135,7 +135,7 @@
       (should (output= (ess-eval-region (point-min) (point-max) nil)
                        "[1] \"foo\"")))))
 
-(ert-deftest ess-r-namespaced-eval-no-srcref-in-errors ()
+(ert-deftest ess-r-namespaced-eval-no-srcref-in-errors-test ()
   ;; Fails since https://github.com/emacs-ess/ESS/commit/3a7d913
   (when nil
     (with-r-running nil
@@ -150,14 +150,14 @@
 
 ;;; Misc
 
-(ert-deftest ess-r-makevars-mode ()
+(ert-deftest ess-r-makevars-mode-test ()
   (save-window-excursion
     (mapc (lambda (file)
             (switch-to-buffer (find-file-noselect file))
             (should (eq major-mode 'makefile-mode)))
           '("fixtures/Makevars" "fixtures/Makevars.win"))))
 
-(ert-deftest ess-find-newest-date ()
+(ert-deftest ess-find-newest-date-test ()
   (should (equal (ess-find-newest-date '(("2003-10-04" . "R-1.7")
                                          ("2006-11-19" . "R-2.2")
                                          ("2007-07-01" . "R-dev")
@@ -165,7 +165,7 @@
                                          ("2005-12-30" . "R-2.0")))
                  "R-dev")))
 
-(ert-deftest ess-insert-S-assign ()
+(ert-deftest ess-insert-S-assign-test ()
   ;; one call should insert assignment:
   (should
    (string= " <- "
@@ -175,7 +175,7 @@
                 (call-interactively 'ess-insert-S-assign)
                 (buffer-substring (point-min) (point-max)))))))
 
-(ert-deftest ess-skip-thing ()
+(ert-deftest ess-skip-thing-test ()
   (should (eql 18
                (ess-r-test-with-temp-text "x <- function(x){\n mean(x)\n }\n \n \n x(3)\n "
                  (progn
@@ -213,14 +213,14 @@
                    (ess-next-code-line)
                    (point))))))
 
-(ert-deftest ess-Rout-file ()
+(ert-deftest ess-Rout-file-test ()
   (let ((buf (find-file-noselect "fixtures/file.Rout")))
     (with-current-buffer buf
       (should (eq major-mode 'ess-r-transcript-mode))
       (font-lock-default-fontify-buffer)
       (should (eq (face-at-point) 'font-lock-function-name-face)))))
 
-(ert-deftest inferior-ess-r-fontification ()
+(ert-deftest inferior-ess-r-fontification-test ()
   (with-r-running nil
     (with-ess-process-buffer nil
       ;; Function-like keywords
@@ -239,7 +239,7 @@
       (should (not (face-at-point))))))
 
 ;; roxy
-(ert-deftest ess-roxy-preview-Rd ()
+(ert-deftest ess-roxy-preview-Rd-test ()
   (skip-unless (or (getenv "CONTINUOUS_INTEGRATION")
                    (member "roxygen2" (ess-r-installed-packages))))
   (with-r-running nil
@@ -275,7 +275,7 @@ add <- function(x, y) {
                 (kill-whole-line)
                 (buffer-substring-no-properties (point-min) (point-max)))))))
 
-(ert-deftest ess-roxy-cpp ()
+(ert-deftest ess-roxy-cpp-test ()
   ;; Test M-q
   (should (string=
            "//' Title

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -41,19 +41,20 @@
                      ".ess.ns_source('file.ext', visibly = FALSE, output = TRUE, package = 'foo', verbose = TRUE)\n"))))
 
 (ert-deftest inferior-ess-inherits-from-comint-test ()
-  (with-temp-buffer
-    (inferior-ess-r-mode)
-    ;; Derive from comint
-    (should (derived-mode-p 'comint-mode))
-    (should
-     ;; Test that comint-mode-map is a keymap-parent
-     (let ((map (current-local-map))
-           found)
-       (while (and map (not found))
-         (if (eq (keymap-parent map) comint-mode-map)
-             (setq found t)
-           (setq map (keymap-parent map))))
-       found))))
+  (let ((inhibit-message ess-inhibit-message-in-tests))
+    (with-temp-buffer
+      (inferior-ess-r-mode)
+      ;; Derive from comint
+      (should (derived-mode-p 'comint-mode))
+      (should
+       ;; Test that comint-mode-map is a keymap-parent
+       (let ((map (current-local-map))
+             found)
+         (while (and map (not found))
+           (if (eq (keymap-parent map) comint-mode-map)
+               (setq found t)
+             (setq map (keymap-parent map))))
+         found)))))
 
 (ert-deftest ess-r-send-single-quoted-strings-test ()
   (with-r-running nil

--- a/test/ess-r-tests.el
+++ b/test/ess-r-tests.el
@@ -199,18 +199,18 @@
                     (goto-char (point-min))
                     (ess-skip-thing 'function)))))
 
-(ert-deftest ess-step-line ()
+(ert-deftest ess-next-code-line-test ()
   (should (eql 5
                (ess-r-test-with-temp-text "1+1\n#2+2\n#3+3\n4+4"
                  (let ((ess-eval-empty t))
                    (goto-char (point-min))
-                   (ess-step-line)
+                   (ess-next-code-line)
                    (point)))))
   (should (eql 15
                (ess-r-test-with-temp-text "1+1\n#2+2\n#3+3\n4+4"
                  (let (ess-eval-empty)
                    (goto-char (point-min))
-                   (ess-step-line)
+                   (ess-next-code-line)
                    (point))))))
 
 (ert-deftest ess-Rout-file ()


### PR DESCRIPTION
Making a PR as per discussion in #721. I am removing `ess-step-line` because it does two things , has a non-suggestive name and, in fact, is not needed. Most of it was swallowed by ess-next-code-line and the places of its previous usage are now more explicit. 