### PR TITLE
Simplify imenu setup

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -148,9 +148,6 @@ as `ess-imenu-use-S'."
   :group 'ess
   :type  'boolean)
 
-(defvar ess-imenu-generic-expression nil
-  "Placeholder for imenu-generic-expression. Dialect specific.")
-
 (defcustom ess-auto-width-visible nil
   "When non-nil, echo width setting in the inferior buffer.
 See `ess-auto-width'. Be warned that ESS can set the width a

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -316,7 +316,6 @@ to look up any doc strings."
     (ess-dump-error-re             . "in \\w* at \\(.*\\):[0-9]+")
     (ess-error-regexp              . "\\(^\\s-*at\\s-*\\(?3:.*\\):\\(?2:[0-9]+\\)\\)")
     (ess-error-regexp-alist        . ess-julia-error-regexp-alist)
-    (ess-imenu-generic-expression  . ess-julia-imenu-generic-expression)
     (ess-mode-completion-syntax-table . ess-julia-completion-syntax-table)
     ;; (inferior-ess-objects-command    . inferior-ess-r-objects-command)
     ;; (inferior-ess-search-list-command        . "search()\n")

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -108,7 +108,6 @@
     ;; (inferior-ess-secondary-prompt . "[+:] ") ;; catch Selection: and alike
     (inferior-ess-secondary-prompt . "+ ") ;; catch Selection: and alike
     (comment-start                . "#")
-    (ess-imenu-generic-expression  . ess-imenu-S-generic-expression)
     (comment-add                  . 1)
     (comment-start-skip           . "#+ *")
     (comment-use-syntax           . t)  ; see log for bug report 2013-06-07
@@ -670,11 +669,10 @@ and I need to relearn emacs lisp (but I had to, anyway."
 
 (defun ess-imenu-S (&optional arg)
   "S Language Imenu support for ESS."
-  (interactive)
-  (setq imenu-generic-expression ess-imenu-generic-expression)
+  (declare (obsolete "It is set automatically in major modes" "ESS 19.04"))
   (imenu-add-to-menubar "Imenu-S"))
 
-(defalias 'ess-imenu-R 'ess-imenu-S)
+(define-obsolete-function-alias 'ess-imenu-R 'ess-imenu-S "ESS 19.04")
 
 
  ;;; Speedbar stuff.

--- a/lisp/ess-sp6-d.el
+++ b/lisp/ess-sp6-d.el
@@ -141,7 +141,8 @@ New way to do it."
   (setq-local ess-local-customize-alist S+-customize-alist)
   (ess-mode)
   (if (fboundp 'ess-add-toolbar) (ess-add-toolbar))
-  (if ess-imenu-use-S (ess-imenu-S)))
+  (setq imenu-generic-expression ess-imenu-S-generic-expression)
+  (when ess-imenu-use-S (imenu-add-to-menubar "Imenu-S")))
 
 (defalias 'S+6-transcript-mode 'S+-transcript-mode)
 (define-derived-mode S+-transcript-mode ess-transcript-mode "ESS S Transcript"

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -721,7 +721,7 @@ GTags file (default TAGS): ")
   (if (and (ess-build-tags-command) (null current-prefix-arg))
       (ess-eval-linewise (format (ess-build-tags-command) dir tagfile))
     ;; else generate from imenu
-    (unless (or imenu-generic-expression ess-imenu-generic-expression) ;; need both!!
+    (unless imenu-generic-expression
       (error "No ess-tag-command found, and no imenu-generic-expression defined"))
     (let* ((find-cmd
             (format "find %s -type f -size 1M \\( -regex \".*\\.\\(cpp\\|jl\\|[RsrSch]\\(nw\\)?\\)$\" \\)" dir))


### PR DESCRIPTION
Remove variable `ess-imenu-generic-expression' and set
`imenu-generic-expression' directly in major mode setup. Also obsolete
auxiliary functions `ess-imenu-S' and `ess-imenu-R'.