### PR TITLE
minimize ess-async-command-test

### DIFF
--- a/test/ess-inf-tests.el
+++ b/test/ess-inf-tests.el
@@ -49,12 +49,14 @@
   ;; (ess-async-command "{cat(1:5);Sys.sleep(5);cat(2:6)}\n" nil (get-process "R")
   ;;                    (lambda (proc) (message "done"))
   (with-r-running nil
-    (let ((output-buffer (get-buffer-create " *ess-async-text-command-output*"))
-          output)
-      (ess-async-command "{cat(1:5);Sys.sleep(0.5);cat(2:6)}\n" output-buffer (get-process "R")
-                         (lambda (proc string) (setq output string)))
-      (sleep-for 0.6)
-      (should (string= "2 3 4 5 6> " output)))))
+    (ess-async-command "{cat(1:5);Sys.sleep(0.5);cat(2:6)}\n"
+                       (get-buffer-create " *ess-async-text-command-output*")
+                       (get-process "R")
+                       (lambda (proc string)))
+    (loop repeat 3
+          until (null (process-get (get-process "R") 'callbacks))
+          do (sleep-for 0 600)
+          finally (should-not (process-get (get-process "R") 'callbacks)))))
 
 (ert-deftest ess-run-presend-hooks-test ()
   (with-r-running nil

--- a/test/ess-inf-tests.el
+++ b/test/ess-inf-tests.el
@@ -52,7 +52,8 @@
     (ess-async-command "{cat(1:5);Sys.sleep(0.5);cat(2:6)}\n"
                        (get-buffer-create " *ess-async-text-command-output*")
                        (get-process "R")
-                       (lambda (proc string)))
+                       #'ignore)
+    (should (process-get (get-process "R") 'callbacks))
     (loop repeat 3
           until (null (process-get (get-process "R") 'callbacks))
           do (sleep-for 0 600)

--- a/test/ess-inf-tests.el
+++ b/test/ess-inf-tests.el
@@ -49,15 +49,16 @@
   ;; (ess-async-command "{cat(1:5);Sys.sleep(5);cat(2:6)}\n" nil (get-process "R")
   ;;                    (lambda (proc) (message "done"))
   (with-r-running nil
-    (ess-async-command "{cat(1:5);Sys.sleep(0.5);cat(2:6)}\n"
-                       (get-buffer-create " *ess-async-text-command-output*")
-                       (get-process "R")
-                       #'ignore)
-    (should (process-get (get-process "R") 'callbacks))
-    (loop repeat 3
-          until (null (process-get (get-process "R") 'callbacks))
-          do (sleep-for 0 600)
-          finally (should-not (process-get (get-process "R") 'callbacks)))))
+    (lexical-let (semaphore)                  
+      (ess-async-command "{cat(1:5);Sys.sleep(0.5);cat(2:6)}\n"
+                         (get-buffer-create " *ess-async-text-command-output*")
+                         (get-process "R")
+                         (lambda (&rest args) (setq semaphore t)))
+      (should (process-get (get-process "R") 'callbacks))
+      (loop repeat 3
+            until (and semaphore (null (process-get (get-process "R") 'callbacks)))
+            do (sleep-for 0 600)
+            finally (should-not (process-get (get-process "R") 'callbacks))))))
 
 (ert-deftest ess-run-presend-hooks-test ()
   (with-r-running nil


### PR DESCRIPTION
The vagaries of timing between R's process stdout and the idiosyncratic
`suppress-output` flag cause this test to occasionally fail, e.g.,
```
    (ert-test-failed
     ((should
       (string= "2 3 4 5 6> " output))
      :form
      (string= "2 3 4 5 6> " "6> ")
      :value nil))
```
Rework the test to merely ensure the callback eventually gets called, without
regard to what its output looks like.