### PR TITLE
Refactor ess-rdired.el

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -73,6 +73,10 @@ This is similar with what you would see with, for example
 version as well. This only works with @code{options(useFancyQuotes =
 TRUE)} (the default).
 
+@item @code{ess-rdired} buffers now derive from tabulated-list-mode.
+They should look better and be a bit faster overall. The size column
+now displays object sizes in bytes.
+
 @item ESS removed support for many unused languages.
 This includes old versions of S+, ARC, OMG, VST, and XLS.
 

--- a/lisp/ess-rdired.el
+++ b/lisp/ess-rdired.el
@@ -76,7 +76,7 @@
 (require 'ess-custom)
 (require 'ess-inf)
 
-(defvar ess-rdired-objects "{.rdired.objects <- function(objs) {
+(defvar ess-rdired-objects "local({.rdired.objects <- function(objs) {
   if (length(objs)==0) {
     \"No objects to view!\"
   } else {
@@ -99,7 +99,7 @@
   row.names(d) <- paste('  ', var.names, sep='')
   d
   }
-}; cat('\n'); print(.rdired.objects(ls()))}\n"
+}; cat('\n'); print(.rdired.objects(ls(envir = .GlobalEnv)))})\n"
   "Function to call within R to print information on objects.
 The last line of this string should be the instruction to call
 the function which prints the output for rdired.")


### PR DESCRIPTION
This PR re-implements ess-rdired so that it derives from `tabulated-list-mode`. It's overall much cleaner (I think, anyway. It's at least shorter by about 140 lines!) and a little snappier. 