### PR TITLE
Query to save modified files in R packages during devtools commands

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -51,6 +51,9 @@ ess-gen-proc-buffer-name:project-or-directory. As the name suggests,
 these now rely on project.el (included with Emacs) rather than
 projectile.el, which is a third-party package.
 
+@item ESS[R]: devtools commands ask about saving modified buffers before running.
+Users can disable the questioning with @code{ess-save-silently}.
+
 @item ESS[R] help pages now provide links to other help topics.
 This is similar with what you would see with, for example
 @code{options(help_type = ``html'')} but works with the plain-text

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -674,10 +674,18 @@ blink the filling region."
   :group 'ess-edit
   :type 'boolean)
 
-(defcustom ess-mode-silently-save t
-  "Non-nil means automatically save ESS source buffers before loading."
+(define-obsolete-variable-alias 'ess-mode-silently-save 'ess-save-silently "ESS 19.04")
+(defcustom ess-save-silently 'auto
+  "If non-nil, possibly save buffers without asking.
+If t, save without asking. If 'auto, save without asking if
+either `compilation-ask-about-save' or `auto-save-visited-mode'
+is non-nil. Affects `ess-save-file'."
   :group 'ess-edit
-  :type 'boolean)
+  :type '(choice (const :tag "Do not save without asking." :value nil)
+                 (const :tag "Use compilation-ask-about-save and auto-save-visited-mode."
+                        :value 'auto)
+                 (const :tag "Save without asking." :value t))
+  :package-version '(ess . "19.04"))
 
 ;;*;; Variables controlling editing
 

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -250,6 +250,7 @@ arguments, or expressions which return R arguments."
         (args (ess-r-command--build-args p actions)))
     (unless (car pkg-info)
       (user-error "Not in a package"))
+    (ess-project-save-buffers)
     (message msg (alist-get :name pkg-info))
     (display-buffer (ess-get-process-buffer))
     (let ((pkg-path (concat "'" (abbreviate-file-name (alist-get :root pkg-info)) "'")))
@@ -362,6 +363,16 @@ With prefix argument ARG, run tests on current file only."
   devtools::revdep_check_save_logs(res, logs_path)
 })
 ")
+
+(defun ess-project-save-buffers ()
+  "Offer to save modified files in the current project.
+Respects `ess-save-silently', which see."
+  (let ((cur-proj ess-r-package--info-cache))
+    (dolist (buf (buffer-list))
+      (when-let ((file (buffer-file-name buf))
+                 (buf-proj (buffer-local-value 'ess-r-package--info-cache buf)))
+        (when (equal cur-proj buf-proj)
+          (ess-save-file file))))))
 
 (defun ess-r-devtools-document-package (&optional arg)
   "Interface for `devtools::document()'.


### PR DESCRIPTION
This PR saves, or offers to save (depending on `ess-silently-save`) modified buffers in the current R project before running devtools commands.