### PR TITLE
Add auto-update mechanism for ess-rdired buffers

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -64,6 +64,10 @@ TRUE)} (the default).
 They should look better and be a bit faster overall. The size column
 now displays object sizes in bytes.
 
+@item @code{ess-rdired} buffers now auto-update.
+The frequency is governed by the new option
+@code{ess-rdired-auto-update-interval}.
+
 @item ESS removed support for many unused languages.
 This includes old versions of S+, ARC, OMG, VST, and XLS.
 

--- a/lisp/ess-rdired.el
+++ b/lisp/ess-rdired.el
@@ -157,6 +157,9 @@ can then examine these objects, plot them, and so on."
 You may interact with these objects, see `ess-rdired-mode' for
 details."
   (interactive)
+  (unless (and (string= "R" ess-dialect)
+               ess-local-process-name)
+    (error "Not in an R buffer with attached process"))
   (let ((proc ess-local-process-name))
     (pop-to-buffer (get-buffer-create ess-rdired-buffer))
     (setq ess-local-process-name proc)


### PR DESCRIPTION
* lisp/ess-rdired.el:
(ess-rdired-auto-update-timer): New user option to control update interval.
(ess-rdired-mode): Start the timer, remove the timer when the buffer is killed.
(ess-rdired): Delegate most functionality to new 'ess-rdired-refresh' function.
(ess-rdired-refresh): New function.
(ess-rdired-cancel-auto-update-timer): New function.