### PR TITLE
Simplify help topic retrieval functions

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2158,9 +2158,6 @@ If set, changes will take effect when next R session is started."
   :group 'ess-command
   :type 'string)
 
-(defvar-local ess-get-help-topics-function nil
-  "Dialect specific help topics retrieval")
-
 (defvar-local ess-display-help-on-object-function nil
   "Dialect specific function for displaying help on object.")
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2164,9 +2164,6 @@ If set, changes will take effect when next R session is started."
 (defvar-local ess-display-help-on-object-function nil
   "Dialect specific function for displaying help on object.")
 
-(defvar-local ess-find-help-file-function nil
-  "Dialect specific function for displaying help on object.")
-
 (defvar-local ess-build-help-command-function nil
   "Dialect specific function for building an help command.")
 

--- a/lisp/ess-gretl.el
+++ b/lisp/ess-gretl.el
@@ -438,7 +438,7 @@ end keywords as associated values.")
         (push (match-string-no-properties 0) acum))
       acum)))
 
-(defun gretl-get-help-topics-function (name)
+(cl-defmethod ess-help-get-topics (proc &context ((string= ess-dialect "gretl") (eql t)))
   (delete-dups
    (append gretl-command-words gretl-genr-functions
            gretl-block-end-keywords gretl-block-other-keywords
@@ -464,7 +464,6 @@ end keywords as associated values.")
     (inferior-ess-prompt		. "\\? ")
     (ess-local-customize-alist		. 'gretl-customize-alist)
     (inferior-ess-program		. "gretlcli")
-    (ess-get-help-topics-function	. 'gretl-get-help-topics-function)
     (ess-load-command   		. "open \"%s\"\n")
     ;; (ess-dump-error-re			. "in \\w* at \\(.*\\):[0-9]+")
     ;; (ess-error-regexp			. "\\(^\\s-*at\\s-*\\(?3:.*\\):\\(?2:[0-9]+\\)\\)")

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -710,7 +710,7 @@ Keystroke    Section
   "Return a list (def obj fun).
 Obj is a name at point, fun is the name of the function call
 point is in, and def is either obj or fun (in that order) which
-has a a help file, i.e. it is a member of slist (string-list).
+has a a help file, i.e. it is a member of SLIST (string-list).
 nil otherwise."
   (let* ((obj (ess-helpobjs-at-point--read-obj))
          (unqualified-obj (and obj (ess-unqualify-symbol obj)))
@@ -729,18 +729,17 @@ nil otherwise."
               (car (member fun slist)))
           obj fun)))
 
+(cl-defgeneric ess-help-get-topics (proc)
+  "Return a list of help topics from PROC."
+  (user-error "Not supported for %s, %s" ess-dialect proc))
+
 (defun ess-find-help-file (p-string)
-  "Find help, prompting for P-STRING.
-Note that we can't search SAS, Stata or XLispStat for additional information."
+  "Find help, prompting for P-STRING."
   (ess-make-buffer-current)
-  (cond
-   ((fboundp ess-get-help-topics-function)
-    (let* ((help-files-list (funcall ess-get-help-topics-function ess-current-process-name))
-           (hlpobjs (ess-helpobjs-at-point help-files-list)))
-      (ess-completing-read p-string (append (delq nil hlpobjs) help-files-list)
-                           nil nil nil nil (car hlpobjs))))
-   (t
-    (read-string (format "%s: " p-string)))))
+  (let* ((help-files-list (ess-help-get-topics ess-current-process-name))
+         (hlpobjs (ess-helpobjs-at-point help-files-list)))
+    (ess-completing-read p-string (append (delq nil hlpobjs) help-files-list)
+                         nil nil nil nil (car hlpobjs))))
 
 
 ;;*;; Utility functions

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -734,10 +734,6 @@ nil otherwise."
 Note that we can't search SAS, Stata or XLispStat for additional information."
   (ess-make-buffer-current)
   (cond
-   ((fboundp ess-find-help-file-function)
-    (funcall ess-find-help-file-function p-string))
-   ;; Fixme: Are `ess-find-help-file-function' and
-   ;; `ess-get-help-topics-function' redundant?
    ((fboundp ess-get-help-topics-function)
     (let* ((help-files-list (funcall ess-get-help-topics-function ess-current-process-name))
            (hlpobjs (ess-helpobjs-at-point help-files-list)))

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -70,7 +70,7 @@ VISIBLY is not currently used."
 
 
 ;;; HELP
-(defun ess-julia-get-help-topics (&optional proc)
+(cl-defmethod ess-help-get-topics (proc &context ((string= ess-dialect "julia") (eql t)))
   (append (with-current-buffer (ess-command "ESS.all_help_topics()\n")
             (split-string (buffer-string) "\n"))
           (ess-julia--get-objects proc)))
@@ -307,7 +307,6 @@ to look up any doc strings."
     (inferior-ess-prompt           . "\\w*> ")
     (ess-local-customize-alist     . 'ess-julia-customize-alist)
     (inferior-ess-program          . inferior-julia-program)
-    (ess-get-help-topics-function  . 'ess-julia-get-help-topics)
     (ess-help-web-search-command   . "https://docs.julialang.org/en/latest/search/?q=%s")
     (ess-manual-lookup-command     . 'ess-julia-manual-lookup-function)
     ;; (ess-reference-lookup-command       . 'ess-julia-reference-lookup-function)

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -2257,8 +2257,7 @@ state.")
         ess-build-help-command-function #'ess-r-build-help-command
         ess-help-sec-regex ess-help-r-sec-regex
         ess-help-sec-keys-alist ess-help-r-sec-keys-alist ; TODO: Still necessary?
-        inferior-ess-help-command inferior-ess-r-help-command
-        ess-get-help-topics-function #'ess-s-get-help-topics-function)
+        inferior-ess-help-command inferior-ess-r-help-command)
   (ess-r-help-add-links))
 
 (define-button-type 'ess-r-help-link
@@ -2273,7 +2272,7 @@ state.")
 (defun ess-r-help-add-links ()
   "Add links to the help buffer."
   (let ((help-topics (when (ess-process-live-p)
-                       (ess-s-get-help-topics-function ess-local-process-name)))
+                       (ess-help-get-topics ess-local-process-name)))
         (inhibit-read-only t))
     (save-excursion
       ;; Search for fancy quotes only. If users have

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -115,7 +115,6 @@
     ;; inferior-ess-prompt is used by comint for navigation, only if
     ;; comint-use-prompt-regexp is t; (transcript-mode also relies on this regexp)
     (inferior-ess-prompt           . inferior-S-prompt)
-    (ess-get-help-topics-function  . #'ess-s-get-help-topics-function)
     (ess-getwd-command          . "getwd()\n")
     (ess-setwd-command          . "setwd('%s')\n")
     (ess-funargs-command        . ".ess_funargs(\"%s\")\n")
@@ -695,8 +694,8 @@ and I need to relearn emacs lisp (but I had to, anyway."
           (ess-S-initialize-speedbar)))
     (error nil)))
 
-(defun ess-s-get-help-topics-function (name)
-  "Return a list of current S help topics associated with process NAME.
+(cl-defmethod ess-help-get-topics (proc &context ((string= ess-dialect "R") (eql t)))
+  "Return a list of current S help topics associated with process PROC.
 If 'sp-for-help-changed?' process variable is non-nil or
 `ess-help-topics-list' is nil, (re)-populate the latter and
 return it.  Otherwise, return `ess-help-topics-list'."
@@ -710,7 +709,7 @@ return it.  Otherwise, return `ess-help-topics-list'."
       (ess-process-put 'sp-for-help-changed? nil)
       (setq ess-help-topics-list
             (delete-dups
-             (append (ess-get-object-list name 'exclude-1st)
+             (append (ess-get-object-list proc 'exclude-1st)
                      (ess-get-help-files-list)
                      (ess-get-help-aliases-list)))))
      (t

--- a/lisp/ess-stata-mode.el
+++ b/lisp/ess-stata-mode.el
@@ -84,7 +84,6 @@
     (inferior-ess-secondary-prompt . "--more--")
     (comint-use-prompt-regexp      . t)
     (inferior-ess-start-args       . inferior-STA-start-args)
-    (ess-get-help-topics-function  . 'ess-get-STA-help-topics)
     (inferior-ess-search-list-command   . "set more off\n search()\n")
     (comment-start                . "/\* ")
     (comment-end                  . " \*/")
@@ -207,8 +206,8 @@ This function is placed in `ess-presend-filter-functions'.
       (nreverse (delete-dups topics))
       )))
 
-(defun ess-get-STA-help-topics (&optional name)
-  "Return a list of current STA help topics associated with process NAME."
+(cl-defmethod ess-help-get-topics (proc &context ((string= ess-dialect "stata") (eql t)))
+  "Return a list of current STA help topics associated with process PROC."
   (or (ess-process-get 'help-topics)
       (progn
         (ess-process-put 'help-topics (ess--STA-retrive-topics-from-search))


### PR DESCRIPTION
Details in the commit comments, but the gist is to remove a few variables that held functions and just use the new generic `ess-help-get-topics`