### PR TITLE
Refactor ess-help--display

### DIFF
--- a/doc/ess.texi
+++ b/doc/ess.texi
@@ -2195,6 +2195,13 @@ frame.  If you wish help buffers to appear in their own frame (either
 one per help buffer, or one for all help buffers), you can customize the
 variable @code{ess-help-own-frame}.
 
+Help buffers are displayed by calling the function
+@code{ess-display-help}. You can customize where these buffers are
+displayed by adding an entry in @code{display-buffer-alist} (see
+@xref{Controlling buffer display,,, ess} for examples) or by customizing
+the options @code{ess-help-own-frame}, @code{ess-help-frame-alist},
+and @code{ess-display-buffer-reuse-frame}.
+
 @findex ess-quit
 @findex ess-cleanup
 @cindex temporary buffers

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2515,8 +2515,9 @@ default."
 
 (defcustom ess-help-pop-to-buffer t
   "If non-nil ess-help buffers are given focus during the display.
-The default is t (except when `focus-follows-mouse' and
-`mouse-autoselect-window' are both t)."
+If non-nil, `ess-display-help' uses `pop-to-buffer' to display
+help, otherwise it uses `display-buffer', which does not select
+the help window."
   :group 'ess-help
   :type 'boolean)
 
@@ -2528,19 +2529,17 @@ Possible values are:
   'one: All help buffers are shown in one dedicated frame.
      t: Each help buffer gets its own frame.
 
-Note if you set this to t you should also set
-`ess-help-reuse-window' to nil to ensure that help buffers are
-displayed in a new frame.
-
-The parameters of the own frame are stored in `ess-help-frame-alist'.
-See also `inferior-ess-own-frame'."
+If this is non-nil,`ess-help-reuse-window' is ignored. The
+parameters of the own frame are stored in
+`ess-help-frame-alist'."
   :group 'ess-help
   :type '(choice (const :tag "Display in current frame" nil)
                  (const :tag "Display in one frame" one)
                  (const :tag "Always display in a new frame" t)))
 
 (defcustom ess-help-reuse-window t
-  "If t, ESS tries to display new help buffers in the existing help window."
+  "If t, ESS tries to display new help buffers in the existing help window.
+This variable is ignored if `ess-help-own-frame' is non-nil."
   :type 'boolean
   :group 'ess-help)
 

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -472,7 +472,7 @@ ESS-specific variables `ess-help-own-frame',
                           display-buffer-pop-up-frame))
                        (ess-help-reuse-window
                         '(display-buffer-reuse-window
-                          display-buffer-reuse-mode-window
+                          ess-display-buffer-reuse-mode-window
                           display-buffer-pop-up-window
                           display-buffer-use-some-window))
                        (t '(display-buffer-pop-up-window
@@ -874,6 +874,62 @@ other dialects)."
       (display-buffer buf)
       (set-window-point (get-buffer-window buf) pos) ;; don't move window point
       buf)))
+
+(with-no-warnings
+  ;; We're just backporting here, don't care about compiler warnings
+  (defalias 'ess-display-buffer-reuse-mode-window
+    ;; TODO: Remove once we drop support for Emacs 25
+    (if (fboundp 'display-buffer-reuse-mode-window)
+        'display-buffer-reuse-mode-window
+      (lambda (buffer alist)
+        (let* ((alist-entry (assq 'reusable-frames alist))
+               (alist-mode-entry (assq 'mode alist))
+	       (frames (cond (alist-entry (cdr alist-entry))
+		             ((if (eq pop-up-frames 'graphic-only)
+			          (display-graphic-p)
+			        pop-up-frames)
+			      0)
+		             (display-buffer-reuse-frames 0)
+		             (t (last-nonminibuffer-frame))))
+               (inhibit-same-window-p (cdr (assq 'inhibit-same-window alist)))
+	       (windows (window-list-1 nil 'nomini frames))
+               (buffer-mode (with-current-buffer buffer major-mode))
+               (allowed-modes (if alist-mode-entry
+                                  (cdr alist-mode-entry)
+                                buffer-mode))
+               (curwin (selected-window))
+               (curframe (selected-frame)))
+          (unless (listp allowed-modes)
+            (setq allowed-modes (list allowed-modes)))
+          (let (same-mode-same-frame
+                same-mode-other-frame
+                derived-mode-same-frame
+                derived-mode-other-frame)
+            (dolist (window windows)
+              (let ((mode?
+                     (with-current-buffer (window-buffer window)
+                       (cond ((memq major-mode allowed-modes)
+                              'same)
+                             ((derived-mode-p allowed-modes)
+                              'derived)))))
+                (when (and mode?
+                           (not (and inhibit-same-window-p
+                                     (eq window curwin))))
+                  (push window (if (eq curframe (window-frame window))
+                                   (if (eq mode? 'same)
+                                       same-mode-same-frame
+                                     derived-mode-same-frame)
+                                 (if (eq mode? 'same)
+                                     same-mode-other-frame
+                                   derived-mode-other-frame))))))
+            (let ((window (car (nconc same-mode-same-frame
+                                      same-mode-other-frame
+                                      derived-mode-same-frame
+                                      derived-mode-other-frame))))
+              (when (window-live-p window)
+                (prog1 (window--display-buffer buffer window 'reuse alist)
+                  (unless (cdr (assq 'inhibit-switch-frame alist))
+                    (window--maybe-raise-frame (window-frame window))))))))))))
 
 (provide 'ess-help)
 ;;; ess-help.el ends here


### PR DESCRIPTION
This fixes some of the smaller bugs that keep popping up with the ess-help--display function like those mentioned in #826 by relying on display-buffer to set up some things automatically.

The biggest downside is probably the backport of display-buffer-reuse-mode-window, which doesn't exist in Emacs 25. 