### PR TITLE
Fix roxy bug inserting parameters from previous function

### DIFF
--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -783,18 +783,17 @@ See `hs-show-block' and `ess-roxy-hide-block'."
   (goto-char (ess-roxy-beg-of-entry)))
 
 (defun ess-roxy-get-function-args ()
-  "Return the arguments specified for the current function as a list of strings."
+  "Return the arguments specified for the current function as a list of strings.
+Assumes point is at the beginning of the function."
   (save-excursion
     (let ((args-txt
-           (progn
-             (beginning-of-defun)
-             (buffer-substring-no-properties
-              (progn
-                (search-forward-regexp "\\([=,-]+ *function *\\|^\s*function\\)" nil nil 1)
-                (+ (point) 1))
-              (progn
-                (ess-roxy-match-paren)
-                (point))))))
+           (buffer-substring-no-properties
+            (progn
+              (search-forward-regexp "\\([=,-]+ *function *\\|^\s*function\\)" nil nil 1)
+              (+ (point) 1))
+            (progn
+              (ess-roxy-match-paren)
+              (point)))))
       (setq args-txt (replace-regexp-in-string "#+[^\"']*\n" "" args-txt))
       (setq args-txt (replace-regexp-in-string "([^)]+)" "" args-txt))
       (setq args-txt (replace-regexp-in-string "=[^,]+" "" args-txt))

--- a/test/ess-test-r.el
+++ b/test/ess-test-r.el
@@ -312,6 +312,25 @@ add <- function(x, y) {
                   (kill-whole-line)
                   (buffer-substring-no-properties (point-min) (point-max))))))))
 
+(ert-deftest ess-roxy-get-function-args-test ()
+  (ess-r-test-with-temp-text
+      "#' a function
+#'
+#' @param x the param
+my_mean <- function(x, y){
+  mean(x) + mean(y)
+}
+
+#' another function
+#'
+#' @param z the param
+my_mean2 <- function(z){
+  mean(z)
+}"
+    (should (equal (ess-roxy-get-function-args) '("x" "y")))
+    (search-forward "param z the param")
+    (should (equal (ess-roxy-get-function-args) '("z")))))
+
 (ert-deftest ess-roxy-cpp-test ()
   ;; Test M-q
   (should (string=


### PR DESCRIPTION
Originally reported on the mailing list by Paul Johnson. With two
functions, 'ess-roxy-update-entry' would insert parameters from the
previous function. This is due to 'beginning-of-defun' getting called
with point already at the beginning of the function in
'ess-roxy-get-function-args'. Fix this by making
'ess-roxy-get-function-args' assume that point is at the beginning of
the function. Add tests.