### PR TITLE
Avoid killing help buffer invoked from package index

### DIFF
--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -46,7 +46,6 @@
 (require 'ess-utils)
 
 (declare-function ess-r-help-mode 'ess-r-mode)
-(declare-function ess-help-r--check-last-help-type 'ess-r-mode)
 (declare-function ess-stata-help-mode "ess-stata-lang")
 
 (defvar ess--help-frame nil
@@ -135,8 +134,7 @@ suplied, it is used instead of `inferior-ess-help-command'."
      (when current-prefix-arg ;update cache if prefix
        (ess-process-put 'sp-for-help-changed? t))
      (list (ess-find-help-file "Help on"))))
-  (ess-help-r--check-last-help-type) ; stabilize ess-help-r--last-help-type to avoid
-                                     ; killing tbuffer if R's help_type changed
+  (ess-help-get-topics ess-current-process-name) 
   (let* ((hb-name (concat "*help[" ess-current-process-name "]("
                           (replace-regexp-in-string "^\\?\\|`" "" object) ")*"))
          (old-hb-p (get-buffer hb-name))

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -46,6 +46,7 @@
 (require 'ess-utils)
 
 (declare-function ess-r-help-mode 'ess-r-mode)
+(declare-function ess-help-r--check-last-help-type 'ess-r-mode)
 (declare-function ess-stata-help-mode "ess-stata-lang")
 
 (defvar ess--help-frame nil
@@ -141,6 +142,8 @@ suplied, it is used instead of `inferior-ess-help-command'."
     (when (or (not old-hb-p)
               current-prefix-arg
               (ess--help-get-bogus-buffer-substring old-hb-p))
+      (ess-help-r--check-last-help-type) ; stabilize ess-help-r--last-help-type to avoid
+                                         ; killing tbuffer if R's help_type changed
       (ess-with-current-buffer tbuffer
         (ess--flush-help-into-current-buffer object command)
         (setq ess-help-object object)

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -135,6 +135,8 @@ suplied, it is used instead of `inferior-ess-help-command'."
      (when current-prefix-arg ;update cache if prefix
        (ess-process-put 'sp-for-help-changed? t))
      (list (ess-find-help-file "Help on"))))
+  (ess-help-r--check-last-help-type) ; stabilize ess-help-r--last-help-type to avoid
+                                     ; killing tbuffer if R's help_type changed
   (let* ((hb-name (concat "*help[" ess-current-process-name "]("
                           (replace-regexp-in-string "^\\?\\|`" "" object) ")*"))
          (old-hb-p (get-buffer hb-name))
@@ -142,8 +144,6 @@ suplied, it is used instead of `inferior-ess-help-command'."
     (when (or (not old-hb-p)
               current-prefix-arg
               (ess--help-get-bogus-buffer-substring old-hb-p))
-      (ess-help-r--check-last-help-type) ; stabilize ess-help-r--last-help-type to avoid
-                                         ; killing tbuffer if R's help_type changed
       (ess-with-current-buffer tbuffer
         (ess--flush-help-into-current-buffer object command)
         (setq ess-help-object object)

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -1241,6 +1241,7 @@ If it changes, we flush the cache.")
 
 (defun ess-help-r--check-last-help-type ()
   (let ((help-type (ess-string-command "getOption('help_type')\n")))
+    (unless ess-help-r--last-help-type (setq ess-help-r--last-help-type help-type))
     (when (not (string= help-type ess-help-r--last-help-type))
       (let ((help-buffers (ess-help-get-local-help-buffers)))
         (mapc #'kill-buffer help-buffers))


### PR DESCRIPTION
```
M-x R
C-c C-d i base
Click on object
```
will result in the warning `Selecting deleted buffer` and no help
buffer.  Such noninteractive calls to `ess-display-help-on-object` do
not first settle the help_type variable, resulting in the help logic
killing the buffer.