### PR TITLE
Do not create help links for objects documented in current buffer

### DIFF
--- a/test/ess-test-r.el
+++ b/test/ess-test-r.el
@@ -524,6 +524,39 @@ the_dat <- read.csv(\"foo.csv\")"
   (comint-next-prompt 1)
   (should (equal (line-number-at-pos) 3)))
 
+(ert-deftest ess-r-help-usage-objects-test ()
+  (with-temp-buffer
+    (let ((major-mode 'ess-r-help-mode))
+      (insert "The Student t Distribution
+
+Description:
+
+     Density, distribution function, quantile function and random
+     generation for the t distribution with df degrees of freedom
+     (and optional non-centrality parameter ‘ncp’).
+
+Usage:
+
+     dt(x, df, ncp, log = FALSE)
+     pt(q, df, ncp, lower.tail = TRUE, log.p = FALSE)
+     qt(p, df, ncp, lower.tail = TRUE, log.p = FALSE)
+     rt(n, df, ncp)
+
+Arguments:
+")
+      (should (equal (ess-r-help-usage-objects) '("rt" "qt" "pt" "dt")))))
+  (with-temp-buffer
+    (let ((major-mode 'ess-r-help-mode))
+      ;; Ensure we don't return "environment" or "parent.frame"
+      (insert "Usage:
+
+     ggplot(data = NULL, mapping = aes(), ...,
+       environment = parent.frame())
+
+Arguments:
+")
+      (should (equal (ess-r-help-usage-objects) '("ggplot"))))))
+
 (provide 'ess-test-r)
 
 ;;; ess-test-r.el ends here


### PR DESCRIPTION
Some R help pages (e.g. qt) document more than one object. Don't
create links that link to the current page. Do this by parsing the
"Usage:" section of the current help buffer.

Closes #847 

We still make links for some things that shouldn't be linked (e.g. `df` is linked in the `qt` help buffer because it's a function but the `df` there is referring to the `qt` argument, not the `df` function), but that should be tackled separately.

cc @mmaechler 