### PR TITLE
Always start a new process when `inferior-ess` is called

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -172,7 +172,6 @@ This may be useful for debugging."
                                temp-ess-dialect)
                            temp-ess-dialect))
            (inf-buf (inferior-ess--get-proc-buffer-create temp-dialect))
-           (inf-name (buffer-name inf-buf))
            (proc-name (with-current-buffer inf-buf ess-local-process-name))
            (cur-dir (inferior-ess--maybe-prompt-startup-directory proc-name temp-dialect))
            (default-directory cur-dir))
@@ -186,8 +185,6 @@ This may be useful for debugging."
       (let ((inf-args (or ess-start-args
                           inferior-ess-start-args)))
         (ess--inferior-major-mode ess-dialect)
-        (with-current-buffer inf-buf
-          (rename-buffer inf-name t))
         ;; Show the buffer
         ;; TODO: Remove inferior-ess-own-frame after ESS 19.04, then just have:
         ;; (pop-to-buffer inf-buf)

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -223,18 +223,18 @@ This may be useful for debugging."
             (ess-wait-for-process proc)))
         inf-buf))))
 
-(defun inferior-ess--get-proc-buffer-create (temp-dialect)
+(defun inferior-ess--get-proc-buffer-create (name)
   "Get a process buffer, creating a new one if needed.
 This always returns a process-less buffer. The variable
 `ess-local-process-name' is set in the buffer with the name of
 the next process to spawn. This name may be different from the
 buffer name, depending on how `ess-gen-proc-buffer-name-function'
-generated the latter."
+generated the latter from NAME."
   (let* ((proc-name (let ((ntry 1))
                       ;; Find the next non-existent process N (*R:N*)
-                      (while (get-process (ess-proc-name ntry temp-dialect))
+                      (while (get-process (ess-proc-name ntry name))
                         (setq ntry (1+ ntry)))
-                      (ess-proc-name ntry temp-dialect)))
+                      (ess-proc-name ntry name)))
          (inf-name (funcall ess-gen-proc-buffer-name-function proc-name)))
     (let ((buf (cond
                 ;; Try to use current buffer, if inferior-ess-mode but

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -251,10 +251,6 @@ This may be useful for debugging."
      ((and (not (comint-check-proc (current-buffer)))
            (derived-mode-p 'inferior-ess-mode))
       (current-buffer))
-     ;; Take the *R:N* buffer if already exists (and contains dead proc!)
-     ;; fixme: buffer name might have been changed, iterate over all
-     ;; inferior-ess buffers.
-     ((get-buffer inf-name))
      ;; Pick up a transcript file
      (ess-ask-about-transfile
       (let ((transfilename (read-file-name
@@ -262,7 +258,8 @@ This may be useful for debugging."
         (if (string= transfilename "")
             (get-buffer-create inf-name)
           (find-file-noselect (expand-file-name transfilename)))))
-     ;; Create a new buffer
+     ;; Create a new buffer or take the *R:N* buffer if already exists
+     ;; (it should contain a dead process)
      (t
       (get-buffer-create inf-name)))))
 

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -55,6 +55,18 @@
           (setq proc (get-buffer-process val)))
       (kill-process proc))))
 
+(ert-deftest ess-test-inferior-live-process-error ()
+  (let ((ess-gen-proc-buffer-name-function
+         ;; Generate same inferior name each time
+         (lambda (&rest args) "" "foo"))
+        (error-msg "Can't start a new session in buffer `foo` because one already exists")
+        proc)
+    (unwind-protect
+        (progn
+          (setq proc (get-buffer-process (run-ess-r-vanilla)))
+          (should (string= (cadr (should-error (run-ess-r-vanilla)))
+                           (format-message error-msg))))
+      (kill-process proc))))
 
 
 ;;*;; Evaluation


### PR DESCRIPTION
`inferior-ess--get-proc-buffer-create` now always returns a process-less buffer. Then we can assume we're starting a process in `inferior-ess`, making things simpler.