### PR TITLE
Simplify ess-etc-dir detection

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -124,6 +124,46 @@
 
 ;;*;; Options and Initialization
 
+;;;###autoload
+(defcustom ess-lisp-directory
+  (directory-file-name
+   (file-name-directory
+    (or load-file-name
+        buffer-file-name)))
+  "Directory containing ess-site.el(c) and other ESS Lisp files."
+  :group 'ess
+  :type 'directory
+  :package-version '(ess . "19.04"))
+
+(defcustom ess-etc-directory
+  ;; Try to detect the `etc' folder only if not alread set up by distribution
+  (let (dir)
+    (dolist (d '("./etc/" "../../etc/ess/" "../etc/" "../etc/ess/"))
+      (setq d (expand-file-name d ess-lisp-directory))
+      (when (file-directory-p d)
+        (setq dir d)))
+    dir)
+  "Location of the ESS etc/ directory.
+The ESS etc directory stores various auxillary files that are useful
+for ESS, such as icons."
+  :group 'ess
+  :type 'directory
+  :package-version '(ess . "19.04"))
+
+;; Depending on how ESS is loaded the `load-path' might not contain
+;; the `lisp' directory. For this reason we need to add it before we
+;; start requiring ESS files
+;;;###autoload
+(add-to-list 'load-path (file-name-as-directory ess-lisp-directory))
+;; Add ess-lisp-directory/obsolete to load-path; files here will
+;; automatically warn that they are obsolete when loaded.
+;;;###autoload
+(add-to-list 'load-path (file-name-as-directory (expand-file-name "obsolete" ess-lisp-directory)))
+
+(unless (file-directory-p ess-etc-directory)
+  (display-warning 'ess (format "Could not find directory `ess-etc-directory': %s"
+                                ess-etc-directory) :error))
+
 ;; Menus and pulldowns.
 
 (defcustom ess-imenu-use-p (fboundp 'imenu)

--- a/lisp/ess-site.el
+++ b/lisp/ess-site.el
@@ -54,43 +54,9 @@
 
 ;; DEBUG: (setq ess-show-load-messages t); instead of nil above
 
-;; This sets `ess-lisp-directory' either from the current directory
-;; when the file is being `load'ed, or from the installed location
-;; otherwise. This way, users can load ESS without having added ESS to
-;; `load-path'.
-(defvar ess-lisp-directory
-  ;; A nice default
-  (directory-file-name
-   (file-name-directory
-    (if load-file-name
-        (file-truename load-file-name)
-      (locate-library "ess-site") )))
-  "Directory containing ess-site.el(c) and other ESS Lisp files.")
-
-(defvar ess-etc-directory nil
-  "Location of the ESS etc/ directory.
-The ESS etc directory stores various auxillary files that are useful
-for ESS, such as icons.")
-
-
-;; Depending on how ESS is loaded the `load-path' might not contain
-;; the `lisp' directory. For this reason we need to add it before we
-;; start requiring ESS files
-(add-to-list 'load-path (file-name-as-directory ess-lisp-directory))
-;; Add ess-lisp-directory/obsolete to load-path; files here will
-;; automatically warn that they are obsolete when loaded.
-(add-to-list 'load-path (file-name-as-directory (expand-file-name "obsolete" ess-lisp-directory)))
-
 (require 'ess-utils)
 (ess-write-to-dribble-buffer
  (format "[ess-site:] ess-lisp-directory = '%s'" ess-lisp-directory))
-
-
-;; If ess.info is not found, then ess-lisp-directory/../doc/info is added
-;; resurrecting Stephen's version with a bug-fix
-(unless (locate-file "ess.info" Info-default-directory-list)
-  (add-to-list 'Info-default-directory-list (expand-file-name "../doc/info/" ess-lisp-directory)))
-
 
 ;;; Loading popular dialects (they should become optional in the future)
 

--- a/lisp/ess.el
+++ b/lisp/ess.el
@@ -47,40 +47,6 @@
 (defvar reporter-prompt-for-summary-p)
 
 
-;;*;; Internal ESS tools and variables
-
-(defvar ess-lisp-directory
-  (directory-file-name
-   (file-name-directory
-    (if load-file-name
-        (file-truename load-file-name)
-      (locate-library "ess-utils") )))
-  "Directory containing ess-site.el(c) and other ESS Lisp files.")
-
-(defvar ess-etc-directory nil
-  "Location of the ESS etc/ directory.
-The ESS etc directory stores various auxillary files that are useful
-for ESS, such as icons.")
-;; Try to detect the `etc' folder only if not alread set up by distribution
-(unless ess-etc-directory
-  (let ((path-list '("../etc/ess/" "../etc/" "../../etc/ess/" "./etc/")))
-    (while (and (listp path-list) (consp path-list))
-      (setq ess-etc-directory
-            (expand-file-name (concat ess-lisp-directory "/"
-                                      (car path-list))))
-      (if (file-directory-p ess-etc-directory)
-          (setq path-list nil)
-        (setq ess-etc-directory nil)
-        (setq path-list (cdr path-list))
-        (when (null path-list)
-          (beep 0) (beep 0)
-          (message (concat
-                    "ERROR:ess-etc-directory\n"
-                    "Relative to ess-lisp-directory, one of the following must exist:\n"
-                    "../etc/ess, ../etc, ../../etc/ess or ./etc"))
-          (sit-for 4))))))
-
-
 ;; Versions
 
 ;; updated by 'make'!


### PR DESCRIPTION
This moves the detection to ess-custom and deletes the double-initialization we have now.