### PR TITLE
Simplify @node declarations in texi files

### DIFF
--- a/doc/announc.texi
+++ b/doc/announc.texi
@@ -6,7 +6,6 @@
 
 @include ess-defs.texi
 @node Announce
-@comment  node-name,  next,  previous,  up
 @chapter ANNOUNCING ESS
 @cindex ANNOUNCE
 
@@ -44,35 +43,35 @@ please read the README files that come with ESS.
 * New Features::
 @end menu
 
-@node Latest Version, Current Features, Announce, Announce
+@node Latest Version
 @section Getting the Latest Version
 @include installation.texi
 
-@node Current Features, Requirements, Latest Version, Announce
+@node Current Features
 @section Current Features
 @include currfeat.texi
 
-@node Requirements, Mailing List, Current Features, Announce
+@node Requirements
 @section Requirements
 @include requires.texi
 
-@node Mailing List, Reporting Bugs, Requirements, Announce
+@node Mailing List
 @section Mailing List
 @include mailing.texi
 
-@node Reporting Bugs, Authors, Mailing List, Announce
+@node Reporting Bugs
 @section Reporting Bugs
 @include bugrept.texi
 
-@node Authors, License, Reporting Bugs, Announce
+@node Authors
 @section Authors
 @include authors.texi
 
-@node License, New Features, Authors, Announce
+@node License
 @section License
 @include license.texi
 
-@node New Features,  , License, Announce
+@node New Features
 @section New Features
 @include newfeat.texi
 

--- a/doc/help-s.texi
+++ b/doc/help-s.texi
@@ -1,5 +1,4 @@
-@node ESS(R)--Editing files, iESS(R)--Inferior ESS processes, ESS for R, ESS for R
-@comment  node-name,  next,  previous,  up -- don't use @ESS ..
+@node ESS(R)--Editing files
 @section ESS[R]--Editing files
 
 @ESS{[R]} mode should be automatically turned on when visiting a file
@@ -8,8 +7,7 @@ features discussed previously.  Alternatively, type @kbd{M-x R-mode} to
 put the current buffer into R mode.  However, one will have to start up
 an inferior process to take advantage of the interactive features.
 
-@node iESS(R)--Inferior ESS processes, Philosophies for using ESS(R), ESS(R)--Editing files, ESS for R
-@comment  node-name,  next,  previous,  up
+@node iESS(R)--Inferior ESS processes
 @section iESS[R]--Inferior ESS processes
 
 To start up iESS mode for R, use:
@@ -67,8 +65,7 @@ function, called @kbd{M-x R-newest}, which will call the newest version
 of R that it found.  (ESS examines the date in the first line of
 information from @code{R --version} to determine which is newest.)
 
-@node Philosophies for using ESS(R), Example ESS usage, iESS(R)--Inferior ESS processes, ESS for R
-@comment  node-name,  next,  previous,  up
+@node Philosophies for using ESS(R)
 @section Philosophies for using ESS[R]
 
 There are two philosophies for using ESS.  Most modern best practices
@@ -89,7 +86,7 @@ manual focuses on.
 (setq ess-mode-silently-save nil)
 @end example
 
-@node Example ESS usage, , Philosophies for using ESS(R), ESS for R
+@node Example ESS usage
 @section Example ESS usage
 
 We present some basic examples for using ESS to interact with R

--- a/doc/help-sas.texi
+++ b/doc/help-sas.texi
@@ -4,8 +4,7 @@ Tom Cook.  Those editing features and new advanced features are part of
 @ESS{[SAS]}.  The user interface of @ESS{[SAS]} has similarities with @ESS{[S]}
 and the @SAS{} Display Manager.
 
-@comment  node-name,  next,  previous,  up
-@node ESS(SAS)--Design philosophy, ESS(SAS)--Editing files, ESS for SAS, ESS for SAS
+@node ESS(SAS)--Design philosophy
 @section ESS[SAS]--Design philosophy
 
 @ESS{[SAS]} was designed to aid the user in writing and maintaining @SAS{}
@@ -26,8 +25,7 @@ and syntax highlighting, are provided transparently; appealing to
 advanced @ESS{[SAS]} users.
 @end enumerate
 
-@comment  node-name,  next,  previous,  up
-@node ESS(SAS)--Editing files, ESS(SAS)--TAB key, ESS(SAS)--Design philosophy, ESS for SAS
+@node ESS(SAS)--Editing files
 @section ESS[SAS]--Editing files
 
 @ESS{[SAS]} is the mode for editing @SAS{} language files.  This mode handles:
@@ -69,8 +67,7 @@ first line is highlighted; for @file{.log} files, only the first line of a
 single/double quotes in @code{CARDS} data lines are @strong{NOT} ignored; in an
 iterative @code{DO} statement, @code{TO} and @code{BY} are not highlighted.
 
-@comment  node-name,  next,  previous,  up
-@node  ESS(SAS)--TAB key, ESS(SAS)--Batch SAS processes, ESS(SAS)--Editing files, ESS for SAS
+@node  ESS(SAS)--TAB key
 @section ESS[SAS]--@key{TAB} key
 
 Two options.  The @key{TAB} key is bound by default to
@@ -99,8 +96,7 @@ prior to a @code{require}/@code{load}:
 Under the alternate behavior, @key{TAB} is bound to @wkbd{M-x tab-to-tab-stop}
 and the stops are defined by @code{ess-sas-tab-stop-list}.
 
-@comment  node-name,  next,  previous,  up
-@node  ESS(SAS)--Batch SAS processes, ESS(SAS)--Function keys for batch processing, ESS(SAS)--TAB key, ESS for SAS
+@node  ESS(SAS)--Batch SAS processes
 @section ESS[SAS]--Batch SAS processes
 
 Submission of a @SAS{} batch job is dependent on your environment.
@@ -222,8 +218,7 @@ Make your editing changes and submit again.
 @key{F3} (@key{F8})
 @end example
 
-@comment  node-name,  next,  previous,  up
-@node  ESS(SAS)--Function keys for batch processing, iESS(SAS)--Interactive SAS processes, ESS(SAS)--Batch SAS processes, ESS for SAS
+@node  ESS(SAS)--Function keys for batch processing
 @section ESS[SAS]--Function keys for batch processing
 
 The setup of function keys for @SAS{} batch processing
@@ -482,9 +477,7 @@ landscape (first line for "global" key mapping, second for "local"):
 (define-key sas-mode-local-map [(control f2)] 'ess-sas-rtf-a4-landscape)
 @end example
 
-
-@comment  node-name,  next,  previous,  up
-@node  iESS(SAS)--Interactive SAS processes, iESS(SAS)--Common problems, ESS(SAS)--Function keys for batch processing, ESS for SAS
+@node  iESS(SAS)--Interactive SAS processes
 @section iESS[SAS]--Interactive SAS processes
 
 Inferior @ESS{} (@iESS{}) is the method for interfacing with interactive
@@ -581,8 +574,7 @@ never need to read it or write to it.  Refer to the @file{.lst} and
 
 Troubleshooting: @xref{iESS(SAS)--Common problems}.
 
-@comment  node-name,  next,  previous,  up
-@node   iESS(SAS)--Common problems, ESS(SAS)--Graphics, iESS(SAS)--Interactive SAS processes, ESS for SAS
+@node   iESS(SAS)--Common problems
 @section iESS[SAS]--Common problems
 
 @enumerate
@@ -636,8 +628,7 @@ shell script appears.
 @comment @end example
 @comment @end enumerate
 
-@comment  node-name,  next,  previous,  up
-@node   ESS(SAS)--Graphics, ESS(SAS)--Windows, iESS(SAS)--Common problems, ESS for SAS
+@node   ESS(SAS)--Graphics
 @section ESS[SAS]--Graphics
 
 Output from a @SAS{/GRAPH} @code{PROC} can be displayed in a @SAS{/GRAPH}
@@ -658,8 +649,7 @@ proc plot;
 run;
 @end example
 
-@comment  node-name,  next,  previous,  up
-@node   ESS(SAS)--Windows,  , ESS(SAS)--Graphics, ESS for SAS
+@node   ESS(SAS)--Windows
 @section ESS[SAS]--Windows
 
 @itemize @bullet

--- a/doc/installation.texi
+++ b/doc/installation.texi
@@ -13,7 +13,7 @@ you. See @ref{Activating and Loading ESS} for more details.
 * Check Installation::
 @end menu
 
-@node Installing from a third-party repository, Installing from source
+@node Installing from a third-party repository
 @section Installing from a third-party repository
 
 ESS is packaged by many third party repositories. Many GNU/Linux
@@ -31,7 +31,7 @@ After installing, users should make sure ESS is activated or loaded in
 each Emacs session. See @ref{Activating and Loading ESS}. Depending on
 install method, this may be taken care of automatically.
 
-@node Installing from source, Activating and Loading ESS, Installing from a third-party repository
+@node Installing from source
 @section Installing from source
 
 Stable versions of ESS are available at the
@@ -76,7 +76,7 @@ run correctly on macOS, you will need to adjust the @file{PREFIX}
 path in @file{Makeconf}. The necessary code and instructions are
 commented in that file.
 
-@node Activating and Loading ESS, Check Installation, Installing from source
+@node Activating and Loading ESS
 @section Activating and Loading ESS
 
 After installing ESS, you must activate or load it each Emacs session.
@@ -114,7 +114,7 @@ or
 In your configuration file, depending on whether you want all ESS
 features or only R related features.
 
-@node Check Installation,  , Activating and Loading ESS
+@node Check Installation
 @section Check Installation
 Restart Emacs and check that ESS was loaded from a correct
 location with @code{M-x ess-version}.

--- a/doc/readme.texi
+++ b/doc/readme.texi
@@ -6,7 +6,6 @@
 
 @include ess-defs.texi
 @node General Information
-@comment  node-name,  next,  previous,  up
 @chapter General Information: README
 @cindex README
 
@@ -70,20 +69,15 @@ Table of Contents
 * Authors::
 @end menu
 
-@node License, Installation, General Information, General Information
-@comment  node-name,  next,  previous,  up
+@node License
 @section License
-
 @include license.texi
 
-@c    vvvvvvvvvvvv node name  *must* match the one in ./ess.texi !
-@node Installation, Starting up, License, General Information
-@comment  node-name,  next,  previous,  up
+@node Installation
 @section Installation
 @include installation.texi
 
-@node Starting up, Current Features, Installation, General Information
-@comment  node-name,  next,  previous,  up
+@node Starting up
 @section Starting an ESS process
 To start an @Sl{} session on Unix or on Windows when you
 use the Cygwin bash shell, simply type @kbd{M-x S RET}.
@@ -91,32 +85,27 @@ use the Cygwin bash shell, simply type @kbd{M-x S RET}.
 To start an @Sl{} session on Windows when you
 use the MSDOS prompt shell, simply type @kbd{M-x S+6-msdos RET}.
 
-@node Current Features, New Features, Starting up, General Information
-@comment  node-name,  next,  previous,  up
+@node Current Features
 @section Current Features
 
 @include currfeat.texi
 
-@node New Features, Reporting Bugs, Current Features, General Information
-@comment  node-name,  next,  previous,  up
+@node New Features
 @section New Features
 
 @include newfeat.texi
 
-@node Reporting Bugs, Mailing Lists, New Features, General Information
-@comment  node-name,  next,  previous,  up
+@node Reporting Bugs
 @section Reporting Bugs
 
 @include bugrept.texi
 
-@node Mailing Lists, Authors, Reporting Bugs, General Information
-@comment  node-name,  next,  previous,  up
+@node Mailing Lists
 @section Mailing Lists
 
 @include mailing.texi
 
-@node Authors,  , Mailing Lists, General Information
-@comment  node-name,  next,  previous,  up
+@node Authors
 @section Authors
 
 @include authors.texi


### PR DESCRIPTION
makeinfo is smart enough to figure next/previous/up out on its own. Unless there's a good reason to do this manually that I'm missing, we should just let it.