### PR TITLE
Obsolete `inferior-ess-start-args`

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1781,6 +1781,9 @@ for editing and then to be returned to the process.")
 The other variables ...-program should be changed, for the
 corresponding program.")
 
+(make-obsolete-variable 'inferior-ess-start-args
+                        "Use the language specific variables like `inferior-R-args'"
+                        "ESS 19.04")
 (defvar inferior-ess-start-args ""
   "String of arguments passed to the ESS process.
 If you wish to pass arguments to a process, see e.g. `inferior-R-args'.")

--- a/lisp/ess-gretl.el
+++ b/lisp/ess-gretl.el
@@ -486,7 +486,6 @@ end keywords as associated values.")
     (ess-smart-operators		. ess-r-smart-operators)
     (inferior-ess-exit-command		. "exit\n")
     ;;harmful for shell-mode's C-a: -- but "necessary" for ESS-help?
-    (inferior-ess-start-args		. "")
     (inferior-ess-language-start	. nil)
     (ess-STERM		. "iESS")
     )

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -325,7 +325,6 @@ to look up any doc strings."
     (ess-smart-operators           . ess-r-smart-operators)
     (inferior-ess-exit-command     . "exit()\n")
     ;;harmful for shell-mode's C-a: -- but "necessary" for ESS-help?
-    (inferior-ess-start-args       . "")
     (inferior-ess-language-start   . nil)
     (ess-STERM                     . "iESS")
     (ess-editor                    . ess-r-editor)

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -381,7 +381,6 @@ To be used as part of `font-lock-defaults' keywords."
      (inferior-ess-search-list-command      . "search()\n")
      (inferior-ess-help-command             . inferior-ess-r-help-command)
      (inferior-ess-exit-command             . "q()")
-     (inferior-ess-start-args               . "")
      (ess-error-regexp-alist                . ess-r-error-regexp-alist)
      (ess-describe-object-at-point-commands . 'ess-r-describe-object-at-point-commands)
      (ess-STERM                             . "iESS")

--- a/lisp/ess-sas-d.el
+++ b/lisp/ess-sas-d.el
@@ -307,7 +307,9 @@ Better logic needed!  (see 2 uses, in this file).")
              temp-dialect))
     (ess-SAS-pre-run-hook temp-dialect)
     (setq ess-eval-visibly-p nil)
-    (let ((inf-buf (inferior-ess)))
+    ;; FIXME: `inferior-SAS-args' is defined from
+    ;; `inferior-SAS-args-temp' in `ess-SAS-pre-run-hook'
+    (let ((inf-buf (inferior-ess inferior-SAS-args)))
       (with-current-buffer inf-buf
         (use-local-map sas-mode-local-map))
       inf-buf)))

--- a/lisp/ess-sp6-d.el
+++ b/lisp/ess-sp6-d.el
@@ -79,9 +79,7 @@
 
      (ess-directory-function           . S+-directory-function)
      (ess-setup-directory-function     . S+-setup-directory-function)
-     (inferior-ess-start-args          . inferior-S+-start-args)
-     (ess-STERM                        . "iESS")
-     )
+     (ess-STERM                        . "iESS"))
    S+common-cust-alist)
 
   "Variables to customize for S+.")
@@ -116,7 +114,7 @@ New way to do it."
   (setq ess-customize-alist S+-customize-alist)
   (ess-write-to-dribble-buffer
    (format "\n(S+): ess-dialect=%s, buf=%s\n" ess-dialect (current-buffer)))
-  (let ((inf-buf (inferior-ess)))
+  (let ((inf-buf (inferior-ess inferior-S+-start-args)))
     (ess-command ess-S+--injected-code)
     (when inferior-ess-language-start
       (ess-eval-linewise inferior-ess-language-start))

--- a/lisp/ess-stata-mode.el
+++ b/lisp/ess-stata-mode.el
@@ -83,7 +83,6 @@
     (inferior-ess-primary-prompt   . "[.:] \\|--more--") 
     (inferior-ess-secondary-prompt . "--more--")
     (comint-use-prompt-regexp      . t)
-    (inferior-ess-start-args       . inferior-STA-start-args)
     (inferior-ess-search-list-command   . "set more off\n search()\n")
     (comment-start                . "/\* ")
     (comment-end                  . " \*/")

--- a/lisp/essd-els.el
+++ b/lisp/essd-els.el
@@ -39,9 +39,13 @@
 (require 'ess-stata-mode)
 (require 'ess-trns)
 (require 'ess-utils)
+
+;; Easily changeable in a user's .emacs
 (defvar S+elsewhere-dialect-name "S+6"
   "Name of 'dialect' for S-PLUS at another location.")
-                                        ;easily changeable in a user's .emacs
+
+(defvar S+elsewhere-start-args "-i"
+  "Arguments for `S+elsewhere-dialect-name'.")
 
 (defcustom inferior-ess-remote-pager nil
   "Remote pager to use for reporting help files and similar things.
@@ -57,7 +61,6 @@ The default value is nil."
      (ess-object-name-db-file           . "ess-spelsewhere-namedb.el" )
      (inferior-ess-program              . inferior-S-elsewhere-program)
      (inferior-ess-help-command         . "help(\"%s\", pager=\"cat\", window=F)\n")
-     (inferior-ess-start-args           . "-i")
      (ess-STERM  . "iESS")
      )
    S+common-cust-alist)
@@ -71,7 +74,7 @@ The default value is nil."
   (ess-write-to-dribble-buffer
    (format "\n(S+elsewhere): ess-dialect=%s, buf=%s\n" ess-dialect
            (current-buffer)))
-  (let ((inf-buf (inferior-ess)))
+  (let ((inf-buf (inferior-ess S+elsewhere-start-args)))
     (when inferior-ess-language-start
       (ess-eval-linewise inferior-ess-language-start))
     inf-buf))


### PR DESCRIPTION
And use language-specific variables instead.