### PR TITLE
Set local process in current buffer on startup

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -175,6 +175,7 @@ This may be useful for debugging."
            (proc-name (with-current-buffer inf-buf ess-local-process-name))
            (cur-dir (inferior-ess--maybe-prompt-startup-directory proc-name temp-dialect))
            (default-directory cur-dir))
+      (setq-local ess-local-process-name proc-name)
       (with-current-buffer inf-buf
         (setq-local default-directory cur-dir)
         ;; TODO: Get rid of this, we should rely on modes to set the

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -68,6 +68,11 @@
                            (format-message error-msg))))
       (kill-process proc))))
 
+(ert-deftest ess-test-inferior-local-process-name ()
+  (let (ess-local-process-name)
+    (with-bare-r-running
+      (should ess-local-process-name))))
+
 
 ;;*;; Evaluation
 

--- a/test/ess-test-r-utils.el
+++ b/test/ess-test-r-utils.el
@@ -169,6 +169,15 @@ split arbitrary."
       (set-buffer-modified-p nil)
       (should (not-change-on-indent buff)))))
 
+(defmacro with-bare-r-running (&rest body)
+  (declare (indent 0) (debug (form body)))
+  `(let (proc)
+     (unwind-protect
+         (progn
+           (setq proc (get-buffer-process (run-ess-test-r-vanilla)))
+           ,@body)
+       (kill-process proc))))
+
 ;; !!! NB: proc functionality from now on uses inferior-ess-ordinary-filter and
 ;; !!! *proc* dynamic var
 (defmacro with-r-running (buffer-or-file &rest body)


### PR DESCRIPTION
From discussion at https://github.com/emacs-ess/ESS/pull/884#discussion_r272488587

I think we should set the local variable because this gives a way to be compatible with both the old `set-buffer` effect and the new non-side-effecty return value.

- With old ESS, `set-buffer` is called with the inferior buffer whose `ess-local-process-name` is set to itself. You can thus get the process or its buffer via `ess-local-process-name`.

- With new ESS, the local variable will be set in the current buffer. You can thus get the process or its buffer via `ess-local-process-name`.

Cf my patch for org-mode, it's compatible with both ESS versions because of this. Given the importance of being compatible with old and new ESS versions during the transition, I recommend we set the local process on startup.

I think this also makes ESS more useful because users can directly interact with their process instead of ESS asking which one to use. If they ever need to use a different process right after having started one, they can `M-x ess-switch`.