### PR TITLE
Remove ess-customize-alist

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2477,13 +2477,6 @@ See also `ess-verbose'."
 (defvar ess-dribble-buffer "*ESS*"
   "Buffer or name of buffer for printing debugging information.")
 
-(defvar ess-customize-alist nil
-  "Variable settings to use for proper behavior.
-Not buffer local!")
-;; TODO: fixme We cannot make it local as yet, Not list is set on inferior startup.
-;; (make-variable-buffer-local 'ess-customize-alist)
-;; (defvaralias 'ess-local-customize-alist 'ess-customize-alist)
-
 (defvar-local ess-local-customize-alist nil
   "Buffer local settings for proper behavior.
 Used to store the values for passing on to newly created buffers.")

--- a/lisp/ess-gretl.el
+++ b/lisp/ess-gretl.el
@@ -510,7 +510,6 @@ end keywords as associated values.")
 ;;;###autoload
 (define-derived-mode ess-gretl-mode ess-mode "ESS[gretl]"
   "Major mode for editing gretl source.  See `ess-mode' for more help."
-  ;; (setq ess-customize-alist gretl-customize-alist)
   ;;(setq imenu-generic-expression R-imenu-generic-expression)
   (ess-setq-vars-local gretl-customize-alist)
   (setq font-lock-defaults `(,gretl-font-lock-keywords))
@@ -540,7 +539,6 @@ to gretl, put them in the variable `inferior-gretl-args'."
   ;; get settings, notably inferior-ess-r-program :
   ;; (if (null inferior-gretl-program)
   ;;     (error "'inferior-gretl-program' does not point to 'gretl-release-basic' executable")
-  (setq ess-customize-alist gretl-customize-alist)
   (ess-write-to-dribble-buffer   ;; for debugging only
    (format
     "\n(Gretl): ess-dialect=%s, buf=%s"
@@ -553,7 +551,7 @@ to gretl, put them in the variable `inferior-gretl-args'."
 			       inferior-gretl-args
 			       "'] ? "))
 		    nil)))
-         (inf-buf (inferior-ess r-start-args)))
+         (inf-buf (inferior-ess r-start-args gretl-customize-alist)))
     (set (make-local-variable 'indent-line-function) 'gretl-indent-line)
     (set (make-local-variable 'gretl-basic-offset) 4)
     (setq indent-tabs-mode nil)

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -419,7 +419,6 @@ always be passed to julia, put them in the variable
   ;; get settings, notably inferior-julia-program :
   (if (null inferior-julia-program)
       (error "'inferior-julia-program' does not point to 'julia' or 'julia-basic' executable")
-    (setq ess-customize-alist ess-julia-customize-alist)
     (ess-write-to-dribble-buffer   ;; for debugging only
      (format
       "\n(julia): ess-dialect=%s, buf=%s, start-arg=%s\n current-prefix-arg=%s\n"
@@ -433,7 +432,7 @@ always be passed to julia, put them in the variable
                                      (concat " [other than '" inferior-julia-args "']"))
                                  " ? "))
 		              nil))))
-      (let ((inf-buf (inferior-ess jl-start-args)))
+      (let ((inf-buf (inferior-ess jl-start-args ess-julia-customize-alist)))
         (ess--tb-start)
         ;; Remove ` from julia's logo
         (goto-char (point-min))

--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -565,7 +565,7 @@ generate the source buffer."
                        ess-source-directory
                      (with-current-buffer (process-buffer (ess-get-process
                                                            ess-local-process-name))
-                       (ess-setq-vars-local ess-customize-alist)
+                       (ess-setq-vars-local ess-local-customize-alist)
                        (apply ess-source-directory nil)))))
          (filename (concat dirname (format ess-dump-filename-template object)))
          (old-buff (get-file-buffer filename)))
@@ -631,7 +631,6 @@ generate the source buffer."
      (format "%s does not exist. Bad dump, starting fresh." filename)))
   ;; Generate a buffer with the dumped data
   (find-file-other-window filename)
-  (setq-local ess-local-customize-alist ess-customize-alist)
   (ess-mode)
   (auto-save-mode 1)            ; Auto save in this buffer
   (setq ess-local-process-name ess-current-process-name)

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -506,22 +506,15 @@ will be prompted to enter arguments interactively."
           (concat r-always-arg
                   inferior-R-args " "   ; add space just in case
                   start-args))
-         (cust-alist (copy-alist ess-r-customize-alist))
          (gdbp (string-match-p "gdb" r-start-args))
          use-dialog-box)
-
-    (when gdbp
-      (setcdr (assoc 'inferior-ess-secondary-prompt cust-alist)
-              (format "\\(%s\\)\\|\\((gdb) \\)"
-                      (cdr (assoc 'inferior-ess-secondary-prompt cust-alist)))))
-
     (when (or ess-microsoft-p
               (eq system-type 'cygwin))
       (setq use-dialog-box nil)
       (when ess-microsoft-p ;; default-process-coding-system would break UTF locales on Unix
         (setq default-process-coding-system '(undecided-dos . undecided-dos))))
 
-    (let ((inf-buf (inferior-ess r-start-args cust-alist gdbp)))
+    (let ((inf-buf (inferior-ess r-start-args ess-r-customize-alist gdbp)))
       (with-current-buffer inf-buf
         (ess-process-put 'funargs-pre-cache ess-r--funargs-pre-cache)
         (remove-hook 'completion-at-point-functions 'ess-filename-completion 'local) ;; should be first
@@ -2219,6 +2212,7 @@ state.")
 (define-derived-mode inferior-ess-r-mode inferior-ess-mode "iESS"
   "Major mode for interacting with inferior R processes."
   :group 'ess-proc
+  (ess-setq-vars-local ess-r-customize-alist)
   (setq-local ess-font-lock-keywords 'inferior-ess-r-font-lock-keywords)
   (setq-local comint-process-echoes (eql ess-eval-visibly t))
   ;; eldoc

--- a/lisp/ess-sas-a.el
+++ b/lisp/ess-sas-a.el
@@ -809,14 +809,14 @@ optional argument is non-nil, then set-buffer rather than switch."
   "And now for something completely different."
   (interactive)
   ;;(ess-sas-file-path)
-  (setq ess-customize-alist SAS-customize-alist)
+  (setq ess-local-customize-alist SAS-customize-alist)
   ;; (let ((ess-temp-sas-file
   ;;        (nth 0 (split-string
   ;;                (car (last (split-string ess-sas-file-path "\\([a-zA-Z][a-zA-Z]:\\|]\\)"))) "[.]"))))
     (setq ess-sas-shell-buffer "*iESS[SAS]*")
     (ess-sas-goto-shell)
     (ess-add-ess-process)
-    (ess-setq-vars-local ess-customize-alist)
+    (ess-setq-vars-local ess-local-customize-alist)
     (inferior-ess-mode)
     (ess-eval-linewise (concat ess-sas-submit-command " " ess-sas-submit-command-options " -stdio"))
                                ;;" -altlog " ess-temp-sas-file ".log -altprint "

--- a/lisp/ess-sas-d.el
+++ b/lisp/ess-sas-d.el
@@ -208,7 +208,6 @@ Better logic needed!  (see 2 uses, in this file).")
   "Major mode for editing SAS source.  See `ess-mode' for more help."
   :group 'ess-sas
   (ess-setq-vars-local SAS-customize-alist)
-  (setq ess-customize-alist SAS-customize-alist)
   (setq ess-local-customize-alist SAS-customize-alist)
   (setq-local sentence-end ";[\t\n */]*")
   (setq-local paragraph-start "^[ \t]*$")
@@ -299,7 +298,6 @@ Better logic needed!  (see 2 uses, in this file).")
 (defun SAS ()
   "Call 'SAS', from SAS Institute."
   (interactive)
-  (setq-default ess-customize-alist SAS-customize-alist)
   (let* ((temp-dialect "SAS")) ;(cdr (rassoc ess-dialect SAS-customize-alist))))
     (ess-write-to-dribble-buffer
      (format "(SAS): ess-dial=%s, temp-dial=%s\n"
@@ -309,7 +307,7 @@ Better logic needed!  (see 2 uses, in this file).")
     (setq ess-eval-visibly-p nil)
     ;; FIXME: `inferior-SAS-args' is defined from
     ;; `inferior-SAS-args-temp' in `ess-SAS-pre-run-hook'
-    (let ((inf-buf (inferior-ess inferior-SAS-args)))
+    (let ((inf-buf (inferior-ess nil SAS-customize-alist)))
       (with-current-buffer inf-buf
         (use-local-map sas-mode-local-map))
       inf-buf)))

--- a/lisp/ess-sp6-d.el
+++ b/lisp/ess-sp6-d.el
@@ -111,10 +111,9 @@
   "Call 'Splus6', based on S version 4, from Bell Labs.
 New way to do it."
   (interactive)
-  (setq ess-customize-alist S+-customize-alist)
   (ess-write-to-dribble-buffer
    (format "\n(S+): ess-dialect=%s, buf=%s\n" ess-dialect (current-buffer)))
-  (let ((inf-buf (inferior-ess inferior-S+-start-args)))
+  (let ((inf-buf (inferior-ess nil S+-customize-alist)))
     (ess-command ess-S+--injected-code)
     (when inferior-ess-language-start
       (ess-eval-linewise inferior-ess-language-start))
@@ -128,7 +127,6 @@ New way to do it."
 (defun S+-mode (&optional proc-name)
   "Major mode for editing S+ source.  See `ess-mode' for more help."
   (interactive)
-  (setq ess-customize-alist S+-customize-alist)
   (setq-local ess-local-customize-alist S+-customize-alist)
   (ess-mode)
   (if (fboundp 'ess-add-toolbar) (ess-add-toolbar))

--- a/lisp/ess-stata-mode.el
+++ b/lisp/ess-stata-mode.el
@@ -144,7 +144,6 @@ This function is placed in `ess-presend-filter-functions'.
 (defun stata (&optional start-args)
   "Call Stata."
   (interactive "P")
-  (setq ess-customize-alist STA-customize-alist)
   (ess-write-to-dribble-buffer
    (format "(STA): ess-dialect=%s , buf=%s \n"
            ess-dialect
@@ -152,7 +151,7 @@ This function is placed in `ess-presend-filter-functions'.
   (let* ((sta-start-args
           (concat inferior-STA-start-args
                   (when start-args (read-string "Starting Args [possibly -k####] ? "))))
-         (inf-buf (inferior-ess sta-start-args))
+         (inf-buf (inferior-ess sta-start-args STA-customize-alist))
          (inf-proc (get-buffer-process inf-buf)))
     (while (process-get inf-proc 'sec-prompt)
       ;; get read of all --more-- if stata.msg is too long.

--- a/lisp/essd-els.el
+++ b/lisp/essd-els.el
@@ -70,11 +70,10 @@ The default value is nil."
   "Call 'S-PLUS 3.x', the 'Real Thing'  from StatSci."
   ;; git commit 104c4d7c56bc239ea245562763caa317bc3a1a84
   (declare (obsolete ess-remote "2000"))
-  (setq ess-customize-alist S+elsewhere-customize-alist)
   (ess-write-to-dribble-buffer
    (format "\n(S+elsewhere): ess-dialect=%s, buf=%s\n" ess-dialect
            (current-buffer)))
-  (let ((inf-buf (inferior-ess S+elsewhere-start-args)))
+  (let ((inf-buf (inferior-ess nil S+elsewhere-customize-alist)))
     (when inferior-ess-language-start
       (ess-eval-linewise inferior-ess-language-start))
     inf-buf))
@@ -82,7 +81,6 @@ The default value is nil."
 (defun S+elsewhere-mode (&optional _proc-name)
   "Major mode for editing S+3 source.  See `ess-mode' for more help."
   (declare (obsolete ess-remote "2000"))
-  (setq ess-customize-alist S+elsewhere-customize-alist)
   (setq-local ess-local-customize-alist S+elsewhere-customize-alist)
   (ess-mode))
 
@@ -145,11 +143,11 @@ DIALECT is the desired ess-dialect. If nil, ask for dialect"
   (interactive)
   (ess-add-ess-process)
   ;; Need to select a remote-customize-alist
-  (let ((ess-customize-alist (ess-select-alist-dialect dialect)))
+  (let ((customize-alist (ess-select-alist-dialect dialect)))
     (ess-write-to-dribble-buffer
      (format "\n(ESS-remote): ess-dialect=%s, buf=%s\n" ess-dialect
              (current-buffer)))
-    (ess-setq-vars-local ess-customize-alist)
+    (ess-setq-vars-local customize-alist)
     (inferior-ess--set-major-mode ess-dialect)
     (set (make-local-variable 'ess-remote) t)
     (setq ess-local-process-name (or proc-name ess-current-process-name))

--- a/lisp/obsolete/ess-noweb-mode.el
+++ b/lisp/obsolete/ess-noweb-mode.el
@@ -89,6 +89,11 @@
   :type 'hook
   :group 'ess-R)
 
+(defvar-local ess--make-local-vars-permanent nil
+  "If this variable is non-nil in a buffer make all variable permannet.
+Used in noweb modes.")
+(put 'ess--make-local-vars-permanent 'permanent-local t)
+
 (defvar weave-process)
 
 


### PR DESCRIPTION
This removes ess-customize-alist (the non-buffer-local variable).

The changes here will trivially conflict with #889, so I'll hold off on merging until that gets merged so as to not create conflicts for you @lionel-

Progress toward #738