### PR TITLE
Unbundle julia-mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,12 @@ before_script:
   - mkdir ess-r
   - ln -s $(which R) $PWD/ess-r/R-3.2.1
   - export PATH=$PATH:$PWD/ess-r/
+  # Get julia-mode
+  - emacs --script targets/travis-get-dependencies.el
 
 script:
 - emacs --version
 - R --version
-- cd lisp; make julia-mode.elc
-- cd ..
 - make -C test -k all
 - make -C doc ../README
 # Create package.el-installable tar file, test that it installs

--- a/Makeconf
+++ b/Makeconf
@@ -1,30 +1,39 @@
-####======= Common Declarations for *all* ESS -*-Makefile-*-s ==========
-
 ## To install ESS for all users on your unix system:
-## 1. Edit Section 1 and 2 below
-## 2. Execute: gmake install
+## 1. Check variables below, edit as necessary
+## 2. make
+## 3. make install
 
 ## Section 1
-## Installation variables for your emacs variant
+## Installation variables for your Emacs variant
 ##
 ## Variable        Description
 ## EMACS           Path to GNU Emacs
-## EMACSBATCH      Emacs command for compiling elisp files
-## SITELISP        Destination of site-lisp; but some variants have no site-lisp
-## LISPDIR         Destination of compiled elisp files
-## INFODIR         Destination of info files
-## ETCDIR          Destination of script and icon files
-## PREFIX(DESTDIR) Directory prepended to SITELISP, INFODIR, DOCDIR & ETCDIR
-##                 Specify either PREFIX or DESTDIR to over-ride /usr
-DESTDIR=/usr
-PREFIX=$(DESTDIR)
+## EMACSBATCH      How to run Emacs as batch
+## SITELISP        Destination of site-lisp
+## ESSDIR          Destination of ESS
+## JULIA_DIR       Path to julia-mode
+DESTDIR ?= /usr
+PREFIX ?= $(DESTDIR)
 
 ##__ GNU Emacs __
 EMACS ?= emacs
-SITELISP=$(PREFIX)/share/emacs/site-lisp
-LISPDIR=$(SITELISP)/ess
-INFODIR=$(PREFIX)/share/info
-ETCDIR =$(PREFIX)/share/emacs/etc/ess
+SITELISP ?= $(PREFIX)/share/emacs/site-lisp
+ESSDIR ?= $(SITELISP)/ess
+EMACSBATCH ?= $(EMACS) -batch -Q -L $(JULIA_DIR)
+
+# Load path:
+ifndef JULIA_DIR
+
+ELPA_DIR ?= ~/.emacs.d/elpa
+
+JULIA_DIR ?= $(shell \
+  find -L $(ELPA_DIR) -maxdepth 1 -regex '.*/julia-mode-[.0-9]*' 2> /dev/null | \
+  sort | tail -n 1)
+ifeq "$(JULIA_DIR)" ""
+  JULIA_DIR = $(SITELISP)
+endif
+
+endif
 
 ##__ GNU Emacs __  for Mac OS X with NeXTstep (Cocoa or GNUstep)
 # PREFIX=/Applications/Emacs.app/Contents/Resources
@@ -42,13 +51,14 @@ ETCDIR =$(PREFIX)/share/emacs/etc/ess
 # INFODIR=/Applications/Aquamacs.app/Contents/Resources/info
 # ETCDIR=$(PREFIX)/ess-mode/etc
 
-EMACSBATCH ?= $(EMACS) -batch -Q
+## COMPILE-FLAGS is set in tests
+COMPILE ?= $(EMACSBATCH) $(COMPILE-FLAGS) --directory . --directory ./obsolete -f batch-byte-compile
+COMPILE-SIMPLE ?= $(EMACSBATCH) --directory . --directory ./obsolete -f batch-byte-compile
 
 ## Section 2
 ## Installation variables for your unix variant
 ##
 ## Variable        Description
-## SHELL           Bourne shell or XPG4 compliant shell
 ## MAKEINFO        program to convert .texi{nfo} to .info
 ## MAKEHTML        program to convert .texi{nfo} to .html
 ## MAKETXT         program to convert .texi{nfo} to .txt
@@ -59,29 +69,15 @@ EMACSBATCH ?= $(EMACS) -batch -Q
 ## DOCDIR          Destination of other doc files
 ## DOWNLOAD        Download internet file to stdout
 
-SHELL = /bin/sh
-
-MAKEINFO = LC_ALL=C LANG=en makeinfo
-# new:  MAKEHTML <output>.html  <input>.texi  {necessary to build 'Index'}
-MAKEHTML = $(MAKEINFO) --html --no-split --css-include=atouchofstyle.css -o
-##                            ^^^^^^^^^^ today's bandwidth is fast
-#MAKETXT  = $(MAKEINFO) --no-validate --no-headers --no-split -o -
-MAKETXT  = $(MAKEINFO) --no-validate --plaintext --no-split -o -
-
-INSTALLDIR = mkdir -p
-#INSTALLDIR = install -d
-
-INSTALL = cp -p
-#INSTALL = install
-
-UNINSTALL = rm -f
-
-DOCDIR=$(PREFIX)/share/doc/ess
-
-# N.B. $(shell) is a GNU-ism: we need a workaround to be UNIX make friendly
-DOWNLOAD=$(shell which wget > /dev/null && echo 'wget -qO -' || which curl)
-##DOWNLOAD = wget -O -
-##DOWNLOAD = curl
+MAKEINFO ?= LC_ALL=C LANG=en makeinfo
+MAKEHTML ?= $(MAKEINFO) --html --no-split --css-include=atouchofstyle.css -o
+MAKETXT  ?= $(MAKEINFO) --no-validate --plaintext --no-split -o -
+INSTALLDIR ?= mkdir -p
+INSTALL ?= cp -p
+UNINSTALL ?= rm -f
+TEXI2PDF ?= LANG=C texi2dvi --pdf
+DOWNLOAD ?= $(shell which wget > /dev/null && echo 'wget -qO -' || which curl)
+INSTALLINFO ?= install-info
 
 ## Section 3
 ## For ESS developers only, not part of installation procedure
@@ -104,3 +100,7 @@ ESS_HOMEPAGE = /u/maechler/emacs/ESS-web
 GPG=$(shell (gpg2 --version > /dev/null 2>&1 && echo gpg2 ) || echo gpg )
 
 .SUFFIXES: .i3 .m3 .nw .tex .dvi .html .c .h .el .elc
+
+# Local Variables:
+# mode: makefile-gmake
+# End:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,22 +1,4 @@
-### Makefile - for DOCUMENTATION (./doc) of ESS distribution.
-###
-
-## Before making changes here, please take a look at Makeconf
 include ../Makeconf
-
-# program to convert .texi{nfo} to .html
-#MM: use makeinfo (i.e. MAKEHTML from above) which is more
-#--  standardized than texi2html which exists in
-#MM  at least two widely differing versions (TeX vs GNU):
-#MM TEXI2HTML = LANG=C texi2html -verbose -iso
-#MM SPLITCHAP = -split_chapter -menu -glossary
-##
-
-TEXI2PDF = LANG=C texi2dvi --pdf
-
-# To obtain sorted indices run:	"texindex ess.??".
-
-#### no user servicable parts beyond this point ####
 
 TEXISRC = announc.texi authors.texi bugrept.texi bugs.texi \
 	credits.texi currfeat.texi ess.texi ess-defs.texi \
@@ -25,17 +7,12 @@ TEXISRC = announc.texi authors.texi bugrept.texi bugs.texi \
 	newfeat.texi requires.texi help-bugs.texi \
         help-jags.texi allnews.texi Makefile ../Makeconf ../VERSION
 
-ESSINFONODE1='* ESS: (ess).'
-ESSINFONODE2='	        Emacs Speaks Statistics'
-ESSINFONODE3='                        (S/S+/R, SAS, BUGS, Stata, XLisp-Stat).'
-
-### Targets --
 PDFs = ess.pdf readme.pdf refcard/refcard.pdf
 TXTs = ../README ../ANNOUNCE ../NEWS ../ONEWS
 
 # Don't build pdf/html by default
 all  : info text
-info : info/ess.info
+info : dir
 text : $(TXTs)
 html : html/ess.html html/readme.html html/news.html
 pdf  : $(PDFs)
@@ -45,28 +22,18 @@ ess.pdf : $(TEXISRC)
 
 readme.pdf : $(TEXISRC); $(TEXI2PDF) readme.texi
 
-cleanaux:
-	-@rm -f *.aux *.cp *.cps *.fn *.fns *.ky *.kys *.log *.out \
+distclean clean:
+	@rm -f *.aux *.cp *.cps *.fn *.fns *.ky *.kys *.log *.out \
 	        *.pg *.pgs *.tmp *.toc *.tp *.vr *.vrs
-## this shall remove *exactly* those things that are *not* in version control:
-clean: cleanaux
-	-@rm -f $(TXTs) $(PDFs) info/*.info* html/*
-
-## this removes also things in VC (svn, when they are remade by "make"):
-distclean : clean
-#	-@rm -f $(PDFs)
+	@rm -f $(TXTs) $(PDFs) info/*.info* \
+		html/*  *.info dir
 
 ../README: $(TEXISRC)
 	-$(MAKETXT) readme.texi \
 	| perl -pe 'last if /^Concept Index/;' > $@
-#	| perl -pe 'last if /^Concept Index/; print "For INSTALLATION, see way below.\n\n" if /^\s*ESS grew out of/' \
 
 ../ANNOUNCE: $(TEXISRC)
 	-$(MAKETXT) announc.texi \
-	| perl -pe 'last if /^Concept Index/;' > $@
-
-README.Microsoft : README.Microsoft.texi
-	$(MAKETXT) README.Microsoft.texi \
 	| perl -pe 'last if /^Concept Index/;' > $@
 
 ../NEWS: Makefile ess-defs.texi newfeat.texi news.texi
@@ -109,15 +76,9 @@ html/ess.html: $(TEXISRC)
 	@echo "making HTML documentation..."
 	mkdir -p html
 	-$(MAKEHTML) html/ess.html ess.texi
-#MM	$(TEXI2HTML) $(SPLITCHAP) ess.texi
-#MM	test -d ess && cp -p ess/ess_toc.html html/index.html || cp -p ess_toc.html html/index.html
-#MM	test -d ess && mv -f ess/*.html html || mv -f *.html html
 
 html/readme.html: $(TEXISRC)
 	-$(MAKEHTML) html/readme.html --no-validate readme.texi
-		 ##                   ^^^^^^^^^^^^^ (design bug: "FIXME" in ess.texi)
-#MM	$(TEXI2HTML) readme.texi
-#	mv -f readme.html html
 
 html/news.html: $(TEXISRC)
 	mkdir -p html

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,12 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item ESS no longer provides julia-mode.
+You will need to install julia-mode in order to successfully install
+ESS. Julia-mode is currently hosted at
+@url{https://github.com/JuliaEditorSupport/julia-emacs}. If you install
+ESS from MELPA, this change does not affect you.
+
 @item iESS: Process runners now return the inferior buffer.
 Note that callers of inferior runners should not assume that the current
 buffer has been set to the inferior buffer. Instead, use

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -3,20 +3,6 @@
 ## Before making changes here, please take a look at Makeconf
 include ../Makeconf
 
-## For noweb extraction of code and documentation.
-
-NOTANGLE=notangle -L
-#NOTANGLE=notangle for no indexing.
-NOWEAVE=noweave
-
-## SUFFIXES are in ../Makeconf :
-.nw.html: ;     $(NOWEAVE) -filter l2h -index -html $*.nw > $*.html
-.nw.tex: ;      $(NOWEAVE) -index -delay $*.nw | cpif $*.tex
-.nw.el:  ;      $(NOTANGLE) -R$*.el | cpif $*.el
-##.nw.c:  ;       $(NOTANGLE) -R$*.c | cpif $*.c
-##.nw.h:  ;       $(NOTANGLE) -R$*.h | cpif $*.h
-.tex.dvi: ;     latex '\scrollmode \input '"$*"; while grep -s 'Rerun to get cross-references right' $*.log; do latex '\scrollmode \input '"$*"; done
-
 ## COMPILE-FLAGS are set in tests
 COMPILE = $(EMACSBATCH) $(COMPILE-FLAGS) --directory . --directory ./obsolete -f batch-byte-compile
 COMPILE-SIMPLE = $(EMACSBATCH) --directory . --directory ./obsolete -f batch-byte-compile
@@ -26,8 +12,7 @@ COMPILE-SIMPLE = $(EMACSBATCH) --directory . --directory ./obsolete -f batch-byt
 
 .PHONY: all dist install uninstall distclean clean compile
 
-JULIAS := julia-mode.el julia-latexsubs.el
-ELS = $(filter-out ess-autoloads.el, $(wildcard *.el obsolete/*.el)) $(JULIAS)
+ELS = $(filter-out ess-autoloads.el, $(wildcard *.el obsolete/*.el))
 ELC = $(ELS:.el=.elc)
 
 all dist: compile ess-autoloads.el
@@ -43,15 +28,8 @@ install: dist
 		ln -s $(LISPDIR)/ess-site.el $(SITELISP)/ess-site.el ; \
 	fi;
 
-uninstall:
-	-cd $(LISPDIR) && $(UNINSTALL) *.elc *.el
-	if [ -n "$(SITELISP)" -a -h "$(SITELISP)/ess-site.el" ] ; \
-	then \
-		cd $(SITELISP) && $(UNINSTALL) ess-site.el ; \
-	fi;
-
 distclean clean:
-	rm -f $(ELC) ess-autoloads.el $(JULIAS) .dependencies
+	rm -f $(ELC) ess-autoloads.el .dependencies
 
 
 ### File Targets
@@ -73,14 +51,6 @@ distclean clean:
 obsolete/%.elc: obsolete/%.el
 	$(COMPILE-SIMPLE) $<
 
-JULIA-REPO=https://raw.githubusercontent.com/JuliaEditorSupport/julia-emacs/master
-## Should happen before building ESS; definitely *NOT* after unpacking tarball :
-$(JULIAS):
-	test -f ../etc/.IS.RELEASE || $(DOWNLOAD) $(JULIA-REPO)/julia-mode.el > julia-mode.el
-	test -f ../etc/.IS.RELEASE || $(DOWNLOAD) $(JULIA-REPO)/julia-latexsubs.el > julia-latexsubs.el
-julia-%.elc: julia-%.el
-	$(COMPILE-SIMPLE) $<
-
 ess-autoloads.el:
 	@printf	"\nGenerating $@\n"
 	$(EMACSBATCH) --eval "(progn\
@@ -89,6 +59,3 @@ ess-autoloads.el:
 	(setq find-file-visit-truename t)\
 	(update-directory-autoloads default-directory))"
 
-# Use this to print an envvar for debugging purposes.
-# Example: make print-EMACS
-print-%: ; @echo $* = $($*)

--- a/targets/travis-get-dependencies.el
+++ b/targets/travis-get-dependencies.el
@@ -1,0 +1,17 @@
+;;; travis-get-dependencies.el --- Install ESS dependencies for Travis  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Install ESS dependencies for travis
+
+(require 'package)
+;;; Code:
+
+(add-to-list 'package-archives (cons "melpa" "https://melpa.org/packages/") t)
+
+(package-initialize)
+
+;; Get julia-mode and install
+(package-refresh-contents)
+(package-install 'julia-mode)
+
+;;; travis-get-dependencies.el ends here

--- a/targets/travis-install-package.el
+++ b/targets/travis-install-package.el
@@ -9,13 +9,7 @@
 (require 'package)
 (require 'subr-x)
 
-(add-to-list 'package-archives (cons "melpa" "https://melpa.org/packages/") t)
-
 (package-initialize)
-
-;; Get julia-mode and install
-(package-refresh-contents)
-(package-install 'julia-mode)
 
 ;; This file gets called from one directory up
 (when-let ((file (directory-files default-directory t ".tar$")))

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,14 +1,11 @@
 
 include ../Makeconf
 
-.PHONY: literate all julia lisp ess inf r r-indent literate cases indent-cases literate-cases
+.PHONY: literate all lisp ess inf r r-indent literate cases indent-cases literate-cases
 
 all: compile lisp
 
-julia:
-	@$(MAKE) -C .. julia
-
-lisp: julia
+lisp:
 	${EMACS} -Q --script run-tests
 
 ess:
@@ -39,5 +36,5 @@ literate-cases:
 
 .PHONY: compile
 compile:
-	@cd ../lisp && make -k all \
+	@cd .. && make -k lisp \
 		"COMPILE-FLAGS = --eval \"(setq byte-compile-error-on-warn t)\""

--- a/test/run-tests
+++ b/test/run-tests
@@ -9,6 +9,12 @@
   (setq ess-test-path (expand-file-name "." current-directory))
   (setq ess-root-path (expand-file-name "../lisp/" current-directory)))
 
+(if (getenv "CONTINUOUS_INTEGRATION")
+    ;; In travis, julia-mode is installed with package.el
+    (progn (require 'package)
+           (package-initialize))
+  (add-to-list 'load-path (getenv "JULIA_DIR")))
+
 (add-to-list 'load-path ess-root-path)
 (add-to-list 'load-path ess-test-path)
 


### PR DESCRIPTION
This removes the awkward julia-mode download from our build system and just assumes julia-mode is present. It gets around issues like we have in the ess-18.10 branch which is currently unusable since julia-mode changed from a single file to multiple files.

The cost is of course that people who previously installed ESS with a tarball will now need to install julia-mode before doing so, see #780.

It doesn't affect MELPA users, as they never used our build system; they get julia-mode from MELPA.