### PR TITLE
Refactor R-newest into ess-run-newest-r

### DIFF
--- a/doc/help-s.texi
+++ b/doc/help-s.texi
@@ -61,7 +61,7 @@ type @kbd{M-x rw} and then hit [Tab].  These other versions of
 R can also be started from the "ESS->Start Process->Other" menu.
 
 Once ESS has found these extra versions of R, it will then create a new
-function, called @kbd{M-x R-newest}, which will call the newest version
+function, called @kbd{M-x run-ess-r-newest}, which will call the newest version
 of R that it found.  (ESS examines the date in the first line of
 information from @code{R --version} to determine which is newest.)
 


### PR DESCRIPTION
- Rename R-newest to ess-run-newest-r. Refactor so that instead of
  setting its own function slot it simply let-binds
  inferior-ess-r-program to the newest version of R found.

- Remove ess-newest-r. It has a confusing name and it only used in one
  place.

- Remove ess-current-R-version. Unused.

- Remove ess-current-R-at-least. Unused.