### PR TITLE
Add a command to insert a pipe

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -87,6 +87,9 @@ buffers. To enable it, customize @code{ess-r-mode-hook}.
 
 @item ESS[Rd]: Rd no longer writes abbrevs to user's abbrev file.
 
+@item ESS[R]: New command ess-r-insert-pipe and new option ess-r-insert-pipe-behavior.
+New keybinding C-c RET to easily insert a pipe.
+
 @item ESS removed support for many unused languages.
 This includes old versions of S+, ARC, OMG, VST, and XLS.
 

--- a/test/ess-test-r.el
+++ b/test/ess-test-r.el
@@ -614,6 +614,43 @@ Arguments:
     (with-r-running nil
       (should-not (buffer-local-value 'comint-input-ring-file-name (ess-get-process-buffer))))))
 
+(ert-deftest ess-test-r-insert-pipe ()
+  (with-temp-buffer
+    (let ((ess-r-insert-pipe-behavior nil))
+      (ess-r-insert-pipe)
+      (should (string= (buffer-string)
+                       " %>% "))))
+  (with-temp-buffer
+    (let ((ess-r-insert-pipe-behavior '(eol)))
+      (insert "foobar")
+      (backward-char 3)
+      (ess-r-insert-pipe)
+      (should (string= (buffer-string)
+                       "foobar %>% "))))
+  (with-temp-buffer
+    (let ((ess-r-insert-pipe-behavior '(newline)))
+      (insert "foobar")
+      (backward-char 3)
+      (ess-r-insert-pipe)
+      (should (string= (buffer-string)
+                       "foo %>%\nbar"))
+      (let ((last-command 'ess-r-insert-pipe)
+            (this-command 'ess-r-insert-pipe))
+        (ess-r-insert-pipe))
+      (should (string= (buffer-string)
+                       "foo %>% bar"))))
+  (with-temp-buffer
+    (let ((ess-r-insert-pipe-behavior '(eol newline)))
+      (insert "foobar")
+      (backward-char 3)
+      (ess-r-insert-pipe)
+      (should (string= (buffer-string)
+                       "foobar %>%\n"))
+      (universal-argument)
+      (ess-r-insert-pipe t)
+      (should (string= (buffer-string)
+                       "foobar %>%\n%>%")))))
+
 (provide 'ess-test-r)
 
 ;;; ess-test-r.el ends here


### PR DESCRIPTION
Current keybinding in ess-r-mode-map is C-c RET. I wanted to use C-c C-m (m for magrittr) but I forgot C-m redirected to RET. C-c RET seems reasonable though. I'm open to others' suggestions.

The exact behavior is governed by ess-r-insert-pipe-behavior. It's a list that can contain elements like eol (for end-of-line) and newline (which also indents).

I hope this behavior is satisfactory to everyone, let me know what you think.