### PR TITLE
[WIP] Python support

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -56,6 +56,7 @@
 (declare-function tramp-tramp-file-p "tramp" (name))
 (declare-function inferior-ess-r-mode "ess-r-mode" ())
 (declare-function inferior-ess-julia-mode "ess-julia" ())
+(declare-function inferior-ess-python-mode "ess-python" ())
 (declare-function inferior-ess-stata-mode "ess-stata-mode" ())
 (declare-function extract-rectangle-bounds "rect" (start end))
 
@@ -91,6 +92,9 @@ been initialised."
   (cond ((string= "R" dialect)
          (progn (require 'ess-r-mode)
                 (inferior-ess-r-mode)))
+        ((string= "python" dialect)
+         (progn (require 'ess-python)
+                (inferior-ess-python-mode)))
         ((string= "julia" dialect)
          (progn (require 'ess-julia)
                 (inferior-ess-julia-mode)))
@@ -714,7 +718,7 @@ PROC defaults to process with name `ess-local-process-name'."
 PROC defaults to the process given by `ess-local-process-name'"
   (process-put (or proc (get-process ess-local-process-name)) propname value))
 
-(defun ess-start-process-specific (language dialect)
+(cl-defgeneric ess-start-process-specific (language dialect)
   "Start an ESS process.
 Typically from a language-specific buffer, using LANGUAGE (and DIALECT)."
   (save-current-buffer
@@ -731,12 +735,10 @@ Typically from a language-specific buffer, using LANGUAGE (and DIALECT)."
        ((fboundp dsymb)
         (funcall dsymb))
        (t ;; else: ess-dialect is not a function
-
         ;; Typically triggered from
         ;; ess-force-buffer-current("Process to load into: ")
         ;;  \-->  ess-request-a-process("Process to load into: " no-switch)
-        (error "No ESS processes running; not yet implemented to start (%s,%s)"
-               language dialect))))))
+        (error "No ESS processes running; not yet implemented to start (%s,%s)" language dialect))))))
 
 (defun ess-request-a-process (message &optional noswitch ask-if-1)
   "Ask for a process, and make it the current ESS process.

--- a/lisp/ess-python.el
+++ b/lisp/ess-python.el
@@ -117,5 +117,7 @@ modifying the command line arguments."
   (setq-local compilation-error-regexp-alist python-shell-compilation-regexp-alist)
   (compilation-shell-minor-mode))
 
+(add-to-list 'auto-mode-alist '("\\.py\\'" . ess-python-mode))
+
 (provide 'ess-python)
 ;;; ess-python.el ends here

--- a/lisp/ess-python.el
+++ b/lisp/ess-python.el
@@ -107,6 +107,8 @@ modifying the command line arguments."
   "Mode for inferior python buffers."
   (setq ess-dialect "python"
         inferior-ess-help-command "help(%s)\n"
+        inferior-ess-primary-prompt python-shell-prompt-regexp
+        inferior-ess-secondary-prompt python-shell-prompt-block-regexp
         inferior-ess-search-list-command "import sys; sys.modules.keys()\n"
         inferior-ess-exit-command "exit()\n")
   (setq-local ess-getwd-command "import os; os.getcwd('%s')")

--- a/lisp/ess-python.el
+++ b/lisp/ess-python.el
@@ -111,7 +111,7 @@ modifying the command line arguments."
         inferior-ess-secondary-prompt python-shell-prompt-block-regexp
         inferior-ess-search-list-command "import sys; sys.modules.keys()\n"
         inferior-ess-exit-command "exit()\n")
-  (setq-local ess-getwd-command "import os; os.getcwd('%s')")
+  (setq-local ess-getwd-command "import os; os.getcwd(os.path.expanduser('%s'))")
   (setq-local ess-setwd-command "import os; os.chdir('%s')")
   (setq-local comint-input-sender #'ess-python-input-sender)
   (setq-local compilation-error-regexp-alist python-shell-compilation-regexp-alist)

--- a/lisp/ess-python.el
+++ b/lisp/ess-python.el
@@ -1,0 +1,107 @@
+;;; ess-python.el --- ESS support for python         -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019  J. Alexander Branham
+
+;; Author: J. Alexander Branham <alex.branham@gmail.com>
+;; Keywords: languages
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; ESS support for python. Support is experimental, use at your own
+;; risk. Please contact the developers before relying on this code,
+;; APIs are subject to change.
+
+;;; Code:
+
+(require 'ess-help)
+(require 'ess-inf)
+(require 'python)
+
+(defgroup ess-python nil
+  "ESS support for python"
+  :group 'languages
+  :group 'ess
+  :group 'python)
+
+(defcustom ess-python-post-run-hook nil
+  "Hook to run after starting python."
+  :type 'hook
+  :group 'ess-python
+  :group 'ess-hooks
+  :package-version '(ess . "19.04"))
+
+(defvar ess-python-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map ess-mode-map)
+    map)
+  "Keymap for `ess-python-mode'.")
+
+(cl-defmethod ess-help-get-topics (_proc &context ((string= ess-dialect "python") (eql t)))
+  ;; TODO, but return nil for now so that `ess-display-help-on-object'
+  ;; doesn't error.
+  nil)
+
+(cl-defmethod ess-start-process-specific (_language _dialect &context ((string= ess-dialect "python") (eql t)))
+  (save-current-buffer
+    (run-ess-python)))
+
+(defun ess-python-input-sender (proc string)
+  "Input sender for `ess-inferior-python-mode' buffers.
+`comint-input-sender' is set to this, which see for PROC and
+STRING."
+  (save-current-buffer
+    (let ((comint-output-filter-functions nil))
+      (cond ((string-match (rx bol (0+ whitespace) (group-n 1 "help(") (group-n 2 (1+ nonl)) ")")
+                           string)
+             (ess-display-help-on-object (match-string 2 string))
+             (process-send-string proc "\n"))
+            (t ;; normal command
+             (inferior-ess-input-sender proc string))))))
+
+;;;###autoload
+(defun run-ess-python (&optional start-args)
+  "Start an inferior python process.
+START-ARGS (interactively, \\[universal-argument]) allows
+modifying the command line arguments."
+  (interactive
+   (if current-prefix-arg
+       (list
+        (read-string "Run python with args: " python-shell-interpreter-args))
+     (list python-shell-interpreter-args)))
+  (let* ((inferior-ess-program python-shell-interpreter)
+         (inf-buf (inferior-ess (or start-args python-shell-interpreter-args) '((ess-dialect . "python")))))
+    (with-current-buffer inf-buf
+      (run-mode-hooks 'ess-python-post-run-hook)
+      (comint-goto-process-mark))
+    inf-buf))
+
+;;;###autoload
+(define-derived-mode ess-python-mode python-mode "ESS[python]"
+  "ESS mode for python buffers."
+  (setq ess-dialect "python"))
+
+(define-derived-mode inferior-ess-python-mode inferior-ess-mode "iESS[python]"
+  "Mode for inferior python buffers."
+  (setq ess-dialect "python"
+        inferior-ess-help-command "help(%s)\n"
+        inferior-ess-search-list-command "import sys; sys.modules.keys()\n"
+        inferior-ess-exit-command "exit()\n")
+  (setq-local ess-getwd-command "import os; os.getcwd('%s')")
+  (setq-local ess-setwd-command "import os; os.chdir('%s')")
+  (setq-local comint-input-sender #'ess-python-input-sender))
+
+(provide 'ess-python)
+;;; ess-python.el ends here

--- a/lisp/ess-python.el
+++ b/lisp/ess-python.el
@@ -30,6 +30,9 @@
 (require 'ess-inf)
 (require 'python)
 
+(eval-when-compile
+  (require 'subr-x))
+
 (defgroup ess-python nil
   "ESS support for python"
   :group 'languages
@@ -57,6 +60,13 @@
 (cl-defmethod ess-start-process-specific (_language _dialect &context ((string= ess-dialect "python") (eql t)))
   (save-current-buffer
     (run-ess-python)))
+
+(cl-defmethod ess-quit--override (_arg &context ((string= ess-dialect "python") (eql t)))
+  "ARG is ignored for python."
+  (if-let ((sprocess (ess-get-process ess-current-process-name)))
+      (progn (ess-cleanup)
+             (ess-send-string sprocess "exit()\n" t))
+    (error "No ESS process running")))
 
 (defun ess-python-input-sender (proc string)
   "Input sender for `ess-inferior-python-mode' buffers.

--- a/lisp/ess-python.el
+++ b/lisp/ess-python.el
@@ -113,7 +113,9 @@ modifying the command line arguments."
         inferior-ess-exit-command "exit()\n")
   (setq-local ess-getwd-command "import os; os.getcwd('%s')")
   (setq-local ess-setwd-command "import os; os.chdir('%s')")
-  (setq-local comint-input-sender #'ess-python-input-sender))
+  (setq-local comint-input-sender #'ess-python-input-sender)
+  (setq-local compilation-error-regexp-alist python-shell-compilation-regexp-alist)
+  (compilation-shell-minor-mode))
 
 (provide 'ess-python)
 ;;; ess-python.el ends here

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -310,6 +310,7 @@ to `ess-completing-read'."
 (defun ess-derived-mode-p ()
   "Non-nil if the current major mode is an ESS major mode."
   (or (derived-mode-p 'ess-mode)
+      (derived-mode-p 'ess-python-mode)
       (derived-mode-p 'ess-julia-mode)))
 
 (defun ess--generate-eval-visibly-submenu (_menu)


### PR DESCRIPTION
Here's a very, very simple implementation of python support based off of how we handle julia. It uses all the built-in ESS stuff for starting, managing, and interacting with the process. This is nice because it makes the implementation very simple (ess-python is just over 100 lines as it stands) and most things "just work:" the ess-eval- functions, movement, etc.

However, it's not so nice because it means we don't support anything relying on python.el's functions for interacting with a running process (so the built-in completion doesn't work, built-in eldoc, etc). There's tons of 3rd-party plugins for that sort of thing, though.

It doesn't do anything smart like handle ipython/jupyter or stuff like that yet.

If merged, closes #910