### PR TITLE
[Fix #911] Don't overwrite local user indentation settings

### DIFF
--- a/test/ess-test-indentation.el
+++ b/test/ess-test-indentation.el
@@ -53,6 +53,8 @@
      ,@(cdr (assq 'RStudio- ess-style-alist)))
     (C++
      ,@(cdr (assq 'C++ ess-style-alist)))
+    (DEFAULT
+      ,@(cdr (assq 'DEFAULT ess-style-alist)))
     (misc1
      (ess-indent-offset . 3)
      (ess-offset-block . open-delim)
@@ -86,7 +88,9 @@ where the edit took place. Return nil if E represents no real change.
   (with-current-buffer buffer
     (setq buffer-undo-list nil)
     (indent-region (point-min) (point-max))
-    (not (buffer-modified-p buffer))))
+    (if (buffer-modified-p buffer)
+        (progn (switch-to-buffer buffer) nil)
+      t)))
 
 (defun ess-test-explain-change-on-indent (buffer)
   "Explainer function for `not-change-on-indent'."
@@ -105,6 +109,18 @@ where the edit took place. Return nil if E represents no real change.
             (diff was writen to ,diff-file)))))))
 
 (put 'not-change-on-indent 'ert-explainer 'ess-test-explain-change-on-indent)
+
+;; Don't overwrite user settings (#911).
+(ert-deftest ess-r-no-user-style-overwrite-test ()
+  (let ((ess-style 'RRR)
+        (ess-r-mode-hook '((lambda () (setq-local ess-indent-offset 1)))))
+    (with-temp-buffer
+      (ess-r-mode)
+      (should (eq ess-indent-offset 1))
+      (ess-set-style)
+      (should (eq ess-indent-offset 1))
+      (ess-set-style 'C++)
+      (should (eq ess-indent-offset 4)))))
 
 (ert-deftest test-ess-R-indentation-RRR ()
   (ess-test-R-indentation "styles/RRR.R" 'RRR))

--- a/test/ess-test-r-utils.el
+++ b/test/ess-test-r-utils.el
@@ -145,8 +145,7 @@ split arbitrary."
             ;; (buffer-substring-no-properties (point-min) (point-max))
             (replace-regexp-in-string
              prompt-regexp "> "
-             (buffer-substring-no-properties (point-min) (point-max))))
-          )
+             (buffer-substring-no-properties (point-min) (point-max)))))
       (kill-process proc)
       ;; fixme: kill in sentinel; this doesn't work in batch mode
       ;; (kill-buffer (process-buffer proc))

--- a/test/ess-test-r.el
+++ b/test/ess-test-r.el
@@ -500,7 +500,7 @@ my_mean2 <- function(z){
 
 (ert-deftest ess-r-comment-dwim-test ()
   "Test `comment-dwim' and Bug #434."
-  (let ((ess-default-style 'RRR))
+  (let ((ess-style 'RRR))
     (ess-r-test-with-temp-text "#¶ "
       (let ((ess-indent-with-fancy-comments t))
         (comment-dwim nil)


### PR DESCRIPTION
This is a followup on #915 which I inadvertently messed up. 

@jabranham I have found a nice compromise. The extra var and tracking of locals are no longer needed. Nor an extra function for the hook. 