### PR TITLE
[WIP] Inferior process misbehavior with individualized prompt

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -66,6 +66,7 @@
 (declare-function ess-dump-object-into-edit-buffer "ess-mode" (object))
 
 (defvar add-log-current-defun-header-regexp)
+(defvar-local ess--make-local-vars-permanent nil)
 
 ;; The following declares can be removed once we drop Emacs 25
 (declare-function tramp-file-name-method "tramp")
@@ -176,8 +177,9 @@ This may be useful for debugging."
       (setq-local default-directory cur-dir)
       ;; TODO: Get rid of this, we should rely on modes to set the
       ;; variables they need.
-      (ess-setq-vars-local customize-alist)
-      (inferior-ess--set-major-mode ess-dialect)
+      (let ((ess--make-local-vars-permanent t))
+        (ess-setq-vars-local customize-alist)
+        (inferior-ess--set-major-mode ess-dialect))
       ;; Read the history file
       (when ess-history-file
         (setq comint-input-ring-file-name

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -1114,7 +1114,7 @@ nil and not t, query for each instance."
           (set (car pair) (eval (cdr pair)))
           (when (bound-and-true-p ess--make-local-vars-permanent)
             (put (car pair) 'permanent-local t))) ;; hack for Rnw
-        alist))
+        (if (symbolp alist) (eval alist) alist)))
 
 (defvar ess-error-regexp   "^\\(Syntax error: .*\\) at line \\([0-9]*\\), file \\(.*\\)$"
   "Regexp to search for errors.")


### PR DESCRIPTION
Like a lot of people, I set my R prompt to something other than the
default "> ".

Commit 1c2a5e95 causes `test-org-ob-R-session-output-test` to hang (this doesn't happen on
travis because the prompt remains the default).

The bug also manifests by simply running `M-x R` (assuming your prompt is not
the default).  You will find the prompt echoes unexpectedly with every
space typed.