### PR TITLE
Remove ess-execute-dialect-specific

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2392,10 +2392,6 @@ highlighted with the same face as `ess-R-keywords'"
 (defvar ess-execute-screen-options-command nil
   "Dialect specific command run by `ess-execute-screen-options'.")
 
-(defvar-local ess-manual-lookup-command nil
-  "Dialect specific command manual lookup.
-Passed to `ess-execute-dialect-specific' which see.")
-
 (defvar-local ess-reference-lookup-command nil
   "Dialect specific command for reference lookup.
 Passed to `ess-execute-dialect-specific' which see.")

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2392,10 +2392,6 @@ highlighted with the same face as `ess-R-keywords'"
 (defvar ess-execute-screen-options-command nil
   "Dialect specific command run by `ess-execute-screen-options'.")
 
-(defvar-local ess-reference-lookup-command nil
-  "Dialect specific command for reference lookup.
-Passed to `ess-execute-dialect-specific' which see.")
-
 (defvar-local ess-funargs-command  nil
   "Dialect specific command to return a list of function arguments.
 See `ess-function-arguments' and .ess_funargs command in R and

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2392,10 +2392,6 @@ highlighted with the same face as `ess-R-keywords'"
 (defvar ess-execute-screen-options-command nil
   "Dialect specific command run by `ess-execute-screen-options'.")
 
-(defvar-local ess-help-web-search-command nil
-  "Dialect specific command web help search.
-Passed to `ess-execute-dialect-specific' which see.")
-
 (defvar-local ess-manual-lookup-command nil
   "Dialect specific command manual lookup.
 Passed to `ess-execute-dialect-specific' which see.")

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -450,11 +450,6 @@ ESS-specific variables `ess-help-own-frame',
   "Dialect-specific override for `ess-manual-lookup'."
   (error "Not implemented for %s" ess-dialect))
 
-(defun ess-reference-lookup ()
-  "Search manual for topic."
-  (interactive)
-  (ess-execute-dialect-specific ess-reference-lookup-command))
-
 (defvar ess-doc-map
   (let (ess-doc-map)
     (define-prefix-command 'ess-doc-map)
@@ -474,8 +469,6 @@ ESS-specific variables `ess-help-own-frame',
     (define-key ess-doc-map "w" #'ess-help-web-search)
     (define-key ess-doc-map "\C-m" #'ess-manual-lookup)
     (define-key ess-doc-map "m" #'ess-manual-lookup)
-    (define-key ess-doc-map "\C-r" #'ess-reference-lookup)
-    (define-key ess-doc-map "r" #'ess-reference-lookup)
     ess-doc-map)
   "ESS documentation map.")
 

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -442,9 +442,13 @@ ESS-specific variables `ess-help-own-frame',
   (error "Not implemented for %s" ess-dialect))
 
 (defun ess-manual-lookup ()
-  "Search manual for topic."
+  "Search manual for documentation."
   (interactive)
-  (ess-execute-dialect-specific ess-manual-lookup-command ))
+  (ess--manual-lookup-override))
+
+(cl-defgeneric ess--manual-lookup-override ()
+  "Dialect-specific override for `ess-manual-lookup'."
+  (error "Not implemented for %s" ess-dialect))
 
 (defun ess-reference-lookup ()
   "Search manual for topic."

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -432,10 +432,14 @@ ESS-specific variables `ess-help-own-frame',
         (pop-to-buffer buff display-alist)
       (display-buffer buff display-alist))))
 
-(defun ess-help-web-search ()
-  "Search the web for documentation."
-  (interactive)
-  (ess-execute-dialect-specific ess-help-web-search-command "Search for: "))
+(defun ess-help-web-search (cmd)
+  "Search the web for documentation on CMD."
+  (interactive "sSearch for: ")
+  (ess--help-web-search-override cmd))
+
+(cl-defgeneric ess--help-web-search-override (_cmd)
+  "Dialect-specific override for `ess-help-web-search', which see for CMD."
+  (error "Not implemented for %s" ess-dialect))
 
 (defun ess-manual-lookup ()
   "Search manual for topic."

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -294,7 +294,6 @@ to look up any doc strings."
     (inferior-ess-prompt           . "\\w*> ")
     (ess-local-customize-alist     . 'ess-julia-customize-alist)
     (inferior-ess-program          . inferior-julia-program)
-    ;; (ess-reference-lookup-command       . 'ess-julia-reference-lookup-function)
     (ess-load-command              . "include(expanduser(\"%s\"))\n")
     (ess-funargs-command           . "ESS.fun_args(\"%s\")\n")
     (ess-dump-error-re             . "in \\w* at \\(.*\\):[0-9]+")

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -296,7 +296,6 @@ to look up any doc strings."
     (inferior-ess-prompt           . "\\w*> ")
     (ess-local-customize-alist     . 'ess-julia-customize-alist)
     (inferior-ess-program          . inferior-julia-program)
-    (ess-help-web-search-command   . "https://docs.julialang.org/en/latest/search/?q=%s")
     (ess-manual-lookup-command     . 'ess-julia-manual-lookup-function)
     ;; (ess-reference-lookup-command       . 'ess-julia-reference-lookup-function)
     (ess-load-command              . "include(expanduser(\"%s\"))\n")
@@ -331,6 +330,10 @@ to look up any doc strings."
     (ess-getwd-command             . "pwd()\n")
     (ess-setwd-command             . "cd(expanduser(\"%s\"))\n"))
   "Variables to customize for Julia.")
+
+(cl-defmethod ess--help-web-search-override (cmd &context (ess-dialect "julia"))
+  "Offer to search the web for a Julia command."
+  (browse-url (format "https://docs.julialang.org/en/latest/search/?q=%s" cmd)))
 
 (defvar ess-julia-completion-syntax-table
   (let ((table (copy-syntax-table ess-r-mode-syntax-table)))

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -88,10 +88,8 @@ VISIBLY is not currently used."
       (nreverse out))))
 
 (defvar ess-julia--manual-topics nil)
-(defun ess-julia-manual-lookup-function (&rest _args)
+(cl-defmethod ess--manual-lookup-override (&context (ess-dialect "julia"))
   "Look up topics at https://docs.julialang.org/en/latest/manual/."
-  (interactive)
-  ;; <li class="toctree-l1"><a class="reference internal" href="introduction/">Introduction</a></li>
   (let* ((pages (or ess-julia--manual-topics
                     (setq ess-julia--manual-topics
                           (ess-julia--retrive-topics
@@ -296,7 +294,6 @@ to look up any doc strings."
     (inferior-ess-prompt           . "\\w*> ")
     (ess-local-customize-alist     . 'ess-julia-customize-alist)
     (inferior-ess-program          . inferior-julia-program)
-    (ess-manual-lookup-command     . 'ess-julia-manual-lookup-function)
     ;; (ess-reference-lookup-command       . 'ess-julia-reference-lookup-function)
     (ess-load-command              . "include(expanduser(\"%s\"))\n")
     (ess-funargs-command           . "ESS.fun_args(\"%s\")\n")

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -389,7 +389,6 @@ To be used as part of `font-lock-defaults' keywords."
      (ess-call-stack-command                . ess-r-call-stack-command)
      (ess-mode-completion-syntax-table      . ess-r-completion-syntax-table)
      (ess-build-eval-message-function       . #'ess-r-build-eval-message)
-     (ess-help-web-search-command           . #'ess-r-sos)
      (ess-build-help-command-function       . #'ess-r-build-help-command)
      (ess-dump-filename-template            . ess-r-dump-filename-template)
      (ess-change-sp-regexp                  . ess-r-change-sp-regexp)
@@ -1081,11 +1080,12 @@ With argument UPDATE, update cached packages list."
         (ess-eval-linewise (format "install.packages('%s')\n" pkg))
       (signal 'quit nil))))
 
-(defun ess-r-sos (cmd)
-  "Interface to findFn in the library sos."
-  (interactive  "sfindFn: ")
+(define-obsolete-function-alias 'ess-r-sos #'ess-help-web-search "ESS 19.04")
+
+(cl-defmethod ess--help-web-search-override (cmd &context (ess-dialect "R"))
   (ess-r-check-install-package "sos")
   (ess-eval-linewise (format "sos::findFn(\"%s\", maxPages=10)" cmd)))
+
 
 (defun ess-R-scan-for-library-call (string)
   "Detect `library/require' call in STRING and update tracking vars.
@@ -2298,7 +2298,6 @@ state.")
   "Major mode for help buffers."
   :group 'ess-help
   (setq ess-dialect "R"
-        ess-help-web-search-command #'ess-r-sos
         ess-build-help-command-function #'ess-r-build-help-command
         ess-help-sec-regex ess-help-r-sec-regex
         ess-help-sec-keys-alist ess-help-r-sec-keys-alist ; TODO: Still necessary?

--- a/lisp/ess-stata-mode.el
+++ b/lisp/ess-stata-mode.el
@@ -71,7 +71,6 @@
     (ess-help-sec-keys-alist       . ess-help-STA-sec-keys-alist)
     (ess-loop-timeout              . 500000 )
     (ess-object-name-db-file       . "ess-sta-namedb.el" )
-    (ess-help-web-search-command   . "https://www.stata.com/search/?q=%s&restrict=&btnG=Search&client=stata&num=&output=xml_no_dtd&site=stata&ie=&oe=UTF-8&sort=&proxystylesheet=stata")
     (inferior-ess-program          . inferior-STA-program)
     (inferior-ess-objects-command  . "describe\n")
     (inferior-ess-help-command     . "help %s\n") ;; assumes set more off
@@ -88,6 +87,12 @@
     (ess-load-command              . "run \"%s\"\n"))
   "Variables to customize for Stata.")
 
+(cl-defmethod ess--help-web-search-override (cmd &context (ess-dialect "stata"))
+  "Browse the web for documentation about CMD in Stata."
+  (browse-url
+   (format
+    "https://www.stata.com/search/?q=%s&restrict=&btnG=Search&client=stata&num=&output=xml_no_dtd&site=stata&ie=&oe=UTF-8&sort=&proxystylesheet=stata"
+    cmd)))
 
 ;;;###autoload
 (define-derived-mode ess-stata-mode ess-mode "ESS[STA]"

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -266,47 +266,6 @@ process to avoid excessive requests."
            (process-put *proc* ',time-var (current-time))
            out)))))
 
-(defmacro ess-execute-dialect-specific (command &optional prompt &rest args)
-  "Execute dialect specific COMMAND.
-
--- If command is nil issue warning 'Not available for dialect X'
--- If command is a elisp function, execute it with ARGS
--- If a string starting with 'http' or 'www', browse with `browse-url',
-   otherwise execute the command in inferior process.
--- If a string, interpret as a command to subprocess, and
-   substitute ARGS with `(format ,command ,@args).
-
-When PROMPT is non-nil ask the user for a string value and
-prepend the response to ARGS.
-
-If prompt is a string just pass it to `read-string'. If a list, pass it
-to `ess-completing-read'."
-  `(if (null ,command)
-       (message "Not implemented for dialect %s" ess-dialect)
-     (let* ((com  (if (symbolp ,command)
-                      (symbol-function ,command)
-                    ,command))
-            (prompt ',prompt)
-            (resp (and prompt
-                       (if (stringp  prompt)
-                           (read-string  prompt)
-                         (apply 'ess-completing-read prompt))))
-            (args (append (list resp) ',args)))
-       (cond ((functionp com)
-              (apply com args))
-             ((and (stringp com)
-                   (string-match "^\\(http\\|www\\)" com))
-              (setq com (apply 'format com args))
-              (require 'browse-url)
-              (browse-url com))
-             ((stringp com)
-              (unless (string-match "\n$" com)
-                (setq com (concat com "\n")))
-              (setq com (apply 'format com args))
-              (ess-eval-linewise com))
-             (t
-              (error "Argument COMMAND must be either a function or a string"))))))
-
 
 ;;; Emacs Integration
 


### PR DESCRIPTION
This PR moves some functions to using the new cl-generics stuff and removes ess-execute-dialect-specific. I don't think this is controversial at all and there's no user-facing changes so I'll let this hang out here and merge it in a few days unless I hear back otherwise.


----

#