### PR TITLE
add latex expansion to ess-julia-mode

### DIFF
--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -373,6 +373,7 @@ It makes underscores and dots word constituent chars.")
   (remove-hook 'completion-at-point-functions 'ess-filename-completion 'local) ;; should be first
   (add-hook 'completion-at-point-functions 'ess-julia-object-completion nil 'local)
   (add-hook 'completion-at-point-functions 'ess-filename-completion nil 'local)
+  (add-hook 'completion-at-point-functions 'ess-julia-latexsub-completion nil 'local)
   (if (fboundp 'ess-add-toolbar) (ess-add-toolbar)))
 
 ;; Inferior mode


### PR DESCRIPTION
Add expansion of Unicode characters in `ess-julia-mode`.
For example, after typing `\alpha` and running command `completion-at-point`, `\alpha` will be replaced by Unicode character α.
This solves problem described at https://github.com/emacs-ess/ESS/pull/122#issuecomment-168600364 