### PR TITLE
Fix help lookup default choice

### DIFF
--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -663,8 +663,8 @@ nil otherwise."
   "Find help, prompting for P-STRING."
   (ess-make-buffer-current)
   (let* ((help-files-list (ess-help-get-topics ess-current-process-name))
-         (hlpobjs (ess-helpobjs-at-point help-files-list)))
-    (ess-completing-read p-string (append (delq nil hlpobjs) help-files-list)
+         (hlpobjs (delq nil (ess-helpobjs-at-point help-files-list))))
+    (ess-completing-read p-string (append hlpobjs help-files-list)
                          nil nil nil nil (car hlpobjs))))
 
 


### PR DESCRIPTION
When `helpobsj` starts w/ one or more `nil` values, delq removes them from the return value, but does not mutate the list.  Then the CAR will be nil and the default choice missing.

Easy fix is to store `delq`'s return value (the list itself is used nowhere else in the function).