### PR TITLE
fix(ess-r-mode): fix eldoc in Emacs 28 snapshot

### DIFF
--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -703,6 +703,9 @@ top level functions only."
   ;; eldoc
   (add-function :before-until (local 'eldoc-documentation-function)
                 #'ess-r-eldoc-function)
+  (if (>= emacs-major-version 28)
+      (add-hook 'eldoc-documentation-functions
+                #'elisp-eldoc-documentation-function nil t))
   (when ess-use-eldoc (eldoc-mode))
   ;; auto-complete
   (ess--setup-auto-complete ess-r-ac-sources)

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -703,7 +703,7 @@ top level functions only."
   ;; eldoc
   (add-function :before-until (local 'eldoc-documentation-function)
                 #'ess-r-eldoc-function)
-  (if (>= emacs-major-version 28)
+  (if (not eldoc-documentation-functions)
       (add-hook 'eldoc-documentation-functions
                 #'elisp-eldoc-documentation-function nil t))
   (when ess-use-eldoc (eldoc-mode))

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -703,7 +703,7 @@ top level functions only."
   ;; eldoc
   (add-function :before-until (local 'eldoc-documentation-function)
                 #'ess-r-eldoc-function)
-  (if (not eldoc-documentation-functions)
+  (if (>= emacs-major-version 28)
       (add-hook 'eldoc-documentation-functions
                 #'elisp-eldoc-documentation-function nil t))
   (when ess-use-eldoc (eldoc-mode))


### PR DESCRIPTION
The eldoc-mode can't be turned on in the Emacs version:
       GNU Emacs 28.0.50 (build 2, x86_64-w64-mingw32) of 2020-02-27

The `eldoc-documentation-functions` is nill and not sure whether it is a bug of Emacs. The fix makes eldoc work with ESS again.