### PR TITLE
Update `default-directory` of process buffer after setting wd

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,12 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item @code{ess-set-working-directory} no longer changes the active
+directory (as defined by the buffer-local variable
+@code{default-directory}) of the buffer where the command is called.
+Instead, the active directory of the inferior buffer is updated to the
+new working directory.
+
 @item The default of ess-eval-visibly is now nil.
 
 @item ESS[R]: There is a new menu entry for reloading the R process.

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -2760,8 +2760,8 @@ NO-ERROR prevents errors when this has not been implemented for
                         (with-parsed-tramp-file-name path v v-localname)
                       path)))
         (ess-eval-linewise (format ess-setwd-command lpath))
-        ;; use set instead of setq to take effect even when let bound
-        (set 'default-directory (file-name-as-directory path)))
+        (ess-set-process-variable 'default-directory
+                                  (file-name-as-directory path)))
     (unless no-error
       (error "Not implemented for dialect %s" ess-dialect))))
 

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -215,10 +215,25 @@ OUT-STRING is the content of the region captured by
         (should (looking-at-p "more_code4"))))
     ))
 
-(ert-deftest ess-verbose-setwd-test ()
+(ert-deftest ess-setwd-test ()
   (with-r-running nil
+    ;; Working directory is set verbosely
     (should (output= (ess-set-working-directory temporary-file-directory)
-                     (format "setwd('%s')" temporary-file-directory)))))
+                     (format "setwd('%s')" temporary-file-directory)))
+    ;; Update process default-directory but not caller's buffer
+    (let* ((cur-dir default-directory)
+           (temp-dir (file-name-as-directory (make-temp-file "setwd-dir" t))))
+      (unwind-protect
+          (progn
+            (setq default-directory temp-dir)
+            (ess-set-working-directory temporary-file-directory)
+            (should (equal default-directory temp-dir))
+            (should (equal (ess-get-process-variable 'default-directory)
+                           temporary-file-directory))
+            (ess-set-working-directory temp-dir)
+            (should (equal (ess-get-process-variable 'default-directory)
+                           temp-dir)))
+        (setq default-directory cur-dir)))))
 
 
 ;;*;; Sending input

--- a/test/ess-test-r-package.el
+++ b/test/ess-test-r-package.el
@@ -79,7 +79,9 @@
           ess-ask-for-ess-directory)
       (ess-set-working-directory (expand-file-name "src" pkg-dir))
       (ess-r-package-use-dir)
-      (should (string= pkg-dir (file-truename (directory-file-name default-directory))))
+      (should (string= pkg-dir (file-truename
+                                (directory-file-name
+                                 (ess-get-process-variable 'default-directory)))))
       (ess-wait-for-process)
       (should (string= pkg-dir (file-truename (ess-get-working-directory))))
       (ess-wait-for-process)

--- a/test/ess-test-r.el
+++ b/test/ess-test-r.el
@@ -145,7 +145,7 @@
     (ess-eval-linewise "getwd()" 'invisible)
     (should (output= (ess-eval-buffer nil)
                      "setwd('/')\n> [1] \"/\""))
-    (should (string= default-directory "/"))))
+    (should (string= (ess-get-process-variable 'default-directory) "/"))))
 
 (ert-deftest ess-inferior-force-test ()
   (with-r-running nil


### PR DESCRIPTION
Instead of updating the caller's buffer.
Closes #1004.