### PR TITLE
Strip roxy prefixes outside the examples field

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -3,6 +3,12 @@
 
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
+
+@item ESS[R]: Evaluated lines starting with the Roxygen prefix
+are now always stripped from the prefix, so they can be sent to the
+process easily. Previously, this was only the case inside the
+@code{examples} field. Since roxygen is switching to R markdown, it
+becomes useful to evaluate chunks of R outside examples.
   
 @item stata support is now obsolete since we were unable to elicit
 FSF paperwork from some of the original authors: see the lisp/obsolete

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -818,23 +818,7 @@ Assumes point is at the beginning of the function."
   "Remove `ess-roxy-str' from STRING before sending to R process.
 Useful for sending code from example section. This function is
 placed in `ess-presend-filter-functions'."
-  ;; Only strip the prefix in the @examples field, and only when
-  ;; STRING is entirely contained inside it. This allows better
-  ;; behavior for evaluation of regions.
-  (let ((roxy-re ess-roxy-re))
-    (if (and (ess-roxy-entry-p "examples")
-             ;; don't send just @examples if we're looking at a line
-             ;; like: ##' @examples
-             (not (string-match-p (concat roxy-re "[[:space:]]*@") string))
-             ;; (with-temp-buffer
-             ;;   ;; Need to carry the buffer-local value of
-             ;;   ;; `ess-roxy-re' into the temp buffer:
-             ;;   (setq ess-roxy-re roxy-re)
-             ;;   (insert string)
-             ;;   (ess-roxy-entry-p))
-             )
-        (replace-regexp-in-string (concat ess-roxy-re "\\s-*") "" string)
-      string)))
+  (replace-regexp-in-string (concat ess-roxy-re "\\s-*") "" string))
 
 (defun ess-roxy-find-par-end (stop-point &rest stoppers)
   (mapc #'(lambda (stopper)


### PR DESCRIPTION
To evaluate more easily Rmd chunks inside other roxygen sections:

````
#' Title
#'
#' ```r
#' letters
#' 1
#' ```
#'
NULL
````