### PR TITLE
Set default value of `ess-eval-visibly` to `'nowait`

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -20,7 +20,9 @@ directory (as defined by the buffer-local variable
 Instead, the active directory of the inferior buffer is updated to the
 new working directory.
 
-@item The default of ess-eval-visibly is now nil.
+@item The default of ess-eval-visibly is now @code{'nowait}.
+With this change you should no longer experience freezes while
+evaluating code.
 
 @item ESS[R]: There is a new menu entry for reloading the R process.
 It is otherwise bound to @code{C-c C-e C-r}. Reloading now reuses the

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1823,9 +1823,9 @@ Otherwise, they get their own temporary buffer."
 
 (defcustom ess-eval-visibly 'nowait
   "Non-nil means ess-eval- commands display commands in the process buffer.
-If 'nowait (the default), ESS shows input commands in the process
-buffer, but doesn't wait for the process. Thus all the output is
-printed after the input lines.
+If 'nowait, ESS shows input commands in the process buffer, but
+doesn't wait for the process. Thus all the output is printed
+after the input lines.
 
 If t, ESS waits after each line of the command for the process
 output. This results in a nice sequence of input and output but

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1821,17 +1821,18 @@ Otherwise, they get their own temporary buffer."
 
 (defvaralias 'ess-eval-visibly-p 'ess-eval-visibly)
 
-(defcustom ess-eval-visibly nil
+(defcustom ess-eval-visibly 'nowait
   "Non-nil means ess-eval- commands display commands in the process buffer.
+If 'nowait (the default), ESS shows input commands in the process
+buffer, but doesn't wait for the process. Thus all the output is
+printed after the input lines.
+
 If t, ESS waits after each line of the command for the process
 output. This results in a nice sequence of input and output but
 stalls Emacs on long output (like Sys.sleep(5) in R).
 
-If 'nowait, ESS still shows the input commands, but don't wait
-for the process. Thus all the output is printed after the input
-lines.
-
-If nil, ESS doesn't print input commands and doesn't wait for the process.
+If nil, ESS doesn't print input commands and doesn't wait for the
+process.
 
 This variable also affect the evaluation of input code in
 iESS. The effect is similar to the above. If t then ess waits for


### PR DESCRIPTION
Closes #998.

This default is better for most people because the process reveals boundaries between rounds of evaluation, which makes it much easier to figure out what an output is about.

Once https://github.com/lionel-/ESS/tree/fix-prompt is merged, the behaviour will be identical to `nil` except for the echoing the input commands at the start of evaluation.