### PR TITLE
Improve xref lookup

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,10 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item ESS[R]: Improved @code{xref} lookup (@kbd{M-.}).
+Function locations are now always detected for package libraries listed
+in @code{ess-r-package-library-paths}.
+
 @item ESS[R]: Evaluated lines starting with the Roxygen prefix
 are now always stripped from the prefix, so they can be sent to the
 process easily. Previously, this was only the case inside the

--- a/etc/ESSR/R/completion.R
+++ b/etc/ESSR/R/completion.R
@@ -21,7 +21,7 @@ local({
 
 .ess_eval <- function(str, env = globalenv()) {
     ## don't remove; really need eval(parse(  here!!
-    tryCatch(base::eval(base::parse(text=str), envir = env),
+    tryCatch(eval(parse(text=str), envir = env),
              error=function(e) NULL) ## also works for special objects containing @:$ etc
 }
 
@@ -38,7 +38,7 @@ local({
     }
     fn <- .ess_eval(name, env)
     if (is.null(fn)) {
-        objs <- getAnywhere(name)$objs
+        objs <- utils::getAnywhere(name)$objs
         for (o in objs) {
             if (is.function(o)) {
                 fn <- o
@@ -55,13 +55,13 @@ local({
             out <- sprintf("(\"%s\" %d %d)\n", file, line, col - 1)
         }
     }
-    base::cat(out)
+    cat(out)
 }
 
 
 .ess_fn_pkg <- function(fn_name) {
     objs <- utils::getAnywhere(fn_name)
-    base::print(base::sub("(package|namespace):", "", objs$where))
+    print(sub("(package|namespace):", "", objs$where))
 }
 
 .ess_funargs <- function(funname) {

--- a/etc/ESSR/R/completion.R
+++ b/etc/ESSR/R/completion.R
@@ -37,6 +37,15 @@ local({
         env <- globalenv()
     }
     fn <- .ess_eval(name, env)
+    if (is.null(fn)) {
+        objs <- getAnywhere(name)$objs
+        for (o in objs) {
+            if (is.function(o)) {
+                fn <- o
+                break;
+            }
+        }
+    }
     out <- "()\n"
     if (is.function(fn) && !is.null(utils::getSrcref(fn))) {
         file <- utils::getSrcFilename(fn, full.names = TRUE)
@@ -46,21 +55,13 @@ local({
             out <- sprintf("(\"%s\" %d %d)\n", file, line, col - 1)
         }
     }
-    cat(out)
+    base::cat(out)
 }
 
 
 .ess_fn_pkg <- function(fn_name) {
-    fn <- .ess_eval(fn_name)
-    env_name <- base::environmentName(base::environment(fn))
-    out <- if (base::is.primitive(fn)) { # environment() does not work on primitives.
-               "base"
-           } else if (base::is.function(fn) && env_name != "R_GlobalEnv") {
-               env_name
-           } else {
-               ""
-           }
-    base::cat(base::sprintf("%s\n", out))
+    objs <- utils::getAnywhere(fn_name)
+    base::print(base::sub("(package|namespace):", "", objs$where))
 }
 
 .ess_funargs <- function(funname) {

--- a/etc/ESSR/R/ns-eval.R
+++ b/etc/ESSR/R/ns-eval.R
@@ -392,7 +392,7 @@
 
 .ess.ns_insert_essenv <- function(nsenv) {
     if (is.character(nsenv))
-        nsenv <- base::asNamespace(nsenv)
+        nsenv <- asNamespace(nsenv)
     stopifnot(isNamespace(nsenv))
     if (identical(nsenv, .BaseNamespaceEnv))
         return(.GlobalEnv)

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -61,10 +61,11 @@ See also `ess-r-set-evaluation-env' and `ess-r-evaluation-env'."
   "Current package info cache.
 See `ess-r-package-info' for its structure.")
 
-(define-obsolete-variable-alias 'ess-r-package-library-path 'ess-r-package-library-paths "v18.04")
 (defcustom ess-r-package-library-paths nil
   "Default path to find user packages.
-Can be either a string specifying a directory or a list of directories."
+Can be either a string specifying a directory or a list of
+directories. This variable is also consulted by
+`xref-find-definitions' in R buffers. See `ess-r-xref-backend'."
   :group 'ess-r-package-library-paths
   :type `(choice string (repeat string)))
 

--- a/lisp/ess-r-xref.el
+++ b/lisp/ess-r-xref.el
@@ -93,19 +93,19 @@ DEFAULT-PKG is the name of the package where presumably SYMBOL is located."
                          ((listp ess-r-package-library-paths)
                           ess-r-package-library-paths)
                          (t (user-error "Invalid value of `ess-r-package-library-paths'"))))
-         (pkg.dir (or (when (= (length pkgs) 1)
-                        (cons (car pkgs) (assoc-default (car pkgs) ess-r-xref-pkg-sources)))
-                      (cl-loop for pkg in pkgs
-                               for d in lib-dirs
-                               for p = (expand-file-name pkg d)
-                               when (file-exists-p p) return (cons pkg p))))
-         (file (when pkg.dir (expand-file-name src-file (cdr pkg.dir)))))
+         (loc (or (when (= (length pkgs) 1)
+                    (cons (car pkgs) (assoc-default (car pkgs) ess-r-xref-pkg-sources)))
+                  (cl-loop for pkg in pkgs
+                           for d in lib-dirs
+                           for p = (expand-file-name pkg d)
+                           when (file-exists-p p) return (cons pkg p))))
+         (file (when loc (expand-file-name src-file (cdr loc)))))
     (when file
       (unless (file-readable-p file)
         (user-error "Can't read %s" file))
       ;; Cache package's source directory.
-      (unless (assoc (car pkg.dir) ess-r-xref-pkg-sources)
-        (push pkg.dir ess-r-xref-pkg-sources))
+      (unless (assoc (car loc) ess-r-xref-pkg-sources)
+        (push loc ess-r-xref-pkg-sources))
       file)))
 
 (defun ess-r-xref--xref (symbol)


### PR DESCRIPTION
Xref wasn't working for me in 80% of the cases. Things seem to be always working with this patch as long as `ess-r-package-library-paths` is correctly setup.

I wonder how we can popularize `ess-r-package-library-paths` a bit more. I expect few people know that in order to make xref work that one is necessary. 