### PR TITLE
[Fix #956] Add inferior-ess-fix-misaligned-output

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,10 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item ESS[R]: Automatic offsetting of R process output is now disabled by default
+because it produces undesirable output in some situations. To re-enable,
+set @code{inferior-ess-fix-misaligned-output} to t.
+
 @item ESS[R]: Improved @code{xref} lookup (@kbd{M-.}).
 Function locations are now always detected for package libraries listed
 in @code{ess-r-package-library-paths}.

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -564,6 +564,11 @@ can use `ess--busy-slash', `ess--busy-B',`ess--busy-stars',
 (defvar ess--busy-timer nil
   "Timer used for busy process indication.")
 
+(defcustom inferior-ess-fix-misaligned-output nil
+  "If non-nil, try to correct misaligned process output."
+  :group 'ess-tracebug
+  :type 'boolean)
+
 (defcustom inferior-ess-replace-long+ t
   "Determines if ESS replaces long + sequences in output.
 If 'strip, remove all such instances.  Otherwise, if non-nil, '+
@@ -1306,8 +1311,9 @@ value as it might be a continuation prompt."
          (t (error "Invalid values of `inferior-ess-replace-long+'")))))))
 
 (defun ess--offset-output (prev-prompt str)
-  "Add suitable offset to STR given the preceding PREV-PROMPT."
-  (if prev-prompt
+  "Add suitable offset to STR given the preceding PREV-PROMPT.
+Do nothing if `inferior-ess-fix-misaligned-output' is nil."
+  (if (and inferior-ess-fix-misaligned-output prev-prompt)
       (let ((len (length prev-prompt)))
         ;; prompts have at least 2 chars
         (if (eq (elt prev-prompt (- len 2)) ?+)

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -249,6 +249,7 @@ OUT-STRING is the content of the region captured by
 
 (ert-deftest ess-inf-send-complex-input-test ()
   (let ((ess-eval-visibly nil)
+        (inferior-ess-fix-misaligned-output t)
         (input "identity(
   identity(
     identity(
@@ -288,7 +289,8 @@ cleaned-prompts >
       )))
 
 (ert-deftest ess-inf-send-cat-some.text-test ()
-  (let ((input "cat(\"some. text\\n\")
+  (let ((inferior-ess-fix-misaligned-output t)
+        (input "cat(\"some. text\\n\")
 head(cars, 2)
 ")
         (output "some. text


### PR DESCRIPTION
Add new `inferior-ess-fix-misaligned-output` defcustom to control the output offset hackery. 

I am leaving the default to `t` because I think it works in most cases and it has been the behavior for some years now. TBD.

@mmaechler do you have other issues that you would like to be dealt with before the release? 