### PR TITLE
Only strip roxy prefix if the whole input is prefixed

### DIFF
--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -815,7 +815,20 @@ Assumes point is at the beginning of the function."
   "Remove `ess-roxy-str' from STRING before sending to R process.
 Useful for sending code from example section. This function is
 placed in `ess-presend-filter-functions'."
-  (replace-regexp-in-string (concat ess-roxy-re "\\s-*") "" string))
+  ;; In the future we might want to detect chunks between markdown
+  ;; fences and strip everything that comes before `@examples`
+  (if (ess-roxy--all-prefixed string)
+      (replace-regexp-in-string (concat ess-roxy-re "\\s-*") "" string)
+    string))
+
+(defun ess-roxy--all-prefixed (string)
+  (let ((ess-roxy-re-lexical ess-roxy-re))
+    (with-temp-buffer
+      (insert string)
+      (goto-char 0)
+      (while (and (looking-at-p ess-roxy-re-lexical)
+                  (re-search-forward "\n" nil t)))
+      (looking-at-p ess-roxy-re-lexical))))
 
 (defun ess-roxy-find-par-end (stop-point &rest stoppers)
   (mapc #'(lambda (stopper)

--- a/test/ess-test-r.el
+++ b/test/ess-test-r.el
@@ -703,6 +703,14 @@ Arguments:
     (with-r-running nil
       (should-not (buffer-local-value 'comint-input-ring-file-name (ess-get-process-buffer))))))
 
+(ert-deftest ess-test-roxy-prefix-strip ()
+  "Only strip prefix if the whole string is prefixed (#1020)"
+  (let ((ess-roxy-re "^#+'"))
+    (should (equal (ess-roxy-remove-roxy-re "#' 1\n#' 2")
+                   "1\n2"))
+    (should (equal (ess-roxy-remove-roxy-re "#' 1\n#' 2\nNULL")
+                   "#' 1\n#' 2\nNULL"))))
+
 (provide 'ess-test-r)
 
 ;;; ess-test-r.el ends here


### PR DESCRIPTION
Closes #1020

Currently does not try to detect leading `#' @examples` field or rmarkdown fences.