### PR TITLE
Fix for change to eldoc-documentation-functions (emacs 28)

### DIFF
--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -258,7 +258,7 @@ objects from that MODULE."
 
 
 ;;; ELDOC
-(defun ess-julia-eldoc-function ()
+(defun ess-julia-eldoc-function (callback)
   "Return the doc string, or nil.
 If an ESS process is not associated with the buffer, do not try
 to look up any doc strings. Honors `eldoc-echo-area-use-multiline-p'."

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -258,7 +258,7 @@ objects from that MODULE."
 
 
 ;;; ELDOC
-(defun ess-julia-eldoc-function (callback)
+(defun ess-julia-eldoc-function (&optional callback)
   "Return the doc string, or nil.
 If an ESS process is not associated with the buffer, do not try
 to look up any doc strings. Honors `eldoc-echo-area-use-multiline-p'."

--- a/lisp/ess-julia.el
+++ b/lisp/ess-julia.el
@@ -258,7 +258,7 @@ objects from that MODULE."
 
 
 ;;; ELDOC
-(defun ess-julia-eldoc-function (&optional callback)
+(defun ess-julia-eldoc-function (&rest _ignored)
   "Return the doc string, or nil.
 If an ESS process is not associated with the buffer, do not try
 to look up any doc strings. Honors `eldoc-echo-area-use-multiline-p'."

--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -49,7 +49,7 @@
   :group 'ess-R
   :type 'string)
 
-(defun ess-r-eldoc-function (callback)
+(defun ess-r-eldoc-function (&optional callback)
   "Return the doc string, or nil.
 If an ESS process is not associated with the buffer, do not try
 to look up any doc strings."

--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -49,7 +49,7 @@
   :group 'ess-R
   :type 'string)
 
-(defun ess-r-eldoc-function ()
+(defun ess-r-eldoc-function (callback)
   "Return the doc string, or nil.
 If an ESS process is not associated with the buffer, do not try
 to look up any doc strings."

--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -49,7 +49,7 @@
   :group 'ess-R
   :type 'string)
 
-(defun ess-r-eldoc-function (&optional callback)
+(defun ess-r-eldoc-function (&rest _ignored)
   "Return the doc string, or nil.
 If an ESS process is not associated with the buffer, do not try
 to look up any doc strings."


### PR DESCRIPTION
On emacs 28, I am getting the following error from ess+eldoc:
```
eldoc error: (wrong-number-of-arguments ((ac-use-comphist ac-point ac-prefix ac-auto-start t) nil Return the doc string, or nil.
If an ESS process is not associated with the buffer, do not try
to look up any doc strings. (if (and eldoc-mode ess-can-eval-in-background) (progn (let* ((proc (ess-get-next-available-process)) (funname (and proc (or (and ess-eldoc-show-on-symbol (thing-at-point 'symbol)) (car (ess--fn-name-start)))))) (if funname (progn (let* ((args (ess-function-arguments funname proc)) (bargs (car (cdr args))) (doc (mapconcat #'(lambda (el) (if (equal (car el) ...) ... (concat (car el) = (cdr el)))) bargs , )) (margs (nth 2 args)) (W (- (window-width (minibuffer-window)) (+ 4 (length funname)))) (multiline (eq t eldoc-echo-area-use-multiline-p)) doc1) (if doc (progn (setq doc (ess-eldoc-docstring-format funname doc (not multiline))) (if (or multiline (and margs (< (length doc1) W))) (progn (setq doc1 (concat doc (propertize   ||  'face font-lock-function-name-face))) (while (and margs (< (length doc1) W)) (let ((head (car-safe (prog1 margs (setq margs (cdr margs)))))) (if (assoc head bargs) nil (setq doc doc1 doc1 (concat doc1 head =, ))))) (if (equal (substring doc -2) , ) (progn (setq doc (substring doc 0 -2)))) (if (and margs (< (length doc) W)) (progn (setq doc (concat doc  {--})))))) doc))))))))) 1)
```
I believe this happens because of a change to the signature of `eldoc-documentation-functions` -- the functions on that hook are now expected to be called with at least one argument (see the change to docstring of that variable in `eldoc.el` in https://github.com/emacs-mirror/emacs/commit/a7a53f0d79e0012c909e87911c4f85ad12bb78b4).

I've fixed this by adding an optional dummy argument to `ess-r-eldoc-function` and `ess-julia-eldoc-function`.

See also: https://github.com/emacs-ess/ESS/pull/993