### PR TITLE
Clean up tests

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -900,9 +900,10 @@ toggled."
             (message "Found no buffers for `ess-dialect' %s associated with process %s"
                      dialect proc-name)))
       (ess-switch-to-ESS eob))
-    (set-transient-map (let ((map (make-sparse-keymap))
-                             (key (vector last-command-event)))
-                         (define-key map key #'ess-switch-to-inferior-or-script-buffer) map))))
+    (when (called-interactively-p 'any)
+      (set-transient-map (let ((map (make-sparse-keymap))
+                               (key (vector last-command-event)))
+                           (define-key map key #'ess-switch-to-inferior-or-script-buffer) map)))))
 
 
 (defun ess-get-process-buffer (&optional name)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 
 include ../Makeconf
 
-.PHONY: literate all julia lisp ess inf r r-indent literate cases indent-cases literate-cases
+.PHONY: literate all julia lisp ess inf org r r-indent literate cases indent-cases literate-cases
 
 all: compile lisp
 
@@ -16,6 +16,9 @@ ess:
 
 inf:
 	${EMACS} -Q --script run-tests --inf
+
+org:
+	${EMACS} -Q --script run-tests --org
 
 r r-core:
 	${EMACS} -Q --script run-tests --r-core

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -89,16 +89,17 @@
   ;; (ess-async-command "{cat(1:5);Sys.sleep(5);cat(2:6)}\n" nil (get-process "R")
   ;;                    (lambda (proc) (message "done"))
   (with-r-running nil
-    (let (semaphore)
+    (let ((inf-proc *proc*)
+          semaphore)
       (ess-async-command "{cat(1:5);Sys.sleep(0.5);cat(2:6)}\n"
                          (get-buffer-create " *ess-async-text-command-output*")
-                         (get-process "R")
+                         inf-proc
                          (lambda (&rest args) (setq semaphore t)))
-      (should (process-get (get-process "R") 'callbacks))
+      (should (process-get inf-proc 'callbacks))
       (cl-loop repeat 3
-               until (and semaphore (null (process-get (get-process "R") 'callbacks)))
+               until (and semaphore (null (process-get inf-proc 'callbacks)))
                do (sleep-for 0 600)
-               finally (should-not (process-get (get-process "R") 'callbacks))))))
+               finally (should-not (process-get inf-proc 'callbacks))))))
 
 (ert-deftest ess-run-presend-hooks-test ()
   (with-r-running nil

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -26,12 +26,10 @@
 ;;*;; Startup
 
 (defun ess-r-tests-startup-output ()
-  (let* ((proc (get-buffer-process (run-ess-test-r-vanilla)))
-         (output-buffer (process-buffer proc)))
-    (unwind-protect
-        (with-current-buffer output-buffer
-          (buffer-string))
-      (kill-process proc))))
+  (let ((inf-buf (run-ess-test-r-vanilla)))
+    (ess-test-unwind-protect inf-buf
+      (with-current-buffer inf-buf
+        (buffer-string)))))
 
 (ert-deftest ess-startup-verbose-setwd-test ()
   (should (string-match "to quit R.\n\n> setwd(.*)$" (ess-r-tests-startup-output))))

--- a/test/ess-test-r-package.el
+++ b/test/ess-test-r-package.el
@@ -71,30 +71,28 @@
 (ert-deftest ess-r-package-vars-test ()
   (with-ess-test-c-file "dummy-pkg/src/test.c"
     (let* ((inf-buf (run-ess-test-r-vanilla))
-           (ess-local-process-name (process-name (get-buffer-process inf-buf))))
-      (unwind-protect
-          (progn
-            (let ((r-setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist)))
-                  (r-getwd-cmd (cdr (assq 'ess-getwd-command ess-r-customize-alist))))
-              (should (string= ess-setwd-command r-setwd-cmd))
-              (should (string= ess-getwd-command r-getwd-cmd)))
-            (let ((pkg-dir (file-truename (cdr (ess-r-package-project))))
-                  ;; Not sure why this is needed:
-                  ess-ask-for-ess-directory)
-              (ess-set-working-directory (expand-file-name "src" pkg-dir))
-              (ess-r-package-use-dir)
-              (should (string= pkg-dir (file-truename
-                                        (directory-file-name
-                                         (ess-get-process-variable 'default-directory)))))
-              (ess-wait-for-process)
-              (should (string= pkg-dir (file-truename (ess-get-working-directory))))
-              (ess-wait-for-process)
-              (let ((proc-buffer (ess-get-process-buffer)))
-                (inferior-ess-reload)
-                (should (string-match "Process R\\(:.\\)? \\(finished\\|killed\\)"
-                                      (with-current-buffer proc-buffer
-                                        (buffer-string)))))))
-        (kill-process (get-buffer-process inf-buf))))))
+           (inf-proc (get-buffer-process inf-buf))
+           (ess-local-process-name (process-name inf-proc)))
+      (ess-test-unwind-protect inf-buf
+        (let ((r-setwd-cmd (cdr (assq 'ess-setwd-command ess-r-customize-alist)))
+              (r-getwd-cmd (cdr (assq 'ess-getwd-command ess-r-customize-alist))))
+          (should (string= ess-setwd-command r-setwd-cmd))
+          (should (string= ess-getwd-command r-getwd-cmd)))
+        (let ((pkg-dir (file-truename (cdr (ess-r-package-project))))
+              ;; Not sure why this is needed:
+              ess-ask-for-ess-directory)
+          (ess-set-working-directory (expand-file-name "src" pkg-dir))
+          (ess-r-package-use-dir)
+          (should (string= pkg-dir (file-truename
+                                    (directory-file-name
+                                     (ess-get-process-variable 'default-directory)))))
+          (ess-wait-for-process)
+          (should (string= pkg-dir (file-truename (ess-get-working-directory))))
+          (ess-wait-for-process)
+          (inferior-ess-reload)
+          (should (string-match "Process R\\(:.\\)? \\(finished\\|killed\\)"
+                                (with-current-buffer inf-buf
+                                  (buffer-string)))))))))
 
 (ert-deftest ess-r-package-package-info-test ()
   (let ((kill-buffer-query-functions nil)

--- a/test/run-tests
+++ b/test/run-tests
@@ -21,12 +21,13 @@
 (setq ess-use-flymake nil)
 
 (when (= (length argv) 0)
-  (setq argv '("--ess" "--inf" "--r-core" "--r-indent" "--r-pkg" "--literate")))
+  (setq argv '("--ess" "--inf" "--org" "--r-core" "--r-indent" "--r-pkg" "--literate")))
 
 (when (member "--ess" argv)
   (load (expand-file-name "ess-test.el" ess-test-path) nil t))
 (when (member "--inf" argv)
-  (load (expand-file-name "ess-test-inf.el" ess-test-path) nil t)
+  (load (expand-file-name "ess-test-inf.el" ess-test-path) nil t))
+(when (member "--org" argv)
   (load (expand-file-name "ess-test-org.el" ess-test-path) nil t))
 (when (member "--r-core" argv)
   (load (expand-file-name "ess-test-r.el" ess-test-path) nil t)


### PR DESCRIPTION
- Properly kill the inferior process and buffer after test is finished. The buffer is killed synchronously to avoid it being accidentally reused at a later time in another test.

- Pass session buffer explicitly in org-mode tests, otherwise they reuse `*R*`.

- Don't set transient map unless called interactively.

Fixes broken tests on master.