### PR TITLE
Do not call `set-buffer` in `run-ess-r`

### DIFF
--- a/lisp/ess-mode.el
+++ b/lisp/ess-mode.el
@@ -35,7 +35,7 @@
 (require 'ess-inf)
 
 ;; Silence the byte compiler
-(declare-function run-ess-r "ess-r-mode" (&optional start-args))
+(declare-function R "ess-r-mode" (&optional start-args))
 (declare-function S+ "ess-sp6-d" (&optional proc-name))
 (declare-function SAS "ess-sas-d" ())
 
@@ -665,7 +665,7 @@ Function defined using `ess-define-runner'."
             (cond ((string= dialect "R")
                    (let ((inferior-ess-r-program (or path name)))
                      (require 'ess-r-mode)
-                     (run-ess-r start-args)))
+                     (R start-args)))
                   ((string= dialect "S")
                    (let ((inferior-S+-program (or path name)))
                      (require 'ess-sp6-d)

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -540,11 +540,12 @@ will be prompted to enter arguments interactively."
         (ess-write-to-dribble-buffer
          (format "(R): inferior-ess-language-start=%s\n"
                  inferior-ess-language-start)))
-      ;; FIXME: Current ob-R expects current buffer set to process buffer
-      (set-buffer inf-buf))))
+      inf-buf)))
 
 ;;;###autoload
-(defalias 'R #'run-ess-r)
+(defun R (&optional start-args)
+  ;; FIXME: Current ob-R expects current buffer set to process buffer
+  (set-buffer (run-ess-r start-args)))
 
 (defun inferior-ess-r--adjust-startup-directory (dir dialect)
   "Adjust startup directory DIR if DIALECT is R.
@@ -879,7 +880,9 @@ prompt for command line arguments."
   (let ((inferior-ess-r-program ess-newest-R))
     (run-ess-r start-args)))
 
-(defalias 'R-newest 'run-ess-r-newest)
+(defun R-newest (&optional start-args)
+  ;; FIXME: Current ob-R expects current buffer set to process buffer
+  (set-buffer (run-ess-r-newest start-args)))
 
 ;; (ess-r-version-date "R-2.5.1") (ess-r-version-date "R-patched")
 ;; (ess-r-version-date "R-1.2.1") (ess-r-version-date "R-1.8.1")

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -337,35 +337,19 @@ some. text
   (skip-unless (and (or (executable-find "R-3.2.1")
                         (getenv "CONTINUOUS_INTEGRATION"))
                     (> emacs-major-version 25)))
-  (should
-   (string= "*R-3.2.1:1*"
-            (let ((ess-use-inferior-program-in-buffer-name t)
-                  (ess-plain-first-buffername nil)
-                  (ess-gen-proc-buffer-name-function #'ess-gen-proc-buffer-name:simple)
-                  (ess-ask-for-ess-directory nil)
-                  (inhibit-message ess-inhibit-message-in-tests)
-                  (name))
-              (R-3.2.1)
-              (setq name (buffer-name))
-              (set-process-query-on-exit-flag (get-buffer-process (current-buffer)) nil)
-              (kill-process (get-buffer-process name))
-              ;; FIXME: Does not work in batch mode
-              ;; (kill-buffer name)
-              name)))
-  (should
-   (string= "*R-3.2.1:2*"
-            (let ((ess-use-inferior-program-name-in-buffer-name t)
-                  (ess-plain-first-buffername nil)
-                  (ess-gen-proc-buffer-name-function #'ess-gen-proc-buffer-name:simple)
-                  (ess-ask-for-ess-directory nil)
-                  (inhibit-message ess-inhibit-message-in-tests)
-                  (name))
-              (R-3.2.1)
-              (setq name (buffer-name))
-              (set-process-query-on-exit-flag (get-buffer-process (current-buffer)) nil)
-              (kill-process (get-buffer-process name))
-              ;; (kill-buffer name)
-              name))))
+  (let ((ess-use-inferior-program-in-buffer-name t)
+        (ess-plain-first-buffername nil)
+        (ess-gen-proc-buffer-name-function #'ess-gen-proc-buffer-name:simple)
+        (ess-ask-for-ess-directory nil)
+        (inhibit-message ess-inhibit-message-in-tests))
+    (let ((inf-buf (R-3.2.1)))
+      (ess-test-unwind-protect inf-buf
+        (with-current-buffer inf-buf
+          (should (string= (buffer-name) "*R-3.2.1:1*")))
+        (let ((other-inf-buf (R-3.2.1)))
+          (ess-test-unwind-protect other-inf-buf
+            (with-current-buffer other-inf-buf
+              (should (string= (buffer-name) "*R-3.2.1:2*")))))))))
 
 (ert-deftest ess-switch-to-inferior-or-script-buffer-test ()
   (with-r-running nil

--- a/test/ess-test-r-utils.el
+++ b/test/ess-test-r-utils.el
@@ -254,6 +254,7 @@ representative to the common interactive use with tracebug on."
      (let* ((inf-buf ,inf-buf)
             (inf-proc (get-buffer-process inf-buf)))
        (when (and inf-proc (process-live-p inf-proc))
+         (set-process-query-on-exit-flag inf-proc nil)
          (kill-process inf-proc)
          (ess-test-sleep-while (process-live-p inf-proc) 0.001 1
                                "Expected dead process"))


### PR DESCRIPTION
This `set-buffer` causes very confusing side effects. For instance, `setq-local` assigns in the wrong buffer after having called `R`. Because of backward compatibility we can't fix it in the `R*` runners, but at least the `run-ess-r-` runners should be free of this side effect.

Also simplifies the runner tests.