### PR TITLE
Require Emacs 26 or newer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: emacs-lisp
 env:
   # When there's a new major Emacs release, also update
   # byte-compile-error-on-warn to the new release, below
-  - EVM_EMACS=emacs-25.1-travis
-  - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis-linux-xenial
   - EVM_EMACS=emacs-26.2-travis-linux-xenial
   - EVM_EMACS=emacs-26.3-travis-linux-xenial

--- a/doc/ess.texi
+++ b/doc/ess.texi
@@ -3097,8 +3097,8 @@ to change the toolbar.
 @cindex finding function definitions
 Xref is an Emacs interface that supports finding ``identifiers,''
 usually function definitions in ESS's view. ESS ships with support for
-Xref in Emacs versions 25.1 and higher. For how to use this feature, see
-@xref{Xref,,, emacs, The Gnu Emacs Reference Manual}.
+Xref. @xref{Xref,,, emacs, The Gnu Emacs Reference Manual} for how to
+use this feature.
 
 @node Rdired
 @section Rdired

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,8 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item ESS now requires Emacs 26.1 or newer.
+
 @item ESS[R]: Automatic offsetting of R process output is now disabled by default
 because it produces undesirable output in some situations. To re-enable,
 set @code{inferior-ess-fix-misaligned-output} to t.

--- a/doc/requires.texi
+++ b/doc/requires.texi
@@ -1,4 +1,4 @@
-ESS supports GNU Emacs versions 25.1 and newer.
+ESS supports GNU Emacs versions 26.1 and newer.
 
 ESS is most likely to work with current/recent versions of the following
 statistical packages: R/S-PLUS, SAS, Stata, OpenBUGS and JAGS.

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -64,13 +64,6 @@
 
 (defvar add-log-current-defun-header-regexp)
 
-;; The following declares can be removed once we drop Emacs 25
-(declare-function tramp-file-name-method "tramp")
-(declare-function tramp-file-name-user "tramp")
-(declare-function tramp-file-name-host "tramp")
-(declare-function tramp-file-name-localname "tramp")
-(declare-function tramp-file-name-hop "tramp")
-
 (defcustom inferior-ess-mode-hook nil
   "Hook for customizing inferior ESS mode.
 Called after `inferior-ess-mode' is entered and variables have

--- a/lisp/ess-r-flymake.el
+++ b/lisp/ess-r-flymake.el
@@ -35,12 +35,6 @@
 (require 'ess-inf)
 (require 'flymake)
 
-;; Appease the byte compiler for Emacs 25. Remove after dropping
-;; support for Emacs 25.
-(declare-function flymake-diag-region "flymake")
-(declare-function flymake-make-diagnostic "flymake")
-(declare-function flymake--overlays "flymake")
-
 (defcustom ess-r-flymake-linters
   '("closed_curly_linter = NULL"
     "commas_linter = NULL"

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -40,8 +40,6 @@
 (declare-function ess-r-get-evaluation-env "ess-r-mode")
 (declare-function ess-r-set-evaluation-env "ess-r-mode")
 (declare-function tramp-dissect-file-name "tramp" (name &optional nodefault))
-;; This can be drop after dropping support for Emacs 25:
-(declare-function tramp-file-name-localname "tramp" (cl-x))
 
 (defvar ess-r-prompt-for-attached-pkgs-only nil
   "If nil provide completion for all installed R packages.
@@ -483,10 +481,8 @@ The check is done with `derived-mode-p'."
   :type 'hook)
 
 (defcustom ess-r-package-mode-line
-  ;; FIXME Emacs 25.1: Use `when-let'
-  '(:eval (let ((pkg-name (ess-r-package-name)))
-            (when pkg-name
-              (format " [pkg:%s]" pkg-name))))
+  '(:eval (when-let ((pkg-name (ess-r-package-name)))
+            (format " [pkg:%s]" pkg-name)))
   "Mode line for ESS developer.
 Set this variable to nil to disable the mode line entirely."
   :group 'ess-r-package

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -94,13 +94,6 @@
 ;; here.
 (declare-function tramp-dissect-file-name "tramp")
 (declare-function tramp-get-remote-tmpdir "tramp")
-;; The following declares can be removed once we drop Emacs 25
-(declare-function tramp-file-name-method "tramp")
-(declare-function tramp-file-name-user "tramp")
-(declare-function tramp-file-name-host "tramp")
-(declare-function tramp-file-name-localname "tramp")
-(declare-function tramp-file-name-hop "tramp")
-
 
 (defgroup ess-tracebug nil
   "Error navigation and debugging for ESS.

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -39,12 +39,6 @@
 (declare-function ess-eval-linewise "ess-inf" (text &optional invisibly eob even-empty wait-last-prompt sleep-sec wait-sec))
 (declare-function color-lighten-name "color" (name percent))
 (declare-function tramp-dissect-file-name "tramp" (name &optional nodefault))
-;; The following declares can be removed once we drop Emacs 25
-(declare-function tramp-file-name-method "tramp")
-(declare-function tramp-file-name-user "tramp")
-(declare-function tramp-file-name-host "tramp")
-(declare-function tramp-file-name-localname "tramp")
-(declare-function tramp-file-name-hop "tramp")
 
 
 ;;*;; elisp tools

--- a/lisp/ess.el
+++ b/lisp/ess.el
@@ -19,7 +19,7 @@
 ;; Created: 7 Jan 1994
 ;; Version: 18.10.3snapshot
 ;; URL: https://ess.r-project.org/
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "26.1"))
 ;; ESSR-Version: 1.6
 
 ;; This file is part of GNU Emacs.

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -334,9 +334,8 @@ some. text
   (should (fboundp 'R-3.2.1)))
 
 (ert-deftest runner-R-3.2.1-buffer-name-test ()
-  (skip-unless (and (or (executable-find "R-3.2.1")
-                        (getenv "CONTINUOUS_INTEGRATION"))
-                    (> emacs-major-version 25)))
+  (skip-unless (or (executable-find "R-3.2.1")
+                   (getenv "CONTINUOUS_INTEGRATION")))
   (let ((ess-use-inferior-program-in-buffer-name t)
         (ess-plain-first-buffername nil)
         (ess-gen-proc-buffer-name-function #'ess-gen-proc-buffer-name:simple)

--- a/test/literate/elt.R
+++ b/test/literate/elt.R
@@ -6,9 +6,8 @@
 ¶NULL
 
 ##! (should t)
-##> (when (>= emacs-major-version 25)
-##>   (ert-skip "Reason")
-##>   (should nil))
+##> (ert-skip "Reason")
+##> (should nil)
 
 ¶NULL
 

--- a/test/literate/fontification.R
+++ b/test/literate/fontification.R
@@ -6,8 +6,7 @@
 ¶while ¶for ¶if ¶switch ¶function ¶return ¶on.exit ¶stop
 ¶tryCatch ¶withRestarts ¶invokeRestart ¶recover ¶browser
 
-##! (when (>= emacs-major-version 25)
-##>   (should (not (face-at-point))))
+##> (should (not (face-at-point)))
 
 ¶while ¶for ¶if ¶switch ¶function ¶return ¶on.exit ¶stop
 ¶tryCatch ¶withRestarts ¶invokeRestart ¶recover ¶browser
@@ -92,8 +91,7 @@ for foo ¶in bar {}
 
 ¶library ¶attach ¶detach ¶source ¶require
 
-##! (when (>= emacs-major-version 25)
-##>   (should (not (face-at-point))))
+##> (should (not (face-at-point)))
 
 ¶library ¶attach ¶detach ¶source ¶require
 


### PR DESCRIPTION
With the release of Emacs 27.1 we should remove support for Emacs 25. Emacs 26.1 was released over two years ago which gives users plenty of time to upgrade. The distros I looked through (debian, fedora, nixOS, arch, etc) are all shipping 26.1 or newer. If someone wants to run Emacs 25, they can also run an older version of ESS.

Note to self to merge #989 after merging this.