### PR TITLE
Improve buffer switching in `ess-request-a-process`

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,10 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item iESS: Inferior processes can now properly reuse frames (#987).
+Fixed issue that caused the current buffer to be incorrectly displayed
+in the new frame when @code{display-buffer} is set to pop up frames.
+
 @item ESS[R]: Fixed package evaluation on remote servers with Tramp (#950).
 Fix contributed by David Pritchard.
 

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -734,6 +734,11 @@ to `ess-completing-read'."
                            (delete-dups (list "R" "S+" (or (bound-and-true-p S+-dialect-name) "S+")
                                               "stata" (or (bound-and-true-p STA-dialect-name) "stata")
                                               "julia" "SAS")))))
+         ;; Set `display-buffer-overriding-action' here since we
+         ;; explicitly handle buffer switching below with
+         ;; `pop-to-buffer' which handles the `display-buffer'
+         ;; framework.
+         (display-buffer-overriding-action '(display-buffer-no-window (allow-no-window . t)))
          (pname-list (delq nil ;; keep only those matching dialect
                            (append
                             (mapcar (lambda (lproc)
@@ -780,8 +785,7 @@ to `ess-completing-read'."
                     (process-name (get-buffer-process buf))
                   (ess-start-process-specific ess-language ess-dialect)
                   (caar ess-process-name-list))))))
-    (if noswitch
-        (pop-to-buffer (current-buffer)) ;; VS: this is weird, but is necessary
+    (unless noswitch
       (pop-to-buffer (ess-get-process-buffer proc)))
     proc))
 

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -719,6 +719,19 @@ LANGUAGE is ignored."
         (error "No ESS processes running; not yet implemented to start (%s,%s)"
                language dialect)))))
 
+(defmacro ess--with-no-pop-to-buffer (&rest body)
+  "Disable some effects of `pop-to-buffer'.
+Prevent `display-buffer' from performing an action and save the
+current buffer to prevent `pop-to-buffer' from setting a new
+current buffer."
+  ;; `pop-to-buffer' might still raise windows and frames so it may be
+  ;; better to have our own configurable `ess--pop-to-buffer' wrapper.
+  (declare (indent 0)
+           (debug (&rest form)))
+  `(let ((display-buffer-overriding-action '(display-buffer-no-window (allow-no-window . t))))
+     (save-current-buffer
+       ,@body)))
+
 (defun ess-request-a-process (message &optional noswitch ask-if-1)
   "Ask for a process, and make it the current ESS process.
 If there is exactly one process, only ask if ASK-IF-1 is non-nil.
@@ -734,11 +747,6 @@ to `ess-completing-read'."
                            (delete-dups (list "R" "S+" (or (bound-and-true-p S+-dialect-name) "S+")
                                               "stata" (or (bound-and-true-p STA-dialect-name) "stata")
                                               "julia" "SAS")))))
-         ;; Set `display-buffer-overriding-action' here since we
-         ;; explicitly handle buffer switching below with
-         ;; `pop-to-buffer' which handles the `display-buffer'
-         ;; framework.
-         (display-buffer-overriding-action '(display-buffer-no-window (allow-no-window . t)))
          (pname-list (delq nil ;; keep only those matching dialect
                            (append
                             (mapcar (lambda (lproc)
@@ -783,7 +791,11 @@ to `ess-completing-read'."
               (let ((buf (ess-completing-read message (append proc-buffers (list "*new*")) nil t nil nil)))
                 (if (not (equal buf "*new*"))
                     (process-name (get-buffer-process buf))
-                  (ess-start-process-specific ess-language ess-dialect)
+                  ;; Prevent new process buffer from being popped
+                  ;; because we handle display depending on the value
+                  ;; of `no-switch`
+                  (ess--with-no-pop-to-buffer
+                    (ess-start-process-specific ess-language ess-dialect))
                   (caar ess-process-name-list))))))
     (unless noswitch
       (pop-to-buffer (ess-get-process-buffer proc)))


### PR DESCRIPTION
Supersedes and closes #989.
Closes #987.

@jabranham I have pushed your cleanups on master so we can see things more clearly :) https://github.com/emacs-ess/ESS/commit/cb75588d972b97e597c42108b3c83c2f67947cac

When I move the `let` around `ess-start-process-specific`, which seems a better place for it, there is no longer CI issues for Emacs 25. Maybe stemmed because the overriding action was still in place when we used `pop-to-buffer` when `no-switch` is non-nil, which was incorrect IIUC, but I'm not sure.

Also use `save-current-buffer` to prevent `pop-to-buffer` from setting it. I think this was the original motivation for Vitalie's change, though I'm unsure as well.

This new setup seems to make sense and I checked that it fixes #987. If I have time I'll try to think about unit tests for this sort of window behaviour.

It might make sense to have our own `ess--pop-to-buffer` wrapper that can be easily disabled with a let-bound global variable because there are still some effects from `pop-to-buffer` that we can't prevent.