### PR TITLE
Make `inferior-ess-replace-long+` process-local

### DIFF
--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -573,7 +573,8 @@ can use `ess--busy-slash', `ess--busy-B',`ess--busy-stars',
   "Determines if ESS replaces long + sequences in output.
 If 'strip, remove all such instances.  Otherwise, if non-nil, '+
 + + + ' containing 3 or more + is replaced by
-`ess-long+replacement'."
+`ess-long+replacement'.
+This variable can be process-local but not buffer-local."
   :group 'ess-tracebug
   :type '(choice (const nil :tag "No replacement")
                  (const 'strip :tag "Replace all")
@@ -1285,13 +1286,16 @@ ends with an incomplete message."
             (setq out :incomplete))))
       out)))
 
-(defun ess--replace-long+-in-prompt (prompt is-final)
+(defun ess--replace-long+-in-prompt (proc prompt is-final)
   "Replace long + + + in PROMPT based on `inferior-ess-replace-long+' value.
 If IS-FINAL means that PROMPT occurs at the end of the process
 chunk. If non-nil, special care is taken not to drop last '+'
 value as it might be a continuation prompt."
   ;; see #576 for interesting input examples
-  (let ((len (length prompt)))
+  (let ((len (length prompt))
+        (inferior-ess-replace-long+ (buffer-local-value
+                                     'inferior-ess-replace-long+
+                                     (process-buffer proc))))
     (if (or (null inferior-ess-replace-long+)
             (< len 2))
         prompt
@@ -1391,7 +1395,7 @@ prompts."
                 (setq pos2 tpos)
                 (setq prompt (let ((prompt (buffer-substring pos1 pos2)))
                                (if do-clean
-                                   (ess--replace-long+-in-prompt prompt (eq pos2 (point-max)))
+                                   (ess--replace-long+-in-prompt proc prompt (eq pos2 (point-max)))
                                  prompt)))
                 ;; Cannot bypass this trivial call to comint-output-filter because
                 ;; external tools could rely on prompts (org-babel [#598] for

--- a/test/ess-test-r-eval.el
+++ b/test/ess-test-r-eval.el
@@ -83,15 +83,8 @@ Standard filter."
   "`ess-eval-region' respects `ess-eval-visibly'.
 Default filter"
   :init ((mode . r)
-         (eval . (progn
-                   (ess-test-r-set-local-process)
-                   (setq-local old-replace inferior-ess-replace-long+)
-                   ;; Replacing strings of " +" causes random
-                   ;; failures, probably because of the buffered
-                   ;; output
-                   (setq inferior-ess-replace-long+ nil)))
+         (eval . (ess-test-r-set-local-process 'tracebug))
          (ess-eval-deactivate-mark . nil))
-  :cleanup (setq inferior-ess-replace-long+ old-replace)
 
   :case "
 ¶1

--- a/test/ess-test-r-utils.el
+++ b/test/ess-test-r-utils.el
@@ -113,6 +113,9 @@ inserted text."
       (ess-wait-for-process (get-buffer-process inf-buf))
       (set-process-filter inf-proc inf-filter)
       (with-current-buffer inf-buf
+        ;; Replacing strings of " +" causes random failures, probably
+        ;; because of the buffered output
+        (setq-local inferior-ess-replace-long+ nil)
         (let ((inhibit-read-only t))
           (erase-buffer)))
       inf-buf))


### PR DESCRIPTION
This makes it easier to disable the replacement in unit tests. It must be disabled because the replacement is not deterministic and depends on how the process output is chunked.