### PR TITLE
Disable namespaced evaluation in examples

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,12 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item ESS[R]: Namespaced evaluation is disable in roxygen examples (#1026).
+Part of this change is that namespaced evaluation has become a
+buffer-local rather than process-local setting (#1046). This makes it
+possible to disable namespaced evaluation in specific buffers or
+contexts.
+
 @item iESS: Inferior processes can now properly reuse frames (#987).
 Fixed issue that caused the current buffer to be incorrectly displayed
 in the new frame when @code{display-buffer} is set to pop up frames.

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -1164,9 +1164,7 @@ variable.")
 
 (defun ess-r-get-evaluation-env ()
   "Get current evaluation env."
-  (or ess-r-evaluation-env
-      (and ess-current-process-name
-           (ess-get-process-variable 'ess-r-evaluation-env))))
+  ess-r-evaluation-env)
 
 (defun ess-r-set-evaluation-env (&optional arg)
   "Select a package namespace for evaluation of R code.
@@ -1184,7 +1182,6 @@ attached packages."
                    (t "*none*"))))
     (if (equal env "*none*")
         (let ((cur-env (ess-r-get-evaluation-env)))
-          ;; fixme: does not work if env is set at process level
           (setq ess-r-evaluation-env nil)
           (delq 'ess-r--evaluation-env-mode-line ess--local-mode-line-process-indicator)
           (message (format "Evaluation in %s disabled" (propertize cur-env 'face font-lock-function-name-face))))

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -1024,6 +1024,16 @@ Only do this if in a roxygen block and
 (with-eval-after-load "cc-mode"
   (add-hook 'c++-mode-hook #'ess-roxy-enable-in-cpp))
 
+(defun ess-roxy--region-p (beg end)
+  (save-excursion
+    (goto-char beg)
+    (catch 'ess-r-not-roxy
+      (while (< (point) end)
+        (unless (looking-at-p ess-roxy-re)
+          (throw 'ess-r-not-roxy nil))
+        (forward-line))
+      t)))
+
 (provide 'ess-roxy)
 
 ;;; ess-roxy.el ends here

--- a/lisp/ess-roxy.el
+++ b/lisp/ess-roxy.el
@@ -1025,14 +1025,15 @@ Only do this if in a roxygen block and
   (add-hook 'c++-mode-hook #'ess-roxy-enable-in-cpp))
 
 (defun ess-roxy--region-p (beg end)
-  (save-excursion
-    (goto-char beg)
-    (catch 'ess-r-not-roxy
-      (while (< (point) end)
-        (unless (looking-at-p ess-roxy-re)
-          (throw 'ess-r-not-roxy nil))
-        (forward-line))
-      t)))
+  (when ess-roxy-re
+    (save-excursion
+      (goto-char beg)
+      (catch 'ess-r-not-roxy
+        (while (< (point) end)
+          (unless (looking-at-p ess-roxy-re)
+            (throw 'ess-r-not-roxy nil))
+          (forward-line))
+        t))))
 
 (provide 'ess-roxy)
 

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -88,6 +88,7 @@
 (declare-function ess-r-package--all-source-dirs "ess-r-package")
 (declare-function ess-r-package-name "ess-r-package")
 (declare-function ess-r-package-source-dirs "ess-r-package")
+(declare-function ess-roxy--region-p "ess-roxy")
 
 ;; Do not require tramp at runtime. It is expensive to load. Instead,
 ;; guard calls with (require 'tramp) and silence the byte compiler
@@ -332,7 +333,8 @@ by `ess-inject-source' variable."
                           ;; We need to always inject with namespaced
                           ;; evaluation (FIXME: not right place for
                           ;; this).
-                          ((ess-r-get-evaluation-env))))
+                          ((and (ess-r-get-evaluation-env)
+                                (not (ess-roxy--region-p start end))))))
          (ess--dbg-del-empty-p (unless inject-p ess--dbg-del-empty-p))
          (string (if inject-p
                      (ess-make-source-refd-command start end visibly process)

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -328,6 +328,8 @@ command conforms to VISIBLY."
   "Send region to process adding source references as specified
 by `ess-inject-source' variable."
   (ess-eval-region--normalise-region start end)
+  ;; Disable evaluation env if we're sending a roxy region. This is
+  ;; not the ideal place to do this.
   (let* ((ess-r-evaluation-env (unless (ess-roxy--region-p start end)
                                  (ess-r-get-evaluation-env)))
          (inject-p  (cond ((eq type 'function)

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -328,11 +328,11 @@ by `ess-inject-source' variable."
                           ((eq type 'buffer)
                            (or (eq ess-inject-source t)
                                (eq ess-inject-source 'function-and-buffer)))
-                          (t (or (eq ess-inject-source t)
-                                 ;; We need to always inject with namespaced
-                                 ;; evaluation (fixme: not right place for
-                                 ;; this).
-                                 (ess-r-get-evaluation-env)))))
+                          ((eq ess-inject-source t))
+                          ;; We need to always inject with namespaced
+                          ;; evaluation (FIXME: not right place for
+                          ;; this).
+                          ((ess-r-get-evaluation-env))))
          (ess--dbg-del-empty-p (unless inject-p ess--dbg-del-empty-p))
          (string (if inject-p
                      (ess-make-source-refd-command start end visibly process)

--- a/test/dummy-pkg/man/doc.Rd
+++ b/test/dummy-pkg/man/doc.Rd
@@ -1,0 +1,5 @@
+\name{doc}
+
+\examples{
+letters
+}

--- a/test/ess-test-r-eval.el
+++ b/test/ess-test-r-eval.el
@@ -205,4 +205,11 @@ NULL
   :messages "Starting evaluation...
 [base] Eval region")
 
+(ert-deftest ess-rd-eval-ns-env-test ()
+  "Namespaced eval is disabled in doc files (#1026)."
+  (with-temp-buffer
+    (find-file-noselect "dummy-pkg/man/doc.Rd")
+    (Rd-mode)
+    (should (not ess-r-evaluation-env))))
+
 ;;; ess-test-r-eval.el ends here

--- a/test/ess-test-r-eval.el
+++ b/test/ess-test-r-eval.el
@@ -21,6 +21,11 @@
 (require 'ess-r-mode)
 (require 'ess-test-r-utils)
 
+;; Make sure inferiors have been loaded so that messages etc. do not
+;; interfere with the tests
+(ess-r-test-proc-buf 'output)
+(ess-r-test-proc-buf 'tracebug)
+
 (etest-deftest ess-r-eval-visibility-eval-standard-filter-test ()
   "`ess-eval-region' respects `ess-eval-visibly'.
 Standard filter."
@@ -143,18 +148,18 @@ Default filter"
 [1] 6
 > ")
 
-(etest-deftest ess-r-eval-ns-env-roxy-test ()
-  "Roxygen blocks are not evaluated in current eval-env."
+(etest-deftest ess-r-eval-ns-env-roxy-standard-test ()
+  "Roxygen blocks are not evaluated in current eval-env (#1026).
+Standard filter."
   :init ((mode . r)
          (ess-r-evaluation-env . "base")
          (eval . (ess-test-r-set-local-process 'output)))
-  :case "#' ¶identical(environment(), globalenv())"
 
+  :case "#' ¶identical(environment(), globalenv())"
   :eval "C-c C-j"
   :inf-result "identical(environment(), globalenv())
 [1] TRUE
 > "
-
   ;; Shouldn't mention "[base]"
   :messages "Starting evaluation...
 Loading line: #' identical(environment(), globalenv())"
@@ -169,7 +174,33 @@ NULL×"
 > NULL
 NULL
 > "
+  ;; Mentions "[base]"
+  :messages "Starting evaluation...
+[base] Eval region")
 
+(etest-deftest ess-r-eval-ns-env-roxy-tracebug-test ()
+  "Roxygen blocks are not evaluated in current eval-env (#1026).
+Tracebug filter."
+  :init ((mode . r)
+         (eval . (ess-test-r-set-local-process 'tracebug))
+         (ess-r-evaluation-env . "base")
+         (ess-eval-visibly . nil))
+  :case "#' ¶identical(environment(), globalenv())"
+  :eval "C-c C-j"
+  :inf-result "[1] TRUE
+> "
+  ;; Shouldn't mention "[base]"
+  :messages "Starting evaluation...
+Loading line: #' identical(environment(), globalenv())"
+
+  :case "
+#' ¶identical(environment(), globalenv())
+NULL×"
+
+  :eval "C-c C-r"
+  :inf-result "+ [1] FALSE
+NULL
+> "
   ;; Mentions "[base]"
   :messages "Starting evaluation...
 [base] Eval region")

--- a/test/ess-test-r-eval.el
+++ b/test/ess-test-r-eval.el
@@ -143,12 +143,13 @@ Default filter"
 [1] 6
 > ")
 
-(etest-deftest ess-r-eval-ns-env-roxy ()
+(etest-deftest ess-r-eval-ns-env-roxy-test ()
   "Roxygen blocks are not evaluated in current eval-env."
   :init ((mode . r)
          (ess-r-evaluation-env . "base")
          (eval . (ess-test-r-set-local-process 'output)))
   :case "#' ¶identical(environment(), globalenv())"
+
   :eval "C-c C-j"
   :inf-result "identical(environment(), globalenv())
 [1] TRUE
@@ -156,16 +157,21 @@ Default filter"
 
   ;; Shouldn't mention "[base]"
   :messages "Starting evaluation...
-[base] Loading line: #' identical(environment(), globalenv())"
+Loading line: #' identical(environment(), globalenv())"
 
   :case "
 #' ¶identical(environment(), globalenv())
 NULL×"
+
   :eval "C-c C-r"
   :inf-result "+ > identical(environment(), globalenv())
 [1] FALSE
 > NULL
 NULL
-> ")
+> "
+
+  ;; Mentions "[base]"
+  :messages "Starting evaluation...
+[base] Eval region")
 
 ;;; ess-test-r-eval.el ends here

--- a/test/ess-test-r-eval.el
+++ b/test/ess-test-r-eval.el
@@ -143,4 +143,29 @@ Default filter"
 [1] 6
 > ")
 
+(etest-deftest ess-r-eval-ns-env-roxy ()
+  "Roxygen blocks are not evaluated in current eval-env."
+  :init ((mode . r)
+         (ess-r-evaluation-env . "base")
+         (eval . (ess-test-r-set-local-process 'output)))
+  :case "#' ¶identical(environment(), globalenv())"
+  :eval "C-c C-j"
+  :inf-result "identical(environment(), globalenv())
+[1] TRUE
+> "
+
+  ;; Shouldn't mention "[base]"
+  :messages "Starting evaluation...
+[base] Loading line: #' identical(environment(), globalenv())"
+
+  :case "
+#' ¶identical(environment(), globalenv())
+NULL×"
+  :eval "C-c C-r"
+  :inf-result "+ > identical(environment(), globalenv())
+[1] FALSE
+> NULL
+NULL
+> ")
+
 ;;; ess-test-r-eval.el ends here


### PR DESCRIPTION
Depends on #1045.

* Make `ess-r-evaluation-env` purely buffer-local. It can't be process-local because that would enable it everywhere including in files where it is normally disabled, like test or documentation files.

* Disable namespaced-evaluation when sending code with all lines starting with the roxy prefix.

Closes #1026.