### PR TITLE
Reconstruct remote filepath in `ess-make-source-refd-command`

### DIFF
--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -253,10 +253,12 @@ inferior process command for loading the temporary file.  This
 command conforms to VISIBLY."
   (let* ((filename buffer-file-name)
          (proc-dir (ess-get-process-variable 'default-directory))
-         (remote (when (file-remote-p proc-dir)
+         (proc-prefix (ess-get-process-variable 'comint-file-name-prefix))
+         (remote (when (file-remote-p proc-prefix)
                    (require 'tramp)
                    ;; should this be done in process buffer?
-                   (tramp-dissect-file-name proc-dir)))
+                   (tramp-dissect-file-name (concat proc-prefix
+                                                    proc-dir))))
          (orig-marker (or ess-tracebug-original-buffer-marker
                           org-edit-src-beg-marker
                           org-babel-current-src-block-location))


### PR DESCRIPTION
As noted in #1024, running `ess-eval-region-or-function-or-paragraph-and-step` and other similar functions when the inferior R process is on a remote machine can result in an error. The error appears to be caused by trying to create a file in the temporary directory in the wrong location on the remote. The underlying issue appears to stem from the call to `ess-make-source-refd-command`. In particular, checking whether the process is on a remote is done via the call to `(file-remote-p proc-dir)`, however the string bound to `proc-dir` has already had the tramp remote server information stripped off of it. This patch uses the variable `comint-file-name-prefix` to recover the remote server information prefix.