### PR TITLE
Further restrict buffer display in ess-request-a-process

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -769,8 +769,10 @@ to `ess-completing-read'."
                                 'ess-dialect
                                 (process-buffer (get-process
                                                  (car pname-list))))))))
-      ;; try to start "the appropriate" process
-      (ess-start-process-specific ess-language ess-dialect)
+      ;; try to start "the appropriate" process, don't show the buffer
+      ;; since we handle that explicitly with no-switch
+      (ess--with-no-pop-to-buffer
+        (ess-start-process-specific ess-language ess-dialect))
       (setq num-processes 1
             pname-list (car ess-process-name-list)
             auto-started? t))


### PR DESCRIPTION
When creating the first process we need to also specifically handle
ess-start-process-specific's propensity to show the buffer otherwise
we wind up show the buffer multiple times in multiple windows.

We can't (easily) remove the buffer showing from
ess-start-process-specific because other commands (eg M-x R) do rely
on this behavior.

Closes #1067