### PR TITLE
Disable help summary in argument completions

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,10 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item ESS[R]: Fixed performance issue with argument completions.
+The help summary for the argument is no longer displayed in the
+echo area. This fixes delays and hangs (#1062).
+
 @item ESS[R]: @code{ess-command} is now more robust and resilient to hangs
 and custom prompts (#1043).
 

--- a/lisp/ess-r-completion.el
+++ b/lisp/ess-r-completion.el
@@ -388,7 +388,9 @@ To be used instead of ESS' completion engine for R versions >= 2.7.0."
                        (args (mapcar (lambda (a) (concat a ess-R-argument-suffix))
                                      args)))
                   (all-completions arg args)))
-    (meta (unless (bound-and-true-p ess-r--no-company-meta)
+    ;; Displaying help for the argument in the echo area is disabled
+    ;; by default for performance reasons. It causes delays or hangs (#1062).
+    (meta (when (bound-and-true-p ess-r--company-meta)
             (let ((proc (ess-get-next-available-process)))
               (when (and proc
                          (with-current-buffer (process-buffer proc)


### PR DESCRIPTION
Fixes #1062

I've disabled this feature since I posted #1062 and found ESS completions to be generally snappier when typing R code. Since the feature is relatively low value (help summary for the argument being completed in the echo area), I think we're better off disabling it, at least for now.