### PR TITLE
Fix timeout in `browser()` sessions

### DIFF
--- a/etc/ESSR/R/.basic.R
+++ b/etc/ESSR/R/.basic.R
@@ -166,7 +166,16 @@ if(.ess.Rversion < "1.8")
 
     writeLines(paste0(sentinel, "-START"))
 
-    out <- withVisible(expr)
+    ## Don't interrupt `browser()` sessions (#1081)
+    restart <- function(...) {
+        if (!is.null(findRestart("browser")))
+            invokeRestart("browser")
+    }
+
+    out <- withCallingHandlers(
+        interrupt = restart,
+        withVisible(expr)
+    )
 
     ## Print result manually because we can't rely on auto-print
     ## without changing the last value

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -682,7 +682,7 @@ nil otherwise."
                           (directory-files dirname))))
                  (ess-search-list))))
 
-(defvar ess-help--aliases-timeout most-positive-fixnum
+(defvar ess-help--aliases-timeout 10
   "The large timeout is necessary for some users (#1025, #1081).")
 
 (defun ess-get-help-aliases-list ()

--- a/lisp/ess-help.el
+++ b/lisp/ess-help.el
@@ -682,8 +682,8 @@ nil otherwise."
                           (directory-files dirname))))
                  (ess-search-list))))
 
-(defvar ess-help--aliases-timeout 10
-  "The large timeout is necessary for some users (#1025).")
+(defvar ess-help--aliases-timeout most-positive-fixnum
+  "The large timeout is necessary for some users (#1025, #1081).")
 
 (defun ess-get-help-aliases-list ()
   "Return a list of aliases which have help available."

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -2263,10 +2263,6 @@ This sends an interrupt and quits a debugging session."
       (process-send-string nil "\n"))
     (unless (ess-wait-for-process proc nil nil nil timeout)
       (error "Timeout while interrupting process"))
-    ;; Quit debugging session before reloading
-    (when (ess-debug-active-p)
-      (ess-debug-command-quit)
-      (ess-wait-for-process proc nil nil nil timeout))
     (with-current-buffer (process-buffer proc)
       (goto-char (process-mark proc)))))
 
@@ -2324,6 +2320,10 @@ START-ARGS gets passed to the dialect-specific
          (start-args (or start-args (cdr inf-start-data))))
     ;; Interrupt early so we can get working directory
     (ess-interrupt)
+    ;; Quit debugging session before reloading
+    (when (ess-debug-active-p)
+      (ess-debug-command-quit)
+      (ess-wait-for-process inf-proc nil nil nil 1))
     (save-window-excursion
       ;; Make sure we don't ask for directory again
       ;; Use current working directory as default

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -140,7 +140,9 @@
              (ess-debug-command-quit)
              (ess-wait-for-process)
              (etest-clear-inferior-buffer))
-  :eval (ess-send-string (ess-get-process) "{ browser(); NULL }\n")
+  :eval (progn
+          (ess-send-string (ess-get-process) "{ browser(); NULL }\n")
+          (ess-wait-for-process))
   :inf-result "Called from: top level 
 Browse[1]> debug at #1: NULL
 Browse[1]> "
@@ -152,7 +154,9 @@ Browse[1]> "
   :eval (should (inferior-ess-available-p))
 
   ;; We're still in the browser
-  :eval (ess-send-string (ess-get-process) "NULL\n")
+  :eval (progn
+          (ess-send-string (ess-get-process) "NULL\n")
+          (ess-wait-for-process))
   :inf-result "NULL
 Browse[1]> ")
 

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -134,6 +134,28 @@
   :inf-result ""
   :eval (should (inferior-ess-available-p)))
 
+(etest-deftest-r ess--command-browser-timeout-test ()
+  "`ess-command' fails with hanging command within browser (#1081)."
+  :cleanup (progn
+             (ess-debug-command-quit)
+             (ess-wait-for-process)
+             (etest-clear-inferior-buffer))
+  :eval (ess-send-string (ess-get-process) "{ browser(); NULL }\n")
+  :inf-result "Called from: top level 
+Browse[1]> debug at #1: NULL
+Browse[1]> "
+
+  :eval (should-error (ess-command "Sys.sleep(2)\n" nil nil nil nil nil nil 0.01))
+
+  ;; No impact on inferior
+  :inf-result ""
+  :eval (should (inferior-ess-available-p))
+
+  ;; We're still in the browser
+  :eval (ess-send-string (ess-get-process) "NULL\n")
+  :inf-result "NULL
+Browse[1]> ")
+
 
 ;;*;; Inferior interaction
 


### PR DESCRIPTION
Closes #1081.

We now check from an `interrupt` handler if a `browser` restart is available and invoke it in that case. This way timeouts don't interrupt the browser session.