### PR TITLE
Don't inhibit quit in `ess-command`

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1272,10 +1272,6 @@ wrapping the code into:
  })"
   (let ((out-buffer (or out-buffer (get-buffer-create " *ess-command-output*")))
         (proc (ess-command--get-proc proc no-prompt-check))
-        ;; Set `inhibit-quit' to t to avoid dumping R output to the
-        ;; process buffer if `ess-command' gets interrupted for some
-        ;; reason. See bugs #794 and #842
-        (inhibit-quit t)
         (sentinel (inferior-ess--output-sentinel))
         (timeout (or timeout 1)))
     (with-current-buffer (process-buffer proc)

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -160,6 +160,21 @@ Browse[1]> "
   :inf-result "NULL
 Browse[1]> ")
 
+(etest-deftest-r ess-command-quit-test ()
+  "`ess-command' does not leak output on quit (#794, #842).
+This is especially important within `while-no-input' used by
+packages like eldoc and company-quickhelp. `throw-on-input' sets
+`quit-flag'."
+  ;; Simulate a quit by throwing from a timer. The timer runs as soon
+  ;; as `ess-command' starts waiting for process output.
+  :eval ((run-at-time nil nil (lambda () (throw 'my-quit 'thrown)))
+         (should (eq (catch 'my-quit
+                       (ess-command "{ cat('output\n'); Sys.sleep(10) }\n" nil nil nil nil nil nil 0.5))
+                     'thrown)))
+  ;; There should be no output after the early exit
+  :inf-result ""
+  :eval (should (inferior-ess-available-p)))
+
 
 ;;*;; Inferior interaction
 


### PR DESCRIPTION
Reverts https://github.com/emacs-ess/ESS/commit/6c34235fe5d90ffa60080b3b25053291611d398b which fixed #794 and #842. This fix is now redundant because we added an unwind-protected `ess-interrupt` call which ensures the ESS command stops running on early exit: https://github.com/emacs-ess/ESS/blob/19de88d2b3b2436955ce0f7e6cf8544d4ffaf8ac/lisp/ess-inf.el#L1334

It's best not to set `inhibit-quit` because it makes it harder to interrupt a long-running command (requires three `C-g` instead of one). It might also be linked to uninterruptible hangs observed on Windows (see #1043).

Now covered by a unit test. The trick is to throw from a zero-delay timer since timers are run as soon as `ess-command` waits for output.