### PR TITLE
Increase `ess-command` timeout to 30s

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -16,14 +16,14 @@ ESS behaviour.
 on the R side. This should speed up help lookup when the search path has
 changed and the aliases are read again.
 
-@item ESS: @code{ess-command} now uses a default timeout of 1 second.
-It should normally be used for instantaneous background tasks since it
-is synchronous and causes Emacs to block while the command is running.
-If the timeout is reached, an error is thrown to avoid hanging Emacs.
-An interrupt is sent to the process in case of early exit.
+@item ESS: @code{ess-command} now uses a default timeout of 30 seconds.
+It should normally be avoided with long-running tasks because it causes
+Emacs to block while the command is running. If the timeout is reached,
+an error is thrown. An interrupt is also sent to the process in case of early
+exit.
 
 This is a behaviour change: you will now have to explicitly opt in
-blocking the whole Emacs UI for more than 2 seconds by supplying a
+blocking the whole Emacs UI for more than 30 seconds by supplying a
 larger timeout (use @code{most-positive-fixnum} for infinity).
 
 @item ESS: @code{ess-wait-for-process} now returns nil if a timeout is

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1236,6 +1236,8 @@ All elements are optional.
   (setq inferior-ess--output-sentinel-count (1+ inferior-ess--output-sentinel-count))
   (format "ess-output-sentinel%s" inferior-ess--output-sentinel-count))
 
+(defvar ess--command-default-timeout 30)
+
 ;; NOTE: We might want to switch to somethig like `cl-defun' with
 ;; keyword arguments given the length of the signature. Would also
 ;; make it easier to deprecate arguments.
@@ -1254,8 +1256,8 @@ seconds should generally be considered a bug.
 
 SLEEP is deprecated and no longer has any effect. WAIT,
 FORCE-REDISPLAY, and TIMEOUT are as in `ess-wait-for-process' and
-are passed to `ess-wait-for-process'. The default timeout is 1
-second. The process is interrupted with `interrupt-process' when
+are passed to `ess-wait-for-process'. The default timeout is 30
+seconds. The process is interrupted with `interrupt-process' when
 the timeout is reached or when an error occurs.
 
 PROC should be a process, if nil the process name is taken from
@@ -1273,7 +1275,7 @@ wrapping the code into:
   (let ((out-buffer (or out-buffer (get-buffer-create " *ess-command-output*")))
         (proc (ess-command--get-proc proc no-prompt-check))
         (sentinel (inferior-ess--output-sentinel))
-        (timeout (or timeout 1)))
+        (timeout (or timeout ess--command-default-timeout)))
     (with-current-buffer (process-buffer proc)
       (let ((proc-alist (ess--alist (ess-local-process-name
                                      inferior-ess-primary-prompt)))


### PR DESCRIPTION
Closes #1104.

The small timeout is too disruptive, especially with remote connections.