### PR TITLE
Keep trailing slash on default-directory from ess-synchronize-dirs

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -2938,7 +2938,8 @@ To be used in `ess-idle-timer-functions'."
       (ess-if-verbose-write "\n(ess-synchronize-dirs)\n")
       (let ((lpath (car (ess-get-words-from-vector ess-getwd-command))))
         (setq default-directory
-              (ess--derive-connection-path default-directory lpath)))
+              (file-name-as-directory
+               (ess--derive-connection-path default-directory lpath))))
       default-directory)))
 
 (defun ess-dirs ()


### PR DESCRIPTION
default-directory should have a trailing slash. This is restored by wrapping the value ess-synchronize-dirs returns with file-name-as-directory.