### PR TITLE
Improve robustness of background commands

### DIFF
--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -215,7 +215,42 @@ Needed with slow-responding processes."
            (ess-command "{ 1\n 2 }\n" buf)
            (should (string= (with-current-buffer buf
                               (buffer-string))
-                            "[1] 2\n")))))
+                            "[1] 2")))))
+
+(ert-deftest ess--delimited-output-info-test ()
+  ;; No output
+  (with-temp-buffer
+    (insert "
+my-sentinel-START
+my-sentinel-END
+baz> ")
+    (display-buffer (current-buffer))
+    (ess--delimited-output-info (current-buffer) "my-sentinel")
+    (should (equal (ess--delimited-output-info (current-buffer) "my-sentinel")
+                   (list 20 20 nil))))
+  ;; Command output and no new output
+  (with-temp-buffer
+    (insert "
+my-sentinel-START
+foo
+bar
+my-sentinel-END
+baz> ")
+    (ess--delimited-output-info (current-buffer) "my-sentinel")
+    (should (equal (ess--delimited-output-info (current-buffer) "my-sentinel")
+                   (list 20 27 nil))))
+  ;; Command output and new output
+  (with-temp-buffer
+    (insert "
+my-sentinel-START
+foo
+bar
+my-sentinel-END
+baz> 
+
+new output")
+    (should (equal (ess--delimited-output-info (current-buffer) "my-sentinel")
+                   (list 20 27 50)))))
 
 ;;*;; Inferior interaction
 

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -217,16 +217,39 @@ Needed with slow-responding processes."
                               (buffer-string))
                             "[1] 2")))))
 
-(ert-deftest ess--delimited-output-info-test ()
+(ert-deftest ess--command-output-info-test ()
+  ;; No output
+  (with-temp-buffer
+    (insert "baz> ")
+    (should (equal (ess--command-output-info (current-buffer))
+                   (list 1 1 nil))))
+  ;; Command output and no new output
+  (with-temp-buffer
+    (insert "
+foo
+bar
+baz> ")
+    (should (equal (ess--command-output-info (current-buffer))
+                   (list 1 9 nil))))
+  ;; Command output and new output
+  (with-temp-buffer
+    (insert "
+foo
+bar
+baz> 
+
+new output")
+    (should (equal (ess--command-output-info (current-buffer))
+                   (list 1 9 16)))))
+
+(ert-deftest ess--command-delimited-output-info-test ()
   ;; No output
   (with-temp-buffer
     (insert "
 my-sentinel-START
 my-sentinel-END
 baz> ")
-    (display-buffer (current-buffer))
-    (ess--delimited-output-info (current-buffer) "my-sentinel")
-    (should (equal (ess--delimited-output-info (current-buffer) "my-sentinel")
+    (should (equal (ess--command-delimited-output-info (current-buffer) "my-sentinel")
                    (list 20 20 nil))))
   ;; Command output and no new output
   (with-temp-buffer
@@ -236,8 +259,7 @@ foo
 bar
 my-sentinel-END
 baz> ")
-    (ess--delimited-output-info (current-buffer) "my-sentinel")
-    (should (equal (ess--delimited-output-info (current-buffer) "my-sentinel")
+    (should (equal (ess--command-delimited-output-info (current-buffer) "my-sentinel")
                    (list 20 27 nil))))
   ;; Command output and new output
   (with-temp-buffer
@@ -249,7 +271,7 @@ my-sentinel-END
 baz> 
 
 new output")
-    (should (equal (ess--delimited-output-info (current-buffer) "my-sentinel")
+    (should (equal (ess--command-delimited-output-info (current-buffer) "my-sentinel")
                    (list 20 27 50)))))
 
 ;;*;; Inferior interaction

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -273,6 +273,18 @@ baz>
 new output")
     (should (equal (ess--command-delimited-output-info (current-buffer) "my-sentinel")
                    (list 20 27 50)))))
+
+(etest-deftest-r command-without-trailing-newline-test ()
+  "It is a bug when a command doesn't output a trailing newline.
+With delimiters it might be possible to figure out the output.
+However if they are not available then the output is
+indistinguishable from the prompt."
+  :eval ((should-error (ess-command "cat(1)\n"))
+         (ess-wait-for-process))
+  ;; Leaks output after the error but that seems fine since errors in
+  ;; filters are bugs
+  :inf-result "
+> ")
 
 ;;*;; Inferior interaction
 

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -94,7 +94,7 @@
   (with-r-running nil
     (let ((inf-proc *proc*)
           semaphore)
-      (ess-async-command "{cat(1:5);Sys.sleep(0.5);cat(2:6)}\n"
+      (ess-async-command "{cat(1:5);Sys.sleep(0.5);cat(2:6, '\n')}\n"
                          (get-buffer-create " *ess-async-text-command-output*")
                          inf-proc
                          (lambda (&rest args) (setq semaphore t)))

--- a/test/ess-test-r.el
+++ b/test/ess-test-r.el
@@ -316,8 +316,7 @@ add(x, y)
 }
 \\description{
 Add together two numbers. add(10, 1)
-} 
-"
+} "
                     (with-current-buffer buf
                       (R-mode)
                       (ess-roxy-mode)


### PR DESCRIPTION
- Deal with intervening inputs while process is interrupting. Covered by unit test. Closes #1119.
- Always restore process from the filter to simplify things.
- We are more defensive when something goes wrong in a couple places (process restoration when an error or exit occurs in the filter in particular).
- Delimited output case: Detect when background command doesn't output a final newline. An error is thrown in that case. Previously the last line of output would be silently discarded along with the prompt.
- Clean up and refactoring. Merged some code paths. Separated detection of delimited output so it can be tested. We no longer divert the process buffer during background commands, only the process filter. The process is restored via a closure.

Closes #1111
Closes #1114
Closes #1119