### PR TITLE
remove extra whitespace around <- when using ess-insert-assign

### DIFF
--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -424,7 +424,8 @@ If `ess-language' is not \"S\", call `self-insert-command' with ARG."
                (if (and char (numberp event))
                    (replace-match char t t)
                  (replace-match "")))
-              (t (insert assign))))
+              (t (delete-horizontal-space) 
+                 (insert assign))))
     (funcall #'self-insert-command arg)))
 
 ;; In case people had this in their config don't cause errors:


### PR DESCRIPTION
The old version used delete-white-space to remove extra spaces around the
assignment operator. For those of us still using this, it would be nice to
get that convenience back.