### PR TITLE
Fix command hang with `{` expressions when `browser()` is active

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -5,7 +5,7 @@ Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
 @item ESS[R]: @code{ess-command} now runs R code in a sandboxed environment.
-Use @code{parent.env(environment())} to inspect the current environment.
+Use @code{.ess.environment()} to inspect the current environment.
 
 @item ESS[R]: Added support for new syntax in R 4.0 and R 4.1.
 This concerns raw strings, lambda functions, and the pipe operator.

--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,9 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item ESS[R]: @code{ess-command} now runs R code in a sandboxed environment.
+Use @code{parent.env(environment())} to inspect the current environment.
+
 @item ESS[R]: Added support for new syntax in R 4.0 and R 4.1.
 This concerns raw strings, lambda functions, and the pipe operator.
 

--- a/etc/ESSR/R/.basic.R
+++ b/etc/ESSR/R/.basic.R
@@ -222,6 +222,10 @@ if(.ess.Rversion < "1.8")
 
     writeLines(paste0(sentinel, "-START"))
 
+    .ess.environment.state$env <- parent.frame()
+    on.exit(.ess.environment.state$env <- NULL, add = TRUE)
+
+
     ## Don't interrupt `browser()` sessions (#1081)
     restart <- function(...) {
         if (!is.null(findRestart("browser")))
@@ -240,4 +244,10 @@ if(.ess.Rversion < "1.8")
 
     ## Keep `.Last.value` stable
     invisible(.Last.value)
+}
+
+.ess.environment.state <- new.env(parent = emptyenv())
+
+.ess.environment <- function() {
+    .ess.environment.state$env
 }

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -481,7 +481,7 @@ fill=TRUE); try(traceback(), silent=TRUE)})\n")
 
 (defun ess-r-format-command (cmd &rest args)
   (let ((sentinel (alist-get 'output-delimiter args)))
-    (format ".ess.command(%s, '%s')\n" cmd sentinel)))
+    (format ".ess.command(local(%s), '%s')\n" cmd sentinel)))
 
 (defvar ess-r-format-command-alist
   '((fun           . ess-r-format-command)

--- a/test/ess-test-inf.el
+++ b/test/ess-test-inf.el
@@ -160,6 +160,24 @@ Browse[1]> "
   :inf-result "NULL
 Browse[1]> ")
 
+(etest-deftest-r ess-command-browser-curly-braces ()
+  "`{` expressions when debugger is active do not interrupt command."
+  :cleanup (progn
+             (ess-debug-command-quit)
+             (ess-wait-for-process)
+             (etest-clear-inferior-buffer))
+  :eval (progn
+          (ess-send-string (ess-get-process) "{ browser(); NULL }\n")
+          (ess-wait-for-process))
+  :inf-result "Called from: top level 
+Browse[1]> debug at #1: NULL
+Browse[1]> "
+
+  :eval (should (string= (ess-string-command "{ 1; 2 }\n")
+                         "[1] 2"))
+  :inf-result ""
+  :eval (should (inferior-ess-available-p)))
+
 (etest-deftest-r ess-command-quit-test ()
   "`ess-command' does not leak output on quit (#794, #842).
 This is especially important within `while-no-input' used by

--- a/test/ess-test-r.el
+++ b/test/ess-test-r.el
@@ -838,10 +838,10 @@ https://github.com/emacs-ess/ESS/issues/725#issuecomment-431781558"
   :inf-cleanup
   (progn
     (kill-buffer ess-rdired-buffer)
-    (ess-command "rm(my_rdired_variable)\n"))
-  
+    (ess-command "rm(my_rdired_variable, envir = globalenv())\n"))
+
   :eval
-  ((ess-command "my_rdired_variable <- TRUE\n")
+  ((ess-command "assign('my_rdired_variable', TRUE, envir = globalenv())\n")
    (save-window-excursion
      (ess-rdired))
    (with-current-buffer ess-rdired-buffer


### PR DESCRIPTION
When `ess-command` is passed a `{` expression and `browser()` is active, we get a hang because R steps through the components of`{`. This didn't happen before because we sent the expression directly. Now we evaluate it from the R function `.ess.command()` and this causes R to stop when evaluation returns to the debugged environment when the argument is forced.

To avoid this, I can't think of anything else besides running the command in `local()`. A nice effect of this change is that the ESS commands are now sandboxed by default. However this is a breaking change, for instance inspecting the current environment from an ESS command will now require `ls(envir = parent.env(environment())`. We could also provide something like `.ess.command.env()` to make this easier.

I think the breaking change is worth it because requiring users to wrap their `{` expressions in `local()` is error prone and is likely to result in ESS hangs when debugging.