### PR TITLE
[Fix #1179] Add support for R projects

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -4,6 +4,8 @@
 Changes and New Features in 19.04 (unreleased):
 @itemize @bullet
 
+@item ESS[R]: Add support for R projects and start R by default in the project folder.
+
 @item ESS[R]: Backticked symbols in the process buffer are no
 longer fontified as strings.
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -311,7 +311,8 @@ This, plus `ess-language', should be able to determine the exact
 version of the statistical package being executed in the particular
 buffer.")
 
-(defcustom ess-directory-function nil
+(defvaralias 'ess-directory-function 'ess-startup-directory-function)
+(defcustom ess-startup-directory-function nil
   "Function to return the directory that ESS is run from.
 If nil or if the function returns nil then you get `ess-startup-directory'."
   :group 'ess
@@ -2464,9 +2465,6 @@ Used to store the values for passing on to newly created buffers.")
 
 (defvar-local ess-listing-minor-mode nil
   "Non-nil if using `ess-listing-minor-mode'.")
-
-(defvar ess--enable-experimental-projects nil
-  "Enable experimental project support in ESS.")
 
 (defvar ess-STERM nil
   "Placeholder for dialect-specific STERM.")

--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -621,29 +621,22 @@ process-less buffer because it was created with
 
 
 ;;*;; Requester functions called at startup
-
-;; FIXME EMACS 25.1:
-;; Deprecate `ess-directory-function' in favor of `project-find-functions'?
 (defun inferior-ess--get-startup-directory ()
   "Return a startup directory."
-  (let ((dir (or (and ess--enable-experimental-projects
-                      (fboundp 'project-current)
-                      (cdr (project-current)))
-                 (and ess-directory-function
+  (let ((dir (or (and ess-directory-function
                       (funcall ess-directory-function))
+                 (when-let ((proj (project-current)))
+                   (ess--project-root proj))
                  ess-startup-directory
                  default-directory)))
     (directory-file-name dir)))
 
-(defun inferior-ess--maybe-prompt-startup-directory (procname dialect)
+(defun inferior-ess--maybe-prompt-startup-directory (procname _dialect)
   "Possibly prompt for a startup directory.
 When `ess-ask-for-ess-directory' is non-nil, prompt.  PROCNAME is
 the name of the inferior process (e.g. \"R:1\"), and DIALECT is
 the language dialect (e.g. \"R\")."
-  (let ((default-dir (if (fboundp 'inferior-ess-r--adjust-startup-directory)
-                         (inferior-ess-r--adjust-startup-directory
-                          (inferior-ess--get-startup-directory) dialect)
-                       (inferior-ess--get-startup-directory))))
+  (let ((default-dir (inferior-ess--get-startup-directory)))
     (if ess-ask-for-ess-directory
         (let ((prompt (format "%s starting project directory? " procname)))
           (ess-prompt-for-directory default-dir prompt))

--- a/lisp/ess-r-flymake.el
+++ b/lisp/ess-r-flymake.el
@@ -97,26 +97,22 @@ each element is passed as argument to 'lintr::with_defaults'."
 (defun ess-r--find-lintr-file ()
   "Return the absolute path to the .lintr file.
 Check first the current directory, then the project root, then
-the user's home directory.  Return nil if we couldn't find a .lintr file."
-  (let ((cur-dir-file (expand-file-name ".lintr" default-directory))
-        (ess-proj-file (and (fboundp 'ess-r-package-project)
-                            (ess-r-package-project)
-                            (expand-file-name ".lintr" (cdr (ess-r-package-project)))))
-        (proj-file (and (project-current)
-                        (ess--project-root (project-current))
-                        (expand-file-name ".lintr" (ess--project-root (project-current)))))
-        (home-file (expand-file-name ".lintr" (getenv "HOME"))))
-    (cond (;; current directory
-           (file-readable-p cur-dir-file)
-           cur-dir-file)
-          ;; Project root according to `ess-r-package-project'
-          ((and ess-proj-file
-                (file-readable-p ess-proj-file))
-           ess-proj-file)
-          ;; Project root according to `ess--project-root'
-          ((and proj-file
-                (file-readable-p proj-file)))
-          ;; Home directory
+the package root, then the user's home directory. Return nil if
+we couldn't find a .lintr file."
+  ;; VS[2022-01-26]: Can't this entire thing be replaced by
+  ;; `(locate-dominating-file ".lintr")`?
+  (let* ((cur-file (expand-file-name ".lintr" default-directory))
+         (pkg (cdr (ess-r-package-project)))
+         (pkg-file (and proj (expand-file-name ".lintr" pkg)))
+         (proj (ess-r-project))
+         (proj-file (and proj (expand-file-name ".lintr" proj)))
+         (home-file (expand-file-name ".lintr" (getenv "HOME"))))
+    (cond ((file-readable-p cur-file)
+           cur-file)
+          ((and proj-file (file-readable-p proj-file))
+           proj-file)
+          ((and pkg-file (file-readable-p pkg-file))
+           pkg-file)
           ((file-readable-p home-file)
            home-file))))
 

--- a/lisp/ess-r-flymake.el
+++ b/lisp/ess-r-flymake.el
@@ -40,6 +40,8 @@
 (declare-function flymake-diag-region "flymake")
 (declare-function flymake-make-diagnostic "flymake")
 (declare-function flymake--overlays "flymake")
+(declare-function ess-r-project "ess-r-mode")
+(declare-function ess-r-package-project "ess-r-package")
 
 (defcustom ess-r-flymake-linters
   '("closed_curly_linter = NULL"
@@ -103,7 +105,7 @@ we couldn't find a .lintr file."
   ;; `(locate-dominating-file ".lintr")`?
   (let* ((cur-file (expand-file-name ".lintr" default-directory))
          (pkg (cdr (ess-r-package-project)))
-         (pkg-file (and proj (expand-file-name ".lintr" pkg)))
+         (pkg-file (and pkg (expand-file-name ".lintr" pkg)))
          (proj (ess-r-project))
          (proj-file (and proj (expand-file-name ".lintr" proj)))
          (home-file (expand-file-name ".lintr" (getenv "HOME"))))

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -588,6 +588,9 @@ will be prompted to enter arguments interactively."
                   inferior-R-args " "   ; add space just in case
                   start-args))
          (debug (string-match-p " -d \\| --debugger=" r-start-args))
+         (project-find-functions (if (memq 'ess-r-project project-find-functions)
+                                     project-find-functions
+                                   (cons 'ess-r-project project-find-functions)))
          use-dialog-box)
     (when (or ess-microsoft-p
               (eq system-type 'cygwin))
@@ -617,21 +620,6 @@ will be prompted to enter arguments interactively."
   (interactive "P")
   ;; FIXME: Current ob-R expects current buffer set to process buffer
   (set-buffer (run-ess-r start-args)))
-
-(defun inferior-ess-r--adjust-startup-directory (dir dialect)
-  "Adjust startup directory DIR if DIALECT is R.
-If in a package project, prefer the tests directory but only if
-the package directory was selected in the first place."
-  (if (string= dialect "R")
-      (let* ((project-dir (cdr (ess-r-package-project)))
-             (tests-dir (expand-file-name (file-name-as-directory "tests")
-                                          project-dir)))
-        (if (and project-dir
-                 (string= project-dir dir)
-                 (string= default-directory tests-dir))
-            tests-dir
-          dir))
-    dir))
 
 (defun inferior-ess-r--init-callback (_proc _name)
   (R-initialize-on-start))
@@ -870,7 +858,7 @@ efficiency reasons."
                                       (file-exists-p (expand-file-name "DESCRIPTION" dir))
                                       (let ((nm (file-name-nondirectory (directory-file-name dir))))
                                         (file-exists-p (expand-file-name (concat nm ".Rproj") dir))))))))
-                      (when dir 
+                      (when dir
                         (let ((dir (directory-file-name dir)))
                           (unless (member dir (list "~" (getenv "HOME")))
                             (list :name (file-name-nondirectory dir)

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -36,6 +36,7 @@
 ;; Silence the byte compiler, OK because this file is only loaded by
 ;; ess-r-mode and has no autoloads.
 (defvar ess-r-customize-alist)
+(declare-function ess-r-project "ess-r-mode")
 (declare-function inferior-ess-r-force "ess-r-mode")
 (declare-function ess-r-get-evaluation-env "ess-r-mode")
 (declare-function ess-r-set-evaluation-env "ess-r-mode")
@@ -526,9 +527,9 @@ Set this variable to nil to disable the mode line entirely."
                   (set (make-local-variable var)
                        (eval (cdr (assq var ess-r-customize-alist)))))
                 vars))
-        (add-hook 'project-find-functions #'ess-r-package-project)
+        (add-hook 'project-find-functions #'ess-r-project)
         (run-hooks 'ess-r-package-enter-hook))
-    (remove-hook 'project-find-functions #'ess-r-package-project)
+    (remove-hook 'project-find-functions #'ess-r-project)
     (run-hooks 'ess-r-package-exit-hook)))
 
 (add-hook 'after-change-major-mode-hook 'ess-r-package-auto-activate)


### PR DESCRIPTION
Project XYZ is defined by `XYZ/.Rpfofile`, `XYZ/DESCRIPTION` or `XYZ/XYZ.Rproj` unless it's the user's home directory.