### PR TITLE
Improve support for `R` sessions started with `ess-remote`

### DIFF
--- a/etc/ESSR/R/mpi.R
+++ b/etc/ESSR/R/mpi.R
@@ -7,7 +7,7 @@
         else as.character(el)
     })
     payload <- paste(dots, collapse = "")
-    cat(sprintf("\033_%s036%s\033\\", head, payload))
+    cat(sprintf("\034%s\036%s\035", head, payload))
 }
 
 .ess_mpi_message <- function(msg){

--- a/etc/ESSR/R/mpi.R
+++ b/etc/ESSR/R/mpi.R
@@ -7,7 +7,7 @@
         else as.character(el)
     })
     payload <- paste(dots, collapse = "")
-    cat(sprintf("_%s%s\\", head, payload))
+    cat(sprintf("\033_%s036%s\033\\", head, payload))
 }
 
 .ess_mpi_message <- function(msg){

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -1257,7 +1257,8 @@ ends with an incomplete message."
                           (apply handler payload))
                       (error "No handler defined for MPI message '%s" head))
                   (goto-char mbeg0)
-                  (delete-region mbeg0 mend0)))
+                  (let ((inhibit-read-only t))
+                    (delete-region mbeg0 mend0))))
             (setq out :incomplete))))
       out)))
 

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -1183,9 +1183,9 @@ Kill the *ess.dbg.[R_name]* buffer."
 
 ;; http://jkorpela.fi/chars/c0.html
 ;; https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences
-(defvar ess-mpi-message-start-delimiter "_")
+(defvar ess-mpi-message-start-delimiter "")
 (defvar ess-mpi-message-field-separator "")
-(defvar ess-mpi-message-end-delimiter "\\")
+(defvar ess-mpi-message-end-delimiter "")
 
 (define-obsolete-variable-alias 'ess-mpi-alist 'ess-mpi-handlers "ESS 19.04")
 (defvar ess-mpi-handlers
@@ -1229,7 +1229,7 @@ value from EXPR and then sent to the subprocess."
 
 (defun ess-mpi-handle-messages (buf)
   "Handle all mpi messages in BUF and delete them.
-The MPI message has the form TYPEFIELD... where TYPE is the
+The MPI message has the form TYPEFIELD... where TYPE is the
 type of the messages on which handlers in `ess-mpi-handlers' are
 dispatched. And FIELDs are strings. Return :incomplete if BUF
 ends with an incomplete message."

--- a/lisp/essd-els.el
+++ b/lisp/essd-els.el
@@ -154,7 +154,8 @@ DIALECT is the desired ess-dialect. If nil, ask for dialect"
       (ess-eval-linewise (format "options(pager='%s')\n"
                                  (or inferior-ess-remote-pager inferior-ess-pager))
                          nil nil nil 'wait)
-      (ess-r-load-ESSR))
+      (ess-r-load-ESSR)
+      (when ess-use-tracebug (ess-tracebug 1)))
 
     (when (equal ess-dialect "S+")
       (ess-command ess-S+--injected-code))


### PR DESCRIPTION
As discussed in #1163 and #1142, there are some issues with `R` sessions invoked via `ess-remote` as [discussed in the manual](https://ess.r-project.org/Manual/ess.html#ESS_002dremote) (i.e., launch a shell within emacs using `M-x shell`, ssh to a server, run `R`, and then do `M-x ess-remote` to get things setup).

The most pressing issue is that some literal control codes in files that are injected during configuration can get intercepted by the shell which screws up subsequent parsing and can have weird consequences. A simple fix for this is to use octal codes rather than literals in the associated R files, and this is all that 2ce1846488544fe9afe6ce24c502185fab6ddff0 does. However, that alone is not sufficient to get the associated functionality working correctly, but if the rest of this PR requires further discussion and a quick fix is desired, I'm happy to submit a PR that includes* only this small commit.

The subsequent commits in this PR are aimed at improving MPI support for `R` sessions started with `ess-remote` as discussed above. I enumerate the changes/commits below, since in general they are all severable.

* In d9443009347caaa779420986191dd1a830db4893, I switch to different control codes and in particular use those associated with separators to reduce the chances of a shell ascribing them special meaning. Note: I use literals in the `elisp` code so in Github it renders like an empty string, but it's easier to see in emacs.

* In a5451413b939aebd1e629ca189510b7b27e9d2d8, change the message handler to override the `read-only` property which prevents it from cleaning up after itself when it runs in a `*shell*` buffer.

* In f5f54f27238d0058b5346cbe2b76751030ee45a1, I (conditionally) invoke `ess-tracebug` when setting things up in a manner analogous to that done by `R-initialize-on-start` (which `ess-remote` doesn't call for what I assume are good reasons unknown to me). This is necessary to set off a chain of activity which ultimately results in `ess-mpi-handle-message` getting run automatically in `R` sessions started with `M-x ess-remote` in the same way that it does in `R` sessions started with `M-x R`.