### PR TITLE
[Fix #1185] Move ask-for directory code after ess-r-mode startup

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -169,9 +169,7 @@ This may be useful for debugging."
                              dialect)
                          dialect))
          (inf-buf (inferior-ess--get-proc-buffer-create temp-dialect))
-         (proc-name (buffer-local-value 'ess-local-process-name inf-buf))
-         (cur-dir (inferior-ess--maybe-prompt-startup-directory proc-name temp-dialect))
-         (default-directory cur-dir))
+         (proc-name (buffer-local-value 'ess-local-process-name inf-buf)))
     (with-current-buffer inf-buf
       ;; TODO: Get rid of this, we should rely on modes to set the
       ;; variables they need.
@@ -179,7 +177,8 @@ This may be useful for debugging."
       (inferior-ess--set-major-mode ess-dialect)
       ;; Set local variables after changing mode because they might
       ;; not be permanent
-      (setq default-directory cur-dir)
+      (setq default-directory
+            (inferior-ess--maybe-prompt-startup-directory proc-name temp-dialect))
       (setq inferior-ess--local-data (cons inferior-ess-program start-args))
       ;; Read the history file
       (when ess-history-file
@@ -204,7 +203,7 @@ This may be useful for debugging."
         (unless (and proc (eq (process-status proc) 'run))
           (error "Process %s failed to start" proc-name))
         (when ess-setwd-command
-          (ess-set-working-directory cur-dir))
+          (ess-set-working-directory default-directory))
         (setq-local font-lock-fontify-region-function #'inferior-ess-fontify-region)
         (setq-local ess-sl-modtime-alist nil)
         (run-hooks 'ess-post-run-hook)

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -588,9 +588,6 @@ will be prompted to enter arguments interactively."
                   inferior-R-args " "   ; add space just in case
                   start-args))
          (debug (string-match-p " -d \\| --debugger=" r-start-args))
-         (project-find-functions (if (memq 'ess-r-project project-find-functions)
-                                     project-find-functions
-                                   (cons 'ess-r-project project-find-functions)))
          use-dialog-box)
     (when (or ess-microsoft-p
               (eq system-type 'cygwin))

--- a/lisp/ess-r-package.el
+++ b/lisp/ess-r-package.el
@@ -527,7 +527,7 @@ Set this variable to nil to disable the mode line entirely."
                   (set (make-local-variable var)
                        (eval (cdr (assq var ess-r-customize-alist)))))
                 vars))
-        (add-hook 'project-find-functions #'ess-r-project)
+        (add-hook 'project-find-functions #'ess-r-project nil 'local)
         (run-hooks 'ess-r-package-enter-hook))
     (remove-hook 'project-find-functions #'ess-r-project)
     (run-hooks 'ess-r-package-exit-hook)))


### PR DESCRIPTION
We have a problem with #1185 

The asking for the directory happens before the `inferior-ess-r-mode` is installed into the buffer, which means the mode hooks that set `project-find-directory` have not run yet. Let binding around the call to `inferior-ess` as it currently is not good because of the warning in #1185.  

The proposed solution is not ideal either because the functions which are run in the mode-hook don't see the new `default-directory`. I am not sure if this is acceptable. 

All other ways to fix this I can think of are rather hacky :thinking: 