### PR TITLE
fix: terminate auto-mode-alist entries

### DIFF
--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -1129,7 +1129,7 @@ use \"bin/Rterm.exe\"."
 (fset 'r-transcript-mode 'ess-r-transcript-mode)
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.[Rr]out" . ess-r-transcript-mode))
+(add-to-list 'auto-mode-alist '("\\.[Rr]out\\'" . ess-r-transcript-mode))
 ;;;###autoload
 (add-to-list 'interpreter-mode-alist '("Rscript" . ess-r-mode))
 ;;;###autoload

--- a/lisp/ess-s-lang.el
+++ b/lisp/ess-s-lang.el
@@ -531,7 +531,7 @@ return it.  Otherwise, return `ess-help-topics-list'."
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.[Ss]t\\'" . S-transcript-mode))
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("\\.Sout" . S-transcript-mode))
+(add-to-list 'auto-mode-alist '("\\.Sout\\'" . S-transcript-mode))
 
 (provide 'ess-s-lang)
 


### PR DESCRIPTION
Anchor  `auto-mode-alist` entries to match until end of file extension