### PR TITLE
Fix up copyright notices for GNU ELPA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ tmp*
 .dependencies
 NEWS
 ONEWS
+
+# ELPA-generated files
+/ess-autoloads.el
+/ess-pkg.el

--- a/doc/ess.texi
+++ b/doc/ess.texi
@@ -57,7 +57,7 @@ ESS version
 @top ESS: Emacs Speaks Statistics
 
 ESS version
-@include ../VERSION
+@ESSVER
 
 @display
 by  A.J. Rossini,

--- a/lisp/obsolete/ess-font-lock.el
+++ b/lisp/obsolete/ess-font-lock.el
@@ -1,7 +1,6 @@
 ;;; ess-font-lock.el --- font-lock color options
 
-;; Copyright (C) 2000--2006 A.J. Rossini, Richard M. Heiberger, Martin
-;;      Maechler, Kurt Hornik, Rodney Sparapani, and Stephen Eglen.
+;; Copyright (C) 2000-2022  Free Software Foundation, Inc.
 
 ;; Author: Richard M. Heiberger <rmh@temple.edu>
 ;; Created: 06 Feb 2000

--- a/targets/create-pkg-file.el
+++ b/targets/create-pkg-file.el
@@ -1,5 +1,7 @@
 ;;; create-pkg-file.el --- Create ess-pkg.el  -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2018-2022  Free Software Foundation, Inc.
+
 ;;; Commentary:
 ;; Creates ess-pkg.el
 

--- a/targets/travis-install-package.el
+++ b/targets/travis-install-package.el
@@ -1,5 +1,7 @@
 ;;; travis-install-package.el  -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2018-2022  Free Software Foundation, Inc.
+
 ;;; Commentary:
 ;; This file simulates a user installing the ess-$VERSION.tar file and
 ;; then loading ess. It's meant to be used for testing purposes only.


### PR DESCRIPTION
Includes a few other minor changes, the most important of which is moving a macro to fix a miscompilation.

* .gitignore: Add ELPA-generated files.

* doc/ess.texi: Make more use of `ESSVER`.

* targets/travis-install-package.el:
* targets/create-pkg-file.el:
* lisp/obsolete/ess-font-lock.el:
* test/etest/etest.el: Fix up copyright notices.
(etest--push-local-config): Move before first use.
(etest--setup-body, etest--run-test, etest-run): Use `lexical-binding`.
(etest-run): Add FIXME.
(etest--decode-keysequence): Fix quote markup in docstring.