### PR TITLE
fix(r): using `TRUE' instead of `T' in ess-installed-packages

### DIFF
--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -1225,7 +1225,7 @@ Placed into `ess-presend-filter-functions' for R dialects."
 
 (cl-defmethod ess-installed-packages (&context (ess-dialect "R"))
   ;;; FIXME? .packages() does not cache; installed.packages() does but is slower first time
-  (ess-get-words-from-vector--foreground "print(.packages(T), max=1e6)\n"))
+  (ess-get-words-from-vector--foreground "print(.packages(TRUE), max=1e6)\n"))
 
 (cl-defmethod ess-load-library--override (pack &context (ess-dialect "R"))
   "Load an R package."


### PR DESCRIPTION
Today, when I call `ess-load-library`, it raises the error below. I fount it is because we use `T` in `ess-installed-packages` for the arguments `all.available` for R fuction `.packages`.

```
Error in if (all.available) { : argument is of length zero
```

```
R version 4.2.1 (2022-06-23 ucrt)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 19044)
```

Signed-off-by: Shuguang Sun <shuguang79@qq.com>