### PR TITLE
tracebug: add keybindings for remaining browser commands

### DIFF
--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -1522,6 +1522,7 @@ the output into *ess.dbg* buffer."
     (define-key map (kbd "M-C") #'ess-debug-command-continue)
     (define-key map [(control meta ?C)] #'ess-debug-command-continue-multi)
     (define-key map (kbd "M-N") #'ess-debug-command-next)
+    (define-key ess-debug-minor-mode-map (kbd "M-S") #'ess-debug-command-step)
     (define-key map [(control meta ?N)] #'ess-debug-command-next-multi)
     (define-key map (kbd "M-Q") #'ess-debug-command-quit)
     (define-key map (kbd "M-U") #'ess-debug-command-up)
@@ -1784,6 +1785,17 @@ Equivalent to `n' at the R prompt."
   (if (ess--dbg-is-recover-p)
       (ess-send-string (ess-get-process) "0")
     (ess-send-string (ess-get-process) "n")))
+
+(defun ess-debug-command-step ()
+      "Step into in debug mode.
+Equivalent to `s' at the R prompt."
+       (interactive)
+  (ess-force-buffer-current)
+  (unless (ess--dbg-is-active-p)
+    (error "Debugger is not active"))
+  (if (ess--dbg-is-recover-p)
+      (ess-send-string (ess-get-process) "0")
+    (ess-send-string (ess-get-process) "s")))
 
 (defun ess-debug-command-next-multi (&optional N)
   "Ask for N and step (n) N times in debug mode."

--- a/lisp/ess-tracebug.el
+++ b/lisp/ess-tracebug.el
@@ -1522,7 +1522,11 @@ the output into *ess.dbg* buffer."
     (define-key map (kbd "M-C") #'ess-debug-command-continue)
     (define-key map [(control meta ?C)] #'ess-debug-command-continue-multi)
     (define-key map (kbd "M-N") #'ess-debug-command-next)
-    (define-key ess-debug-minor-mode-map (kbd "M-S") #'ess-debug-command-step)
+    (define-key map (kbd "M-S") #'ess-debug-command-step)
+    (define-key map (kbd "M-W") #'ess-debug-command-where)
+    (define-key map (kbd "M-F") #'ess-debug-command-finish)
+    (define-key map (kbd "M-H") #'ess-debug-command-help)
+    (define-key map (kbd "M-R") #'ess-debug-command-resume)
     (define-key map [(control meta ?N)] #'ess-debug-command-next-multi)
     (define-key map (kbd "M-Q") #'ess-debug-command-quit)
     (define-key map (kbd "M-U") #'ess-debug-command-up)
@@ -1796,6 +1800,50 @@ Equivalent to `s' at the R prompt."
   (if (ess--dbg-is-recover-p)
       (ess-send-string (ess-get-process) "0")
     (ess-send-string (ess-get-process) "s")))
+
+(defun ess-debug-command-finish ()
+  "Step next in debug mode.
+Equivalent to `f' at the R prompt."
+  (interactive)
+  (ess-force-buffer-current)
+  (unless (ess--dbg-is-active-p)
+    (error "Debugger is not active"))
+  (if (ess--dbg-is-recover-p)
+      (progn (ess-send-string (ess-get-process) "0")
+       (ess-send-string (ess-get-process) "f"))
+    (ess-send-string (ess-get-process) "f")))
+
+
+(defun ess-debug-command-resume ()
+  "Step next in debug mode.
+Equivalent to `f' at the R prompt."
+  (interactive)
+  (ess-force-buffer-current)
+  (unless (ess--dbg-is-active-p)
+    (error "Debugger is not active"))
+  (if (ess--dbg-is-recover-p)
+      (progn (ess-send-string (ess-get-process) "0")
+       (ess-send-string (ess-get-process) "r"))
+    (ess-send-string (ess-get-process) "r")))
+
+(defun ess-debug-command-where ()
+  "Step next in debug mode.
+Equivalent to `where' at the R prompt."
+  (interactive)
+  (ess-force-buffer-current)
+  (unless (ess--dbg-is-active-p)
+    (error "Debugger is not active"))
+    (ess-send-string (ess-get-process) "where"))
+
+
+(defun ess-debug-command-help ()
+  "Step next in debug mode.
+Equivalent to `where' at the R prompt."
+  (interactive)
+  (ess-force-buffer-current)
+  (unless (ess--dbg-is-active-p)
+    (error "Debugger is not active"))
+    (ess-send-string (ess-get-process) "help"))
 
 (defun ess-debug-command-next-multi (&optional N)
   "Ask for N and step (n) N times in debug mode."


### PR DESCRIPTION
Mirroring the remaining [browser functions](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/browser). I tested this by running these lines in my config, and it worked in the file I had open. There's probably a better way to do help so that it lists these commands too, but hopefully the pattern is clear enough.

The bindings are of course just suggestions. They were unbound in my work environment and roughly followed the conventions of the other tracebug browser controls.

Hopefully this proves useful to someone else.