### PR TITLE
+ \dontdiff{.}

### DIFF
--- a/lisp/ess-rd.el
+++ b/lisp/ess-rd.el
@@ -131,7 +131,7 @@ All Rd mode abbrevs start with a grave accent (`)."
     ;;
     "RdOpts" "R" "S3method" "S4method" "Sexpr"
     "abbr" "acronym"
-    "bold" "cite" "code" "command" "cr" "dQuote" "deqn" "dfn" "dontrun"
+    "bold" "cite" "code" "command" "cr" "dQuote" "deqn" "dfn" "dontdiff" "dontrun"
     "dontshow" "donttest" "dots" "email" "emph" "enc" "env" "eqn" "figure" "file"
     "href"
     "ifelse" "if"


### PR DESCRIPTION
A new built-in Rd macro `\dontdiff` has been added to the trunk in r85975. The output of enclosed example code will be ignored when comparing to saved reference output (`<pkg>-Ex.Rout.save`).