### PR TITLE
Extended support for function shorthand notation

### DIFF
--- a/doc/newfeat.texi
+++ b/doc/newfeat.texi
@@ -1,6 +1,15 @@
 @comment @itemize @w{}
 @comment @item
 
+Changes and New Features in development version:
+@itemize @bullet
+
+@item ESS[R]: The shorthand notation for lambda functions
+and the question mark are now fontified as keywords.
+Contributed by Maxime Pettinger.
+
+@end itemize
+
 Changes and New Features in 24.01.1:
 @itemize @bullet
 

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2050,10 +2050,9 @@ See also function `ess-create-object-name-db'.")
     "switch" "function" "return" "on.exit" "stop" ".Defunct" "tryCatch"
     "withRestarts" "invokeRestart"
     "recover" "browser")
-  "Reserved words or special functions in the R language.
-See also `ess-R-keystrings'.")
+  "Reserved words or special functions in the R language.")
 
-(defvar ess-R-keystrings
+(defvar ess-r--keystrings
   '("\\" "\?")
   "Reserved non-word strings or special functions whose names
 include special characters in the R language.

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2050,7 +2050,17 @@ See also function `ess-create-object-name-db'.")
     "switch" "function" "return" "on.exit" "stop" ".Defunct" "tryCatch"
     "withRestarts" "invokeRestart"
     "recover" "browser")
-  "Reserved words or special functions in the R language.")
+  "Reserved words or special functions in the R language.
+See also `ess-R-keystrings'.")
+
+(defvar ess-R-keystrings
+  '("\\" "\?")
+  "Reserved non-word strings or special functions whose names
+include special characters in the R language.
+
+Similar font-locking usage as `ess-R-keywords', but dedicated to
+strings that should not be treated as `words’ by `regexp-opt' in
+`ess-r--find-fl-keyword'.")
 
 (defvar ess-S-keywords
   (append ess-R-keywords '("terminate")))

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2097,7 +2097,8 @@ strings that should not be treated as `words’ by `regexp-opt' in
 (defvar ess-R-function-name-regexp
   (concat "\\("      "\\sw+" "\\)"
           "[ \t]*"   "\\(<-\\)"
-          "[ \t\n]*" "\\(function\\b\\|\\\\\\)"))
+          "[ \t\n]*" "\\(function\\b\\|\\(\\\\[ \t\n(]+\\)\\)"))
+;; "[ \t\n(]+" after "\\\\" since cannot use "\\b" to bound a non-word
 
 (defvar ess-S-function-name-regexp
   ess-R-function-name-regexp)

--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -2098,7 +2098,7 @@ strings that should not be treated as `words’ by `regexp-opt' in
 (defvar ess-R-function-name-regexp
   (concat "\\("      "\\sw+" "\\)"
           "[ \t]*"   "\\(<-\\)"
-          "[ \t\n]*" "function\\b"))
+          "[ \t\n]*" "\\(function\\b\\|\\\\\\)"))
 
 (defvar ess-S-function-name-regexp
   ess-R-function-name-regexp)

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -419,7 +419,7 @@ To be used as part of `font-lock-defaults' keywords."
         (if (member kw ess-r--non-fn-kwds)
             (push kw non-fn-kwds)
           (push kw fn-kwds)))
-      (dolist (kw ess-R-keystrings)
+      (dolist (kw ess-r--keystrings)
 	(if (member kw ess-r--non-fn-kstrs)
 	    (push kw non-fn-kstrs)
 	  (push kw fn-kstrs)))

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -394,23 +394,44 @@ namespace.")
     font-lock-comment-face))
 
 (defvar ess-r--non-fn-kwds
-  '("in" "else" "break" "next" "repeat"))
+  '("in" "else" "break" "next" "repeat")
+  "Reserved words that should not be treated as names of special
+functions by `ess-r--find-fl-keyword'; such reserved words do
+not need to be followed by an open parenthesis to trigger
+font-locking.
+See also `ess-r--non-fn-kstrs'.")
+
+(defvar ess-r--non-fn-kstrs
+  '("\?")
+  "Reserved non-word strings that should not be treated as names of
+special functions by `ess-r--find-fl-keyword'; such reserved
+strings do not need to be followed by an open parenthesis to
+trigger font-locking.
+See also `ess-r--non-fn-kwds'.")
 
 (defvar-local ess-r--keyword-regexp nil)
 (defun ess-r--find-fl-keyword (limit)
-  "Search for R keyword and set the match data.
+  "Search for R keyword or keystring and set the match data.
 To be used as part of `font-lock-defaults' keywords."
   (unless ess-r--keyword-regexp
-    (let (fn-kwds non-fn-kwds)
+    (let (fn-kwds non-fn-kwds fn-kstrs non-fn-kstrs)
       (dolist (kw ess-R-keywords)
         (if (member kw ess-r--non-fn-kwds)
             (push kw non-fn-kwds)
           (push kw fn-kwds)))
+      (dolist (kw ess-R-keystrings)
+	(if (member kw ess-r--non-fn-kstrs)
+	    (push kw non-fn-kstrs)
+	  (push kw fn-kstrs)))
       (setq ess-r--keyword-regexp
             (concat "\\("
                     (regexp-opt non-fn-kwds 'words)
+                    "\\|"
+                    (regexp-opt non-fn-kstrs t)
                     "\\)\\|\\("
                     (regexp-opt fn-kwds 'words)
+                    "\\|"
+                    (regexp-opt fn-kstrs t)
                     "\\)"))))
   (let (out)
     (while (and (not out)

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -372,7 +372,7 @@ namespace.")
                  (ess-goto-char string-end)
                  (ess-looking-at "<-")
                  (ess-goto-char (match-end 0))
-                 (ess-looking-at "function\\b" t)))
+                 (ess-looking-at "function\\b\\|\\\\" t)))
           font-lock-function-name-face)
          ((save-excursion
             (and (cdr (assq 'ess-fl-keyword:fun-calls ess-R-font-lock-keywords))

--- a/lisp/ess-utils.el
+++ b/lisp/ess-utils.el
@@ -807,7 +807,7 @@ Copied almost verbatim from gnus-utils.el (but with test for mac added)."
 
                   "\\(" space "\\s<.*\\s>\\)*"      ; whitespace, comment
                   ;; FIXME: in principle we should skip 'definition *= *' here
-                  space "function\\s-*(" ; whitespace, function keyword, parenthesis
+                  space "\\(function\\|\\\\\\)\\s-*(" ; whitespace, function keyword, parenthesis
                   )))
     `(,part-1 ,part-2))
   "Partial regex for matching functions.

--- a/test/ess-test-r-fontification.el
+++ b/test/ess-test-r-fontification.el
@@ -57,6 +57,7 @@
 ¶while ¶for ¶if ¶switch ¶function ¶return ¶on.exit ¶stop
 ¶tryCatch ¶withRestarts ¶invokeRestart ¶recover ¶browser
 ¶message ¶warning ¶signalCondition ¶withCallingHandlers
+¶\\
 "
   (should (not (face-at-point))))
 
@@ -66,7 +67,7 @@
 ¶while() ¶for() ¶if() ¶function()
 ¶switch() ¶return() ¶on.exit() ¶stop() ¶tryCatch()
 ¶withRestarts() ¶invokeRestart() ¶recover() ¶browser()
-¶.Defunct()
+¶.Defunct() ¶\\(\\\\\\)()
 "
   (should (eq (face-at-point) 'ess-keyword-face))
 
@@ -75,7 +76,7 @@
 while¶() for¶() if¶() function¶()
 switch¶() return¶() on.exit¶() stop¶() tryCatch¶()
 withRestarts¶() invokeRestart¶() recover¶() browser¶()
-.Defunct¶()
+.Defunct¶() \\(\\\\\\)¶()
 "
   (should (not (face-at-point)))
 
@@ -95,7 +96,7 @@ message¶() warning¶() signalCondition¶() withCallingHandlers¶()
 
 (etest-deftest ess-test-r-fontification-keywords-simple-test ()
   "Simple keywords are always fontified."
-  :case "¶else ¶break ¶next ¶repeat"
+  :case "¶else ¶break ¶next ¶repeat ¶\?"
   (should (eq (face-at-point) 'ess-keyword-face)))
 
 (etest-deftest ess-test-r-fontification-keywords-in-test ()
@@ -154,6 +155,7 @@ message¶() warning¶() signalCondition¶() withCallingHandlers¶()
 ¶`[.foo` <- function(...) NULL
 ¶\"[.foo\" <- function(...) NULL
 "
+
   (should (eq (face-at-point) 'font-lock-function-name-face))
 
   (with-ess-disabled-font-lock-keyword 'ess-R-fl-keyword:fun-defs


### PR DESCRIPTION
Adds font-locking support for R function shorthand notation `\()` and for names of functions defined using this shorthand notation. Also makes the shorthand notation a recognized function pattern.