### PR TITLE
Add more available roxygen2 tags to ess-roxy-tags-param

### DIFF
--- a/lisp/ess-custom.el
+++ b/lisp/ess-custom.el
@@ -1427,19 +1427,21 @@ Used to decide highlighting and tag completion."
   :type '(repeat string))
 
 (defcustom ess-roxy-tags-param '("author" "aliases" "concept" "details"
-                                 "examples" "format" "keywords"
+                                 "example" "examples" "examplesIf"
+                                 "format" "keywords"
                                  "method" "exportMethod"
                                  "name" "note" "param"
-                                 "include" "references" "return"
+                                 "include" "references" "return" "returns"
                                  "seealso" "source" "docType"
                                  "title" "TODO" "usage" "import"
-                                 "exportClass" "exportPattern" "S3method"
+                                 "exportClass" "exportPattern"
+                                 "exportS3Method" "S3method"
                                  "inherit" "inheritParams" "inheritSection"
                                  "importFrom" "importClassesFrom"
                                  "importMethodsFrom" "useDynLib"
                                  "rawNamespace"
                                  "rdname" "section" "slot" "description"
-                                 "md" "eval" "family")
+                                 "md" "eval" "evalNamespace" "family")
   "The tags used in roxygen fields that require a parameter.
 Used to decide highlighting and tag completion."
   :group 'ess-roxy


### PR DESCRIPTION
This PR tries to complete the built-in `ess-roxy-tags-params` with a few more roxygen2 tags that are documented in the latest {Roxygen2} package vignettes: <https://roxygen2.r-lib.org/articles/namespace.html> and <https://roxygen2.r-lib.org/articles/rd.html>.  To be more specific, the following five tags are added:

- `@evalNamespace`
- `@example`
- `@examplesIf`
- `@exportS3Method`
- `@returns`

With this PR, ESS will highlight and complete those tags if I understand the variable `ess-roxy-tags-params` correctly. Thanks!