### PR TITLE
fix error handling in esslint()

### DIFF
--- a/lisp/ess-r-flymake.el
+++ b/lisp/ess-r-flymake.el
@@ -90,7 +90,7 @@ each element is passed as argument to `lintr::with_defaults'."
         } else {
             tryCatch(lintr::lint(commandArgs(TRUE), ...),
                     error = function(e) {
-                       cat('@@warning: @@', e)
+                       cat('@@warning: @@', conditionMessage(e))
                     })
         }
     }


### PR DESCRIPTION
`lintr::lint()` errors were catched but failed to get reported due to a trivial coding error that this PR fixes.

The Flymake log buffer showed
```
Warning [ess-r-flymake  *ess-r-flymake*]:  Error in cat("@@warning: @@", e) :
  argument 2 (type ’list’) cannot be handled by ’cat’
```
rather than the catched error message.

Earlier confusion about this broken warning can be found in #883, #1016, #1238.
After this patch, I can see and investigate the underlying `lint()` error, which in my case was "Malformed config file".