### PR TITLE
fix loading ESSR in R 2.5

### DIFF
--- a/etc/ESSR/R/.basic.R
+++ b/etc/ESSR/R/.basic.R
@@ -80,7 +80,7 @@
 .ess.helpLinks <- function(topic, package) {
     tryCatch(
         warning = function(...) NULL,
-        error = function(...) NULL,
+        error = function(...) NULL, # needs R >= 2.13.0
         {
             ast <- .ess.fetchParsedRd(topic, package)
             .ess.findLinks(ast)
@@ -156,7 +156,7 @@
 }
 
 .ess.strip.error <- function(msg, srcfile) {
-    pattern <- paste0(srcfile, ":[0-9]+:[0-9]+: ")
+    pattern <- paste(srcfile, ":[0-9]+:[0-9]+: ", sep = "")
     sub(pattern, "", msg)
 }
 
@@ -218,12 +218,12 @@ if(.ess.Rversion < "1.8")
         sink(getConnection(1))
 
     on.exit({
-        writeLines(paste0(sentinel, "-END"))
+        writeLines(paste(sentinel, "-END", sep = ""))
         if (sinked)
             sink(NULL)
     })
 
-    writeLines(paste0(sentinel, "-START"))
+    writeLines(paste(sentinel, "-START", sep = ""))
 
     .ess.environment.state$env <- parent.frame()
     on.exit(.ess.environment.state$env <- NULL, add = TRUE)

--- a/etc/ESSR/R/.load.R
+++ b/etc/ESSR/R/.load.R
@@ -11,7 +11,7 @@
 ## load .base.R and all other files into ESSR environment; then attach ESSR
 .ess.ESSR.load <- function(dir) {
 
-    if (nzchar(Sys.getenv("ESSR_TEST_LOAD_ERROR")))
+    if (Sys.getenv("ESSR_TEST_LOAD_ERROR") != "")
         stop('Loading failed with a nice message.')
 
     Rver <- .ess.ESSR.get.rver()


### PR DESCRIPTION
Loading ESSR failed in R 2.5.0 (not that I run this regularly,  but it was annoying when I wanted to try something in some older R versions).

The first problem was in `.ess.ESSR.load()` which relied on `nzchar` from R >= 2.6.0. Avoiding this would still not give me a working prompt because `.ess.command()`, which is needed by `ess-r-initialize`, used `paste0()` which "only" exists since R 2.15.0. The corresponding fixes are trivial and attached here.

NB: This PR does *not* address the current incompatibility of ESSR with even older versions of R.

- R < 1.8.0 fails because `:::` in `.ess.fetchParsedRd()` gives syntax errors.
- R < 2.3.0 fails because `emptyenv()` for `.ess.environment.state` does not exist.
- R < 2.5.0 fails because `withVisible()` in `.ess.command()` does not exist.

So just *loading* ESSR is still broken in these old R versions.
It turns out the header comment in `ESSR/R/.basic.R`, "Should work on *all* versions of R", is increasingly hard to fulfil.