### PR TITLE
byte-compile warnings

### DIFF
--- a/lisp/ess-inf.el
+++ b/lisp/ess-inf.el
@@ -1,6 +1,6 @@
 ;;; ess-inf.el --- Support for running S as an inferior Emacs process  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 1989-2023 Free Software Foundation, Inc.
+;; Copyright (C) 1989-2025 Free Software Foundation, Inc.
 
 ;; Author: David Smith <dsmith@stats.adelaide.edu.au>
 ;; Created: 7 Jan 1994
@@ -3143,7 +3143,7 @@ Uses `temp-buffer-show-function' and respects
 
 (defun ess--inject-code-from-file (file &optional chunked)
   "Load code from FILE into process.
-If CHUNKED is non-nil, split the file by  separator (must be at
+If CHUNKED is non-nil, split the file by \\^L separator (must be at
 bol) and load each chunk separately."
   ;; This is different from ess-load-file as it works by directly loading the
   ;; string into the process and thus works on remotes.

--- a/lisp/ess-r-mode.el
+++ b/lisp/ess-r-mode.el
@@ -1,6 +1,6 @@
 ;;; ess-r-mode.el --- R customization  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 1997-2022 Free Software Foundation, Inc.
+;; Copyright (C) 1997-2025 Free Software Foundation, Inc.
 ;; Author: A.J. Rossini
 ;; Created: 12 Jun 1997
 ;; Maintainer: ESS-core <ESS-core@r-project.org>
@@ -992,7 +992,7 @@ as `ess-r-created-runners' upon ESS initialization."
         (message "Recreated %d R versions known to ESS: %s"
                  (length versions) versions))
       (if ess-microsoft-p
-          (cl-mapcar (lambda (v p) (ess-define-runner v "R" p)) versions ess-rterm-version-paths)
+          (cl-mapc (lambda (v p) (ess-define-runner v "R" p)) versions ess-rterm-version-paths)
         (mapc (lambda (v) (ess-define-runner v "R")) versions))
       ;; Add to menu
       (when ess-r-created-runners
@@ -1619,7 +1619,7 @@ environment to the search path."
 Send the contents of the etc/ESSR/R directory to the remote
 process through the process connection file by file. Then,
 collect all the objects into an ESSR environment and attach to
-the search path. If CHUNKED is non-nil, split each file by 
+the search path. If CHUNKED is non-nil, split each file by \\^L
 separators and send chunk by chunk."
   (ess-command (format ".ess.ESSRversion <<- '%s'\n" essr-version))
   (with-temp-message "Loading ESSR into remote ..."


### PR DESCRIPTION
Closes https://github.com/emacs-ess/ESS/issues/1315

applies patch from @<!-- -->monnier

deals with control chars in a couple other files

> The simplest change is to drop the final "ar".

implements tip from @<!-- -->monnier

updates copyright year in affected files

no byte-compile warnings occur after these were implemented





