### PR TITLE
Fix wrong comment syntax from d8d8e4e8

### DIFF
--- a/etc/ESSR/R/completion.R
+++ b/etc/ESSR/R/completion.R
@@ -108,7 +108,7 @@ local({
 }
 
 
-;;; builds on R`s functionality in  src/library/utils/R/completion.R :
+## builds on R`s functionality in  src/library/utils/R/completion.R :
 .ess_get_completions <- function(string, end, suffix = " = ") {
     oldopts <- utils::rc.options(funarg.suffix = suffix)
     on.exit(utils::rc.options(oldopts))


### PR DESCRIPTION
Lisp-style comments added in d8d8e4e8 prevented loading ESSR functionality:

```
Messages while loading ESSR: + + + + + + + + + Error in parse(n = -1, file = file, srcfile = NULL, keep.source = FALSE) : 
  111:1: unexpected ’;’
110: 
111: ;
     ^
```