### PR TITLE
guard against % in error message

### DIFF
--- a/lisp/ess-r-flymake.el
+++ b/lisp/ess-r-flymake.el
@@ -142,7 +142,7 @@ Otherwise, construct a string to pass to lintr::linters_with_defaults."
   (when (re-search-forward "@@\\(\\(error\\|warning\\): \\)@@" nil t)
     (let ((type (ess-r--flymake-msg-type (match-string 1)))
           (msg (buffer-substring-no-properties (match-end 0) (point-max))))
-      (flymake-log type msg)
+      (flymake-log type "%s" msg)
       (eq type :error))))
 
 (defun ess-r--flymake-parse-output (msg-buffer src-buffer report-fn)


### PR DESCRIPTION
This was a nasty bug that took me way too long to debug. The condition message from a `lint()` error contained a percent symbol, which made the Flymake backend hang without a message in the Flymake log but `*Messages*` showed

    error in process sentinel: flymake--log-1: Not enough arguments for format string
